### PR TITLE
F1: add provisional capability contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Entries start at 1.2.0. For earlier releases see the git log.
 
 ## [Unreleased]
 
+### Added
+- `ModelPaths` and the provisional `PathModel`, `TransformModel`,
+  `TerminalDistributionModel`, `TerminalSmileModel`, and `Payoff` capability contracts establish
+  the path, terminal-model, and pathwise-product boundaries for book analytics.
+
 ## [2.3.0] - 2026-08-24
 
 ### Added

--- a/scripts/check_wheel_contents.py
+++ b/scripts/check_wheel_contents.py
@@ -42,14 +42,23 @@ def check_wheel(wheel_path: Path) -> None:
     assert "stochvolmodels/settings.yaml" not in members, (
         "machine-local settings.yaml entered the wheel"
     )
-    assert "stochvolmodels/__init__.py" in members
+    required_runtime_files = {
+        "stochvolmodels/__init__.py",
+        "stochvolmodels/data/model_paths.py",
+        "stochvolmodels/models/__init__.py",
+        "stochvolmodels/products/__init__.py",
+    }
+    missing_runtime_files = required_runtime_files.difference(members)
+    assert not missing_runtime_files, (
+        f"required runtime files missing from wheel: {sorted(missing_runtime_files)}"
+    )
     test_modules = {
         member
         for member in members
         if member.startswith("stochvolmodels/tests/test_") and member.endswith(".py")
     }
-    assert len(test_modules) == 26, (
-        f"expected exactly 26 automated test modules, found {len(test_modules)}"
+    assert len(test_modules) == 27, (
+        f"expected exactly 27 automated test modules, found {len(test_modules)}"
     )
     assert not any(member.endswith("_test.py") for member in members), (
         "automated tests must use the test_*.py form"

--- a/src/stochvolmodels/data/model_paths.py
+++ b/src/stochvolmodels/data/model_paths.py
@@ -1,0 +1,149 @@
+"""Canonical path payload shared by dynamic models and pathwise payoffs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+import numpy as np
+
+
+def _validate_label(name: str, value: object) -> None:
+    """Require a non-empty string without surrounding whitespace."""
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    if not value or value != value.strip():
+        raise ValueError(f"{name} must be non-empty and trimmed")
+
+
+def _validate_real_array(name: str, value: object) -> np.ndarray:
+    """Require a real numeric NumPy array and return it without copying."""
+    if not isinstance(value, np.ndarray):
+        raise TypeError(f"{name} must be a NumPy array")
+    if value.dtype.kind not in "iuf":
+        raise TypeError(f"{name} must have a real numeric dtype")
+    return value
+
+
+def _validate_metadata(name: str, value: object) -> None:
+    """Validate an opaque metadata mapping without inspecting its values."""
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{name} must be a mapping")
+    for key in value:
+        _validate_label(f"{name} key", key)
+
+
+@dataclass(eq=False)
+class ModelPaths:
+    """Store one dynamic model simulation on an explicit observation grid.
+
+    Arrays and mappings are retained by reference. The container validates their
+    structure but does not copy values, normalize likelihood ratios, or derive
+    importance-sampling diagnostics.
+
+    Parameters
+    ----------
+    observation_times
+        Strictly increasing finite times beginning at zero, with shape ``(n_times,)``.
+    assets
+        Simulated asset levels with shape ``(n_paths, n_times, n_assets)``. Non-finite
+        or non-positive values are retained so producers can report failed paths.
+    asset_ids
+        Unique identifiers for the explicit asset axis.
+    sampling_measure
+        Measure under which paths were sampled.
+    target_measure
+        Measure for which downstream expectations are intended.
+    numeraire
+        Numeraire convention associated with the simulated paths.
+    scheme
+        Identity of the numerical simulation scheme.
+    states
+        Model-defined state arrays. Each has leading shape ``(n_paths, n_times)`` and
+        may have additional non-empty axes.
+    state_units
+        Units for every named state, using exactly the same keys as ``states``.
+    log_likelihood_ratios
+        Optional raw log likelihood ratios with shape ``(n_paths,)``. Values are
+        retained exactly and are not normalized. Finite values and negative infinity
+        are valid; NaN and positive infinity are rejected.
+    provenance
+        Opaque RNG and simulation provenance.
+    diagnostics
+        Opaque numerical and weighting diagnostics supplied by the producer.
+    """
+
+    observation_times: np.ndarray
+    assets: np.ndarray
+    asset_ids: tuple[str, ...]
+    sampling_measure: str
+    target_measure: str
+    numeraire: str
+    scheme: str
+    states: Mapping[str, np.ndarray] = field(default_factory=dict)
+    state_units: Mapping[str, str] = field(default_factory=dict)
+    log_likelihood_ratios: np.ndarray | None = None
+    provenance: Mapping[str, object] = field(default_factory=dict)
+    diagnostics: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Validate path alignment and convention metadata without mutation."""
+        times = _validate_real_array("observation_times", self.observation_times)
+        if times.ndim != 1 or times.size == 0:
+            raise ValueError("observation_times must be a non-empty one-dimensional array")
+        if not np.all(np.isfinite(times)):
+            raise ValueError("observation_times must contain only finite values")
+        if times[0] != 0.0:
+            raise ValueError("observation_times must begin at zero")
+        if np.any(times[1:] <= times[:-1]):
+            raise ValueError("observation_times must be strictly increasing")
+
+        assets = _validate_real_array("assets", self.assets)
+        if assets.ndim != 3 or any(size == 0 for size in assets.shape):
+            raise ValueError("assets must have non-empty shape (n_paths, n_times, n_assets)")
+        if assets.shape[1] != times.size:
+            raise ValueError("the assets time axis must match observation_times")
+
+        if not isinstance(self.asset_ids, tuple):
+            raise TypeError("asset_ids must be a tuple")
+        for asset_id in self.asset_ids:
+            _validate_label("asset_id", asset_id)
+        if len(self.asset_ids) != assets.shape[2]:
+            raise ValueError("asset_ids must match the assets asset axis")
+        if len(set(self.asset_ids)) != len(self.asset_ids):
+            raise ValueError("asset_ids must be unique")
+
+        for name in ("sampling_measure", "target_measure", "numeraire", "scheme"):
+            _validate_label(name, getattr(self, name))
+
+        if not isinstance(self.states, Mapping):
+            raise TypeError("states must be a mapping")
+        for state_name, state_values in self.states.items():
+            _validate_label("state name", state_name)
+            state_array = _validate_real_array(f"states[{state_name!r}]", state_values)
+            if state_array.ndim < 2:
+                raise ValueError("state arrays must have at least path and time axes")
+            if state_array.shape[:2] != assets.shape[:2]:
+                raise ValueError("state path and time axes must match assets")
+            if any(size == 0 for size in state_array.shape[2:]):
+                raise ValueError("state trailing axes must be non-empty")
+
+        if not isinstance(self.state_units, Mapping):
+            raise TypeError("state_units must be a mapping")
+        if set(self.state_units) != set(self.states):
+            raise ValueError("state_units keys must exactly match states keys")
+        for state_name, unit in self.state_units.items():
+            _validate_label("state unit name", state_name)
+            _validate_label(f"state_units[{state_name!r}]", unit)
+
+        if self.log_likelihood_ratios is not None:
+            log_ratios = _validate_real_array(
+                "log_likelihood_ratios", self.log_likelihood_ratios
+            )
+            if log_ratios.ndim != 1 or log_ratios.size != assets.shape[0]:
+                raise ValueError("log_likelihood_ratios must have shape (n_paths,)")
+            if np.any(np.isnan(log_ratios)) or np.any(np.isposinf(log_ratios)):
+                raise ValueError("log_likelihood_ratios cannot contain NaN or positive infinity")
+
+        _validate_metadata("provenance", self.provenance)
+        _validate_metadata("diagnostics", self.diagnostics)

--- a/src/stochvolmodels/models/__init__.py
+++ b/src/stochvolmodels/models/__init__.py
@@ -1,0 +1,69 @@
+"""Provisional structural capabilities for stochastic-volatility models.
+
+Runtime checks recognize declared capability names only. Concrete implementations
+remain responsible for their documented signatures, inputs, and outputs.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+import numpy as np
+
+from stochvolmodels.data.model_paths import ModelPaths
+
+if TYPE_CHECKING:
+    from stochvolmodels.data.option_chain import OptionSlice
+
+__all__ = (
+    "PathModel",
+    "TerminalDistributionModel",
+    "TerminalSmileModel",
+    "TransformModel",
+)
+
+
+@runtime_checkable
+class PathModel(Protocol):
+    """Capability for dynamically consistent simulation on an observation grid."""
+
+    def simulate_paths(self, **kwargs: object) -> ModelPaths:
+        """Return a validated ``ModelPaths`` payload for a documented request."""
+        ...
+
+
+@runtime_checkable
+class TransformModel(Protocol):
+    """Capability for evaluating a model's logarithmic moment transform."""
+
+    def log_mgf_grid(self, **kwargs: object) -> np.ndarray:
+        """Return log-transform values shaped like the requested transform grid."""
+        ...
+
+
+@runtime_checkable
+class TerminalDistributionModel(Protocol):
+    """Capability for European pricing under a one-maturity terminal law."""
+
+    @property
+    def ttm(self) -> float:
+        """Return the terminal law's time to maturity in years."""
+        ...
+
+    def price_european(self, option_slice: OptionSlice) -> np.ndarray:
+        """Return prices shaped like ``option_slice.strikes``."""
+        ...
+
+
+@runtime_checkable
+class TerminalSmileModel(Protocol):
+    """Capability for evaluating a one-expiry implied-volatility smile."""
+
+    @property
+    def ttm(self) -> float:
+        """Return the smile's time to maturity in years."""
+        ...
+
+    def implied_vols(self, option_slice: OptionSlice) -> np.ndarray:
+        """Return implied volatilities shaped like ``option_slice.strikes``."""
+        ...

--- a/src/stochvolmodels/products/__init__.py
+++ b/src/stochvolmodels/products/__init__.py
@@ -1,0 +1,40 @@
+"""Structural contract for pathwise payoff definitions."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+from stochvolmodels.data.model_paths import ModelPaths
+
+__all__ = ("Payoff",)
+
+
+@runtime_checkable
+class Payoff(Protocol):
+    """Pathwise payoff with explicit asset, expiry, and settlement metadata."""
+
+    @property
+    def required_asset_ids(self) -> tuple[str, ...]:
+        """Return the asset identifiers consumed by the payoff."""
+        ...
+
+    @property
+    def expiry(self) -> float:
+        """Return the payoff observation time in years."""
+        ...
+
+    @property
+    def payoff_unit(self) -> str:
+        """Return the unit of the unconverted payoff values."""
+        ...
+
+    @property
+    def settlement_unit(self) -> str:
+        """Return the unit in which the payoff settles."""
+        ...
+
+    def __call__(self, paths: ModelPaths) -> np.ndarray:
+        """Return payoff values with shape ``(n_paths,)``."""
+        ...

--- a/src/stochvolmodels/tests/test_capability_contracts.py
+++ b/src/stochvolmodels/tests/test_capability_contracts.py
@@ -1,0 +1,392 @@
+"""Structural contracts for path, transform, terminal, and payoff capabilities."""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import stochvolmodels
+from stochvolmodels.data.model_paths import ModelPaths
+from stochvolmodels.data.option_chain import OptionSlice
+from stochvolmodels.models import (
+    PathModel,
+    TerminalDistributionModel,
+    TerminalSmileModel,
+    TransformModel,
+)
+from stochvolmodels.products import Payoff
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _valid_kwargs() -> dict[str, object]:
+    """Return a fresh minimal valid ``ModelPaths`` input dictionary."""
+    return {
+        "observation_times": np.array([0.0, 0.5, 1.0]),
+        "assets": np.ones((4, 3, 1)),
+        "asset_ids": ("spot",),
+        "sampling_measure": "Q",
+        "target_measure": "Q",
+        "numeraire": "money_market",
+        "scheme": "dummy",
+    }
+
+
+def _assert_invalid(**changes: object) -> None:
+    """Assert that one mutation of the valid fixture is rejected."""
+    kwargs = _valid_kwargs()
+    kwargs.update(changes)
+    with pytest.raises((TypeError, ValueError)):
+        ModelPaths(**kwargs)
+
+
+def test_model_paths_preserves_uniform_payloads_without_materializing_weights() -> None:
+    """The canonical container stores producer arrays directly and keeps uniform weights absent."""
+    times = np.array([0.0])
+    assets = np.array([[[-1.0]], [[2.0]]])
+    provenance = {"rng": "fixture"}
+    diagnostics = {"failed_paths": 0}
+    paths = ModelPaths(
+        observation_times=times,
+        assets=assets,
+        asset_ids=("rate",),
+        sampling_measure="Q",
+        target_measure="Q",
+        numeraire="bond",
+        scheme="fixture",
+        provenance=provenance,
+        diagnostics=diagnostics,
+    )
+
+    assert paths.observation_times is times
+    assert paths.assets is assets
+    assert paths.provenance is provenance
+    assert paths.diagnostics is diagnostics
+    assert paths.log_likelihood_ratios is None
+
+
+def test_model_paths_accepts_model_defined_state_axes_and_raw_log_ratios() -> None:
+    """State trailing axes stay model-defined and raw log likelihood ratios stay untouched."""
+    states = {
+        "variance": np.ones((4, 3)),
+        "asset_variance": np.ones((4, 3, 2)),
+        "factors": np.ones((4, 3, 3)),
+    }
+    units = {"variance": "1/year", "asset_variance": "1/year", "factors": "1"}
+    logs = np.array([2.0, -3.0, 0.0, -np.inf])
+    diagnostics = {
+        "weight_convention": "raw_log_likelihood_ratio",
+        "weight_sum": 1.5,
+        "effective_sample_size": 2.5,
+        "ess_fraction": 0.625,
+        "low_ess": False,
+    }
+    paths = ModelPaths(
+        observation_times=np.array([0.0, 0.5, 1.0]),
+        assets=np.ones((4, 3, 2)),
+        asset_ids=("spot", "future"),
+        sampling_measure="P",
+        target_measure="Q",
+        numeraire="money_market",
+        scheme="fixture",
+        states=states,
+        state_units=units,
+        log_likelihood_ratios=logs,
+        diagnostics=diagnostics,
+    )
+
+    assert paths.states is states
+    assert paths.state_units is units
+    assert paths.log_likelihood_ratios is logs
+    assert paths.diagnostics is diagnostics
+    np.testing.assert_array_equal(paths.log_likelihood_ratios, logs)
+
+
+def test_model_paths_default_mappings_are_not_shared() -> None:
+    first = ModelPaths(**_valid_kwargs())
+    second = ModelPaths(**_valid_kwargs())
+
+    assert first.states is not second.states
+    assert first.state_units is not second.state_units
+    assert first.provenance is not second.provenance
+    assert first.diagnostics is not second.diagnostics
+
+
+def test_model_paths_uses_identity_equality_for_array_backed_payloads() -> None:
+    first = ModelPaths(**_valid_kwargs())
+    second = ModelPaths(**_valid_kwargs())
+
+    assert first == first
+    assert first != second
+
+
+@pytest.mark.parametrize(
+    "times",
+    [
+        [0.0, 1.0],
+        np.array([]),
+        np.zeros((1, 1)),
+        np.array([0.0, 1.0], dtype=object),
+        np.array([0.0 + 0.0j, 1.0 + 0.0j]),
+        np.array([0, 1], dtype="timedelta64[ns]"),
+        np.array([0.0, np.nan]),
+        np.array([0.0, np.inf]),
+        np.array([0.1, 1.0]),
+        np.array([0.0, 0.5, 0.5]),
+        np.array([0.0, 1.0, 0.5]),
+    ],
+)
+def test_model_paths_rejects_invalid_observation_times(times: object) -> None:
+    _assert_invalid(observation_times=times)
+
+
+@pytest.mark.parametrize(
+    "assets",
+    [
+        [[[1.0]]],
+        np.ones(4),
+        np.ones((4, 3)),
+        np.ones((4, 3, 1, 1)),
+        np.ones((4, 3, 1), dtype=object),
+        np.ones((4, 3, 1), dtype=complex),
+        np.zeros((4, 3, 1), dtype="timedelta64[ns]"),
+        np.ones((0, 3, 1)),
+        np.ones((4, 2, 1)),
+        np.ones((4, 3, 0)),
+    ],
+)
+def test_model_paths_rejects_invalid_asset_arrays(assets: object) -> None:
+    _assert_invalid(assets=assets)
+
+
+@pytest.mark.parametrize(
+    "asset_ids",
+    [
+        ["spot"],
+        (),
+        ("spot", "future"),
+        ("spot", "spot"),
+        ("",),
+        (" spot",),
+        (1,),
+    ],
+)
+def test_model_paths_rejects_invalid_asset_ids(asset_ids: object) -> None:
+    _assert_invalid(asset_ids=asset_ids)
+
+
+@pytest.mark.parametrize(
+    ("states", "state_units"),
+    [
+        ([], {}),
+        ({"": np.ones((4, 3))}, {"": "1"}),
+        ({1: np.ones((4, 3))}, {1: "1"}),
+        ({"variance": [[1.0]]}, {"variance": "1/year"}),
+        ({"variance": np.ones((4, 3), dtype=object)}, {"variance": "1/year"}),
+        ({"variance": np.ones((4, 3), dtype=complex)}, {"variance": "1/year"}),
+        (
+            {"variance": np.zeros((4, 3), dtype="timedelta64[ns]")},
+            {"variance": "1/year"},
+        ),
+        ({"variance": np.ones(4)}, {"variance": "1/year"}),
+        ({"variance": np.ones((3, 3))}, {"variance": "1/year"}),
+        ({"variance": np.ones((4, 2))}, {"variance": "1/year"}),
+        ({"factors": np.ones((4, 3, 0))}, {"factors": "1"}),
+    ],
+)
+def test_model_paths_rejects_invalid_states(states: object, state_units: object) -> None:
+    _assert_invalid(states=states, state_units=state_units)
+
+
+@pytest.mark.parametrize(
+    "state_units",
+    [
+        [],
+        {},
+        {"variance": "1/year", "extra": "1"},
+        {"variance": ""},
+        {"variance": " 1/year"},
+        {"variance": 1},
+    ],
+)
+def test_model_paths_rejects_invalid_state_units(state_units: object) -> None:
+    _assert_invalid(states={"variance": np.ones((4, 3))}, state_units=state_units)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["sampling_measure", "target_measure", "numeraire", "scheme"],
+)
+@pytest.mark.parametrize("value", [None, 1, "", " Q", "Q "])
+def test_model_paths_rejects_invalid_convention_labels(field: str, value: object) -> None:
+    _assert_invalid(**{field: value})
+
+
+@pytest.mark.parametrize(
+    "logs",
+    [
+        [0.0, 0.0, 0.0, 0.0],
+        np.ones((4, 1)),
+        np.ones(3),
+        np.ones(4, dtype=object),
+        np.ones(4, dtype=complex),
+        np.zeros(4, dtype="timedelta64[ns]"),
+        np.array([0.0, np.nan, 0.0, 0.0]),
+        np.array([0.0, np.inf, 0.0, 0.0]),
+    ],
+)
+def test_model_paths_rejects_invalid_log_likelihood_ratios(logs: object) -> None:
+    _assert_invalid(log_likelihood_ratios=logs)
+
+
+@pytest.mark.parametrize("field", ["provenance", "diagnostics"])
+@pytest.mark.parametrize("value", [[], {"": 1}, {" bad": 1}, {1: "value"}])
+def test_model_paths_rejects_invalid_metadata_mappings(field: str, value: object) -> None:
+    _assert_invalid(**{field: value})
+
+
+class _DummyPathModel:
+    def simulate_paths(self, **_: object) -> ModelPaths:
+        return ModelPaths(**_valid_kwargs())
+
+
+class _DummyTransformModel:
+    def log_mgf_grid(self, **kwargs: object) -> np.ndarray:
+        return np.zeros_like(kwargs["phi_grid"], dtype=complex)
+
+
+class _DummyTerminalDistribution:
+    ttm = 1.0
+
+    def price_european(self, option_slice: OptionSlice) -> np.ndarray:
+        return np.zeros_like(option_slice.strikes)
+
+
+class _DummyTerminalSmile:
+    ttm = 1.0
+
+    def implied_vols(self, option_slice: OptionSlice) -> np.ndarray:
+        return np.full_like(option_slice.strikes, 0.2)
+
+
+class _DummyTerminalTransform(_DummyTerminalDistribution, _DummyTransformModel):
+    pass
+
+
+class _DummyPayoff:
+    required_asset_ids = ("spot",)
+    expiry = 1.0
+    payoff_unit = "currency"
+    settlement_unit = "currency"
+
+    def __call__(self, paths: ModelPaths) -> np.ndarray:
+        return paths.assets[:, -1, 0]
+
+
+def test_provisional_capabilities_are_structural_and_terminal_models_stay_separate() -> None:
+    path_model = _DummyPathModel()
+    transform_model = _DummyTransformModel()
+    terminal_distribution = _DummyTerminalDistribution()
+    terminal_smile = _DummyTerminalSmile()
+    terminal_transform = _DummyTerminalTransform()
+    payoff = _DummyPayoff()
+
+    assert isinstance(path_model, PathModel)
+    assert isinstance(transform_model, TransformModel)
+    assert isinstance(terminal_distribution, TerminalDistributionModel)
+    assert isinstance(terminal_smile, TerminalSmileModel)
+    assert isinstance(payoff, Payoff)
+    assert not isinstance(terminal_distribution, PathModel)
+    assert not isinstance(terminal_distribution, TransformModel)
+    assert isinstance(terminal_transform, TerminalDistributionModel)
+    assert isinstance(terminal_transform, TransformModel)
+
+    paths = path_model.simulate_paths()
+    values = payoff(paths)
+    assert values.shape == (paths.assets.shape[0],)
+
+
+def test_capability_modules_keep_narrow_import_boundaries_and_root_api_stable() -> None:
+    allowed_imports = {
+        PACKAGE_ROOT / "data" / "model_paths.py": {
+            "__future__",
+            "collections.abc",
+            "dataclasses",
+            "numpy",
+        },
+        PACKAGE_ROOT / "models" / "__init__.py": {
+            "__future__",
+            "collections.abc",
+            "typing",
+            "numpy",
+            "stochvolmodels.data.model_paths",
+            "stochvolmodels.data.option_chain",
+        },
+        PACKAGE_ROOT / "products" / "__init__.py": {
+            "__future__",
+            "typing",
+            "numpy",
+            "stochvolmodels.data.model_paths",
+        },
+    }
+    for path, allowed in allowed_imports.items():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        imported = {
+            node.module
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module is not None
+        }
+        imported.update(
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        )
+        assert imported <= allowed
+
+    new_symbols = {
+        "ModelPaths",
+        "PathModel",
+        "Payoff",
+        "TerminalDistributionModel",
+        "TerminalSmileModel",
+        "TransformModel",
+    }
+    assert new_symbols.isdisjoint(stochvolmodels.__all__)
+
+
+def test_capability_imports_do_not_load_heavy_pricing_layers() -> None:
+    source_root = str(PACKAGE_ROOT.parent)
+    code = f"""
+import sys
+sys.path.insert(0, {source_root!r})
+import stochvolmodels.models
+import stochvolmodels.products
+forbidden = (
+    "numba",
+    "pandas",
+    "scipy",
+    "stochvolmodels.data.option_chain",
+    "vanilla_option_pricers",
+)
+loaded = sorted(
+    root
+    for root in forbidden
+    if any(name == root or name.startswith(root + ".") for name in sys.modules)
+)
+assert not loaded, loaded
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr


### PR DESCRIPTION
Adds the verified F1 capability foundation for the volatility-book execution roadmap.

Changes:
- add validated, zero-copy ModelPaths storage
- add provisional dynamic, transform, terminal-distribution, terminal-smile, and payoff protocols
- preserve the stable package-root surface and keep capability imports lightweight
- add failing-first contract coverage and explicit wheel-content checks
- record the public submodule additions under Unreleased

Verification:
- 88 capability-contract tests passed
- 122 focused contract tests passed
- 370 source fast tests passed with OCA 5.2.0
- critical Ruff, changed-file Ruff, and 100% interrogate passed
- mutation proofs caught duplicate-time, dtype/equality, and import-boundary defects
- final wheel content audit passed (91 files)
- clean installed wheel: 355 passed, 15 expected skips, 2 slow deselections

No pricing, transform, simulation, calibration, or root-API behavior changes.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced new capability contracts including ModelPaths, PathModel, TransformModel, TerminalDistributionModel, TerminalSmileModel, and Payoff to define book analytics boundaries.</li>
<li>Added a new data module `src/stochvolmodels/data/model_paths.py` to manage canonical path payloads.</li>
<li>Updated `scripts/check_wheel_contents.py` to enforce the inclusion of new runtime modules and adjust the expected test module count.</li>
<li>Added a new test module `src/stochvolmodels/tests/test_capability_contracts.py` to validate the new contracts.</li>
</ul></div>