### PR TITLE
feat: add Student-t terminal adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Entries start at 1.2.0. For earlier releases see the git log.
 - `ModelPaths` and the provisional `PathModel`, `TransformModel`,
   `TerminalDistributionModel`, `TerminalSmileModel`, and `Payoff` capability contracts establish
   the path, terminal-model, and pathwise-product boundaries for book analytics.
+- `stochvolmodels.pricers.tdist_pricer.TdistTerminalModel` provides a validated,
+  parameter-bound Student-t terminal-law and Black-smile adapter for standard European calls and
+  puts while preserving the legacy pricing and calibration entry points.
 
 ## [2.3.0] - 2026-08-24
 

--- a/src/stochvolmodels/fitters/tdist.py
+++ b/src/stochvolmodels/fitters/tdist.py
@@ -1,10 +1,11 @@
 """
-Student-t distribution analytics for option valuation.
+Student-t arithmetic-return analytics for option valuation.
 
-Terminal log-returns are Student-t with nu > 2 degrees of freedom, scaled by
-upsilon so that the variance matches vol^2 ttm. Finite variance requires nu > 2,
-and the kth moment exists only for k < nu, so low nu produces heavy tails and a
-pronounced smile while leaving the second moment intact.
+The centered simple-return shock is Student-t with nu > 2 degrees of freedom and
+scale upsilon chosen so its variance is vol^2 ttm. The terminal asset is spot times
+the positive part of one plus drift times maturity plus that shock, which creates an
+atom at zero. Finite variance requires nu > 2, and the kth shock moment exists only
+for k < nu.
 """
 import numpy as np
 from numba import njit
@@ -31,7 +32,13 @@ def compute_upsilon(vol: float, ttm: float, nu: float) -> float:
     return vol*np.sqrt(ttm*(nu-2.0)/nu)
 
 
-def pdf_tdist(x: Union[np.ndarray, float], mu: float, vol: float, nu: float, ttm: float) -> Union[float, np.ndarray]:
+def pdf_tdist(
+    x: Union[np.ndarray, float],
+    mu: float,
+    vol: float,
+    nu: float,
+    ttm: float,
+) -> Union[float, np.ndarray]:
     """Student-t density with location mu ttm, scale upsilon and nu degrees of freedom."""
     upsilon = compute_upsilon(vol=vol, ttm=ttm, nu=nu)
     z = (x - mu * ttm) / upsilon
@@ -40,7 +47,13 @@ def pdf_tdist(x: Union[np.ndarray, float], mu: float, vol: float, nu: float, ttm
     return c*f
 
 
-def cdf_tdist(x: Union[np.ndarray, float], mu: float, vol: float, nu: float, ttm: float) -> Union[float, np.ndarray]:
+def cdf_tdist(
+    x: Union[np.ndarray, float],
+    mu: float,
+    vol: float,
+    nu: float,
+    ttm: float,
+) -> Union[float, np.ndarray]:
     """
     cumulative distribution of cumullative location-scale t-distribution
     cdf = int^{x}_{-infty} f(u)du
@@ -51,8 +64,13 @@ def cdf_tdist(x: Union[np.ndarray, float], mu: float, vol: float, nu: float, ttm
     return cdf
 
 
-def cum_mean_tdist(x: Union[np.ndarray, float], mu: float = 0, vol: float = 0.2, nu: float = 3.0, ttm: float = 0.25
-                   ) -> Union[float, np.ndarray]:
+def cum_mean_tdist(
+    x: Union[np.ndarray, float],
+    mu: float = 0,
+    vol: float = 0.2,
+    nu: float = 3.0,
+    ttm: float = 0.25,
+) -> Union[float, np.ndarray]:
     """
     cumulative expected value
     h = int^{x}_{-infty} u f(u)du
@@ -60,11 +78,19 @@ def cum_mean_tdist(x: Union[np.ndarray, float], mu: float = 0, vol: float = 0.2,
     upsilon = compute_upsilon(vol=vol, ttm=ttm, nu=nu)
     z = (x-mu*ttm) / upsilon
     norm = (gamma(0.5*(1.0+nu)) / gamma(0.5*nu))*np.sqrt(nu/np.pi) / (1.0-nu)
-    h = mu * cdf_tdist(x, mu=mu, vol=vol, nu=nu, ttm=ttm) + upsilon * norm * np.power(1.0 + np.square(z) / nu, -0.5 * (nu - 1.0))
+    h = (
+        mu * cdf_tdist(x, mu=mu, vol=vol, nu=nu, ttm=ttm)
+        + upsilon * norm * np.power(1.0 + np.square(z) / nu, -0.5 * (nu - 1.0))
+    )
     return h
 
 
-def imply_drift_tdist(rf_rate: float = 0.0, vol: float = 0.2, nu: float = 3.0, ttm: float = 0.25) -> float:
+def imply_drift_tdist(
+    rf_rate: float = 0.0,
+    vol: float = 0.2,
+    nu: float = 3.0,
+    ttm: float = 0.25,
+) -> float:
     """
     imply drift of t-distribution under risk-neutral measure
     """
@@ -180,8 +206,24 @@ def infer_implied_vol_tdist(spot: float,
     compute normal implied vol
     """
     x1, x2 = 0.05, 10.0  # starting values
-    f = compute_vanilla_price_tdist(spot=spot, strikes=strike, ttm=ttm, vol=x1, nu=nu, rf_rate=rf_rate, optiontypes=optiontype) - given_price
-    fmid = compute_vanilla_price_tdist(spot=spot, strikes=strike, ttm=ttm, vol=x2, nu=nu, rf_rate=rf_rate, optiontypes=optiontype) - given_price
+    f = compute_vanilla_price_tdist(
+        spot=spot,
+        strikes=strike,
+        ttm=ttm,
+        vol=x1,
+        nu=nu,
+        rf_rate=rf_rate,
+        optiontypes=optiontype,
+    ) - given_price
+    fmid = compute_vanilla_price_tdist(
+        spot=spot,
+        strikes=strike,
+        ttm=ttm,
+        vol=x2,
+        nu=nu,
+        rf_rate=rf_rate,
+        optiontypes=optiontype,
+    ) - given_price
     if f*fmid < 0.0:
         if f < 0.0:
             rtb = x1
@@ -193,7 +235,15 @@ def infer_implied_vol_tdist(spot: float,
         for j in range(0, 100):
             dx = dx*0.5
             xmid = rtb+dx
-            fmid = compute_vanilla_price_tdist(spot=spot, strikes=strike, ttm=ttm, vol=xmid, nu=nu, rf_rate=rf_rate, optiontypes=optiontype) - given_price
+            fmid = compute_vanilla_price_tdist(
+                spot=spot,
+                strikes=strike,
+                ttm=ttm,
+                vol=xmid,
+                nu=nu,
+                rf_rate=rf_rate,
+                optiontypes=optiontype,
+            ) - given_price
             if fmid <= 0.0:
                 rtb = xmid
             if np.abs(fmid) < tol:
@@ -220,7 +270,9 @@ def infer_tdist_implied_vols_from_model_slice_prices(ttm: float,
                                                      ) -> np.ndarray:
     """invert model prices of one slice to Student-t implied volatilities."""
     model_vol_ttm = np.zeros_like(strikes)
-    for idx, (strike, model_price, optiontype) in enumerate(zip(strikes, model_prices, optiontypes)):
+    for idx, (strike, model_price, optiontype) in enumerate(
+        zip(strikes, model_prices, optiontypes)
+    ):
         model_vol_ttm[idx] = infer_implied_vol_tdist(spot=spot, ttm=ttm, rf_rate=rf_rate,
                                                      given_price=model_price,
                                                      strike=strike,

--- a/src/stochvolmodels/pricers/tdist_pricer.py
+++ b/src/stochvolmodels/pricers/tdist_pricer.py
@@ -1,13 +1,13 @@
-"""
-implementation of gaussian mixture pricer and calibration
-"""
-import numpy as np
+"""Student-t terminal-distribution pricing and calibration."""
 from dataclasses import dataclass
-from scipy.optimize import minimize
-from numba.typed import List
-from typing import Tuple
+from numbers import Real
+from typing import ClassVar, Tuple
 
-# sv 
+import numpy as np
+from numba.typed import List
+from scipy.optimize import minimize
+
+# sv
 import stochvolmodels.fitters.tdist as td
 from stochvolmodels.utils.funcs import to_flat_np_array, timer
 from stochvolmodels.pricers.model_pricer import (
@@ -18,7 +18,7 @@ from stochvolmodels.pricers.model_pricer import (
 from stochvolmodels.utils.config import VariableType
 
 # data
-from stochvolmodels.data.option_chain import OptionChain
+from stochvolmodels.data.option_chain import OptionChain, OptionSlice
 
 
 @dataclass
@@ -26,22 +26,21 @@ class TdistParams(ModelParams):
     """
     parameters of the Student-t model: volatility, drift and degrees of freedom nu.
 
-    Terminal log-returns are Student-t with nu > 2, scaled so the variance matches
-    vol^2 ttm. Lower nu gives heavier tails and a more pronounced smile.
+    The centered arithmetic-return shock is Student-t with nu > 2 and variance
+    ``vol**2 * ttm``. The terminal asset is the positive part of spot times one plus
+    drift times maturity plus that shock, so the floor creates an atom at zero.
     """
     drift: float
     vol: float
     nu: float
-    ttm: float  # ttm is important as all params are fixed to this ttm, it is not part of calibration
+    ttm: float  # Parameters are fixed to this maturity, which is not calibrated.
 
 
 class TdistPricer(ModelPricer):
 
     """ModelPricer valuing options under a Student-t terminal distribution."""
     def price_chain(self, option_chain: OptionChain, params: TdistParams, **kwargs) -> np.ndarray:
-        """
-        implementation of generic method price_chain using heston wrapper for tdist prices
-        """
+        """Price all chain slices through the legacy closed-form Student-t kernel."""
         model_prices_ttms = tdist_vanilla_chain_pricer(drift=params.drift,
                                                        vol=params.vol,
                                                        nu=params.nu,
@@ -109,7 +108,10 @@ class TdistPricer(ModelPricer):
         def objective(pars: np.ndarray, args: np.ndarray) -> float:
             """weighted mean squared error between model and market implied volatilities."""
             params = parse_model_params(pars=pars)
-            model_vols = self.compute_model_ivols_for_chain(option_chain=option_chain, params=params)
+            model_vols = self.compute_model_ivols_for_chain(
+                option_chain=option_chain,
+                params=params,
+            )
             resid = np.nansum(weights * np.square(to_flat_np_array(model_vols) - market_vols))
             return resid
 
@@ -145,6 +147,142 @@ class TdistPricer(ModelPricer):
         return fit_params
 
 
+@dataclass(frozen=True, init=False)
+class TdistTerminalModel:
+    """Validated, parameter-bound Student-t law for one-maturity European options.
+
+    The bound drift is consistent with exactly one maturity and discount rate through
+    the floored-arithmetic-return martingale equation. Only standard calls and puts are
+    supported; the historical ``IC`` and ``IP`` codes do not implement inverse settlement
+    and are deliberately rejected at this boundary. Discount consistency uses the
+    dimensionless condition ``abs(log(discount * expected_growth)) <= 5e-10``.
+    """
+
+    _drift: float
+    _vol: float
+    _nu: float
+    _ttm: float
+
+    _MARTINGALE_LOG_ATOL: ClassVar[float] = 5.0e-10
+
+    def __init__(self, params: TdistParams) -> None:
+        """Validate and snapshot one legacy parameter payload."""
+        if not isinstance(params, TdistParams):
+            raise TypeError("params must be a TdistParams instance")
+
+        values = {
+            "drift": params.drift,
+            "vol": params.vol,
+            "nu": params.nu,
+            "ttm": params.ttm,
+        }
+        for name in ("drift", "vol", "nu", "ttm"):
+            value = values[name]
+            if (
+                isinstance(value, (bool, np.bool_))
+                or not isinstance(value, Real)
+                or not np.isfinite(value)
+            ):
+                raise ValueError(f"{name} must be a finite real scalar")
+        if values["vol"] <= 0.0:
+            raise ValueError("vol must be positive")
+        if values["nu"] <= 2.0:
+            raise ValueError("nu must be greater than 2")
+        if values["ttm"] <= 0.0:
+            raise ValueError("ttm must be positive")
+
+        for name, value in values.items():
+            object.__setattr__(self, f"_{name}", float(value))
+
+    @property
+    def params(self) -> TdistParams:
+        """Return a detached legacy parameter payload for inspection or facade calls."""
+        return TdistParams(
+            drift=self._drift,
+            vol=self._vol,
+            nu=self._nu,
+            ttm=self._ttm,
+        )
+
+    @property
+    def ttm(self) -> float:
+        """Return the terminal law's time to maturity in years."""
+        return self._ttm
+
+    def _expected_growth(self) -> float:
+        """Return expected terminal asset growth before discounting."""
+        default_boundary = -(1.0 + self._drift * self._ttm)
+        default_probability = td.cdf_tdist(
+            x=default_boundary,
+            mu=0.0,
+            vol=self._vol,
+            nu=self._nu,
+            ttm=self._ttm,
+        )
+        truncated_mean = td.cum_mean_tdist(
+            x=default_boundary,
+            mu=0.0,
+            vol=self._vol,
+            nu=self._nu,
+            ttm=self._ttm,
+        )
+        expected_growth = (
+            (1.0 + self._drift * self._ttm) * (1.0 - default_probability)
+            - truncated_mean
+        )
+        if not np.isfinite(expected_growth) or expected_growth <= 0.0:
+            raise ValueError("params imply an invalid expected terminal growth factor")
+        return float(expected_growth)
+
+    def _option_chain(self, option_slice: OptionSlice) -> OptionChain:
+        """Validate one standard-payoff slice and convert it to the legacy facade input."""
+        if not isinstance(option_slice, OptionSlice):
+            raise TypeError("option_slice must be an OptionSlice instance")
+        if option_slice.ttm != self.ttm:
+            raise ValueError("option_slice.ttm must exactly match the bound params.ttm")
+
+        unsupported = set(np.asarray(option_slice.optiontypes).astype(str)) - {"C", "P"}
+        if unsupported:
+            raise NotImplementedError(
+                "TdistTerminalModel supports C/P only; inverse IC/IP settlement is not implemented"
+            )
+
+        discounted_growth = option_slice.discfactor * self._expected_growth()
+        if not np.isfinite(discounted_growth) or discounted_growth <= 0.0:
+            raise ValueError("option_slice discount rate implies invalid discounted growth")
+        martingale_log_error = abs(np.log(discounted_growth))
+        if martingale_log_error > self._MARTINGALE_LOG_ATOL:
+            raise ValueError(
+                "option_slice discount rate is inconsistent with the bound drift: "
+                f"abs(log(discount * expected_growth)) must not exceed "
+                f"{self._MARTINGALE_LOG_ATOL:.0e}"
+            )
+
+        return OptionChain.slice_to_chain(
+            ttm=option_slice.ttm,
+            forward=option_slice.forward,
+            strikes=np.asarray(option_slice.strikes, dtype=float),
+            optiontypes=np.asarray(option_slice.optiontypes),
+            discfactor=option_slice.discfactor,
+            id=option_slice.id,
+        )
+
+    def price_european(self, option_slice: OptionSlice) -> np.ndarray:
+        """Return standard-call/put prices shaped like ``option_slice.strikes``."""
+        option_chain = self._option_chain(option_slice)
+        prices = TdistPricer().price_chain(option_chain=option_chain, params=self.params)
+        return np.asarray(prices[0], dtype=float)
+
+    def implied_vols(self, option_slice: OptionSlice) -> np.ndarray:
+        """Return Black implied volatilities shaped like ``option_slice.strikes``."""
+        option_chain = self._option_chain(option_slice)
+        ivols = TdistPricer().compute_model_ivols_for_chain(
+            option_chain=option_chain,
+            params=self.params,
+        )
+        return np.asarray(ivols[0], dtype=float)
+
+
 def tdist_vanilla_chain_pricer(vol: float,
                                nu: float,
                                drift: float,
@@ -159,8 +297,9 @@ def tdist_vanilla_chain_pricer(vol: float,
     """
     # outputs as numpy lists
     model_prices_ttms = List()
-    for ttm, forward, discfactor, strikes_ttm, optiontypes_ttm in zip(ttms, forwards, discfactors, strikes_ttms,
-                                                                      optiontypes_ttms):
+    for ttm, forward, discfactor, strikes_ttm, optiontypes_ttm in zip(
+        ttms, forwards, discfactors, strikes_ttms, optiontypes_ttms
+    ):
         discount_rate = -np.log(discfactor) / ttm
         option_prices_ttm = td.compute_vanilla_price_tdist(spot=forward*discfactor,
                                                            strikes=strikes_ttm,

--- a/src/stochvolmodels/tests/test_distribution_pricer_contracts.py
+++ b/src/stochvolmodels/tests/test_distribution_pricer_contracts.py
@@ -5,6 +5,8 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 from numba.typed import List
+from scipy.integrate import quad
+from scipy.stats import t as student_t
 
 import stochvolmodels.pricers.gmm_pricer as gmm_module
 import stochvolmodels.pricers.tdist_pricer as tdist_module
@@ -14,15 +16,49 @@ from stochvolmodels import (
     GmmParams,
     GmmPricer,
     OptionChain,
+    OptionSlice,
     TdistParams,
     TdistPricer,
     compute_bsm_vanilla_price,
 )
 from stochvolmodels.fitters.tdist import imply_drift_tdist
+from stochvolmodels.models import (
+    PathModel,
+    TerminalDistributionModel,
+    TerminalSmileModel,
+    TransformModel,
+)
 from stochvolmodels.pricers.gmm_pricer import (
     compute_gmm_vanilla_price,
     compute_gmm_vanilla_slice_prices,
     gmm_vanilla_chain_pricer,
+)
+from stochvolmodels.pricers.tdist_pricer import TdistTerminalModel
+
+
+_TDIST_TTM = 0.5
+_TDIST_FORWARD = 1.0
+_TDIST_DISCOUNT_FACTOR = np.exp(-0.01)
+_TDIST_DRIFT = 0.019643159690483324
+_TDIST_STRIKES = np.array([0.8, 0.9, 1.0, 1.1, 1.2])
+_TDIST_OPTIONTYPES = np.array(["P", "P", "C", "C", "C"])
+_TDIST_PRICES = np.array(
+    [
+        0.01778114786520990,
+        0.03790196930809202,
+        0.07631380572251986,
+        0.03799929065161961,
+        0.01794390178480159,
+    ]
+)
+_TDIST_BLACK_IVOLS = np.array(
+    [
+        0.32463119501585250,
+        0.29311367679985950,
+        0.27367063936838343,
+        0.26544693479584630,
+        0.26590566227895550,
+    ]
 )
 
 
@@ -62,6 +98,84 @@ def _synthetic_tdist_slice(params: TdistParams) -> OptionChain:
         bid_ivs=List([ivols]),
         ask_ivs=List([ivols]),
     )
+
+
+def _tdist_terminal_model(**overrides: float) -> TdistTerminalModel:
+    """Return the frozen-reference Student-t terminal model with optional overrides."""
+    values = {
+        "drift": _TDIST_DRIFT,
+        "vol": 0.3,
+        "nu": 5.0,
+        "ttm": _TDIST_TTM,
+    }
+    values.update(overrides)
+    return TdistTerminalModel(params=TdistParams(**values))
+
+
+def _tdist_terminal_slice(
+    *,
+    strikes: np.ndarray = _TDIST_STRIKES,
+    optiontypes: np.ndarray = _TDIST_OPTIONTYPES,
+    ttm: float = _TDIST_TTM,
+    discfactor: float = _TDIST_DISCOUNT_FACTOR,
+) -> OptionSlice:
+    """Return the frozen-reference option slice."""
+    return OptionSlice(
+        ttm=ttm,
+        forward=_TDIST_FORWARD,
+        strikes=strikes,
+        optiontypes=optiontypes,
+        id="student_t_reference",
+        discfactor=discfactor,
+    )
+
+
+def _integrated_tdist_prices(
+    model: TdistTerminalModel,
+    option_slice: OptionSlice,
+) -> np.ndarray:
+    """Integrate payoffs directly under SciPy's Student-t density and the zero atom."""
+    params = model.params
+    spot = option_slice.forward * option_slice.discfactor
+    scale = params.vol * np.sqrt(params.ttm * (params.nu - 2.0) / params.nu)
+    law = student_t(df=params.nu, loc=0.0, scale=scale)
+    default_boundary = -(1.0 + params.drift * params.ttm)
+    default_probability = law.cdf(default_boundary)
+    prices = np.empty(option_slice.strikes.size, dtype=float)
+
+    for index, (strike, optiontype) in enumerate(
+        zip(option_slice.strikes, option_slice.optiontypes)
+    ):
+        exercise_boundary = strike / spot - (1.0 + params.drift * params.ttm)
+        if optiontype == "C":
+            undiscounted, _ = quad(
+                lambda shock: (
+                    spot * (1.0 + params.drift * params.ttm + shock) - strike
+                )
+                * law.pdf(shock),
+                exercise_boundary,
+                np.inf,
+                epsabs=1.0e-13,
+                epsrel=1.0e-13,
+                limit=200,
+            )
+        else:
+            continuous, _ = quad(
+                lambda shock: (
+                    strike - spot * (1.0 + params.drift * params.ttm + shock)
+                )
+                * law.pdf(shock),
+                default_boundary,
+                exercise_boundary,
+                epsabs=1.0e-13,
+                epsrel=1.0e-13,
+                limit=200,
+            )
+            undiscounted = strike * default_probability + continuous
+        prices[index] = option_slice.discfactor * undiscounted
+
+    assert default_probability > 0.0
+    return prices
 
 
 def _synthetic_gmm_slice(params: GmmParams) -> OptionChain:
@@ -384,6 +498,211 @@ def test_student_t_vector_pricing_and_implied_vol_round_trip() -> None:
             optiontypes="BAD",
             rf_rate=rate,
         )
+
+
+def test_tdist_terminal_model_matches_frozen_prices_and_black_ivols() -> None:
+    """The adapter preserves captured analytics and exposes both terminal capabilities."""
+    model = _tdist_terminal_model()
+    option_slice = _tdist_terminal_slice()
+
+    prices = model.price_european(option_slice)
+    ivols = model.implied_vols(option_slice)
+
+    assert isinstance(model, TerminalDistributionModel)
+    assert isinstance(model, TerminalSmileModel)
+    assert not isinstance(model, PathModel)
+    assert not isinstance(model, TransformModel)
+    assert model.ttm == _TDIST_TTM
+    assert prices.shape == option_slice.strikes.shape
+    assert ivols.shape == option_slice.strikes.shape
+    assert np.issubdtype(prices.dtype, np.floating)
+    assert np.issubdtype(ivols.dtype, np.floating)
+    np.testing.assert_allclose(prices, _TDIST_PRICES, rtol=0.0, atol=3.0e-14)
+    np.testing.assert_allclose(ivols, _TDIST_BLACK_IVOLS, rtol=0.0, atol=5.0e-12)
+
+
+def test_tdist_terminal_prices_match_independent_payoff_integration() -> None:
+    """Closed-form prices agree with direct integration including the default atom."""
+    model = _tdist_terminal_model()
+    option_slice = _tdist_terminal_slice()
+
+    np.testing.assert_allclose(
+        model.price_european(option_slice),
+        _integrated_tdist_prices(model, option_slice),
+        rtol=2.0e-12,
+        atol=2.0e-13,
+    )
+
+
+def test_tdist_terminal_prices_satisfy_discounted_put_call_parity() -> None:
+    """Paired calls and puts preserve the adapter's forward convention."""
+    model = _tdist_terminal_model()
+    strikes = np.array([0.8, 1.0, 1.2])
+    calls = model.price_european(
+        _tdist_terminal_slice(strikes=strikes, optiontypes=np.array(["C"] * 3))
+    )
+    puts = model.price_european(
+        _tdist_terminal_slice(strikes=strikes, optiontypes=np.array(["P"] * 3))
+    )
+
+    np.testing.assert_allclose(
+        calls - puts,
+        _TDIST_DISCOUNT_FACTOR * (_TDIST_FORWARD - strikes),
+        rtol=2.0e-12,
+        atol=2.0e-13,
+    )
+
+
+def test_tdist_terminal_prices_are_monotone_and_convex_in_strike() -> None:
+    """Standard call and put grids satisfy their no-arbitrage strike-shape constraints."""
+    model = _tdist_terminal_model()
+    strikes = np.linspace(0.5, 1.5, 21)
+    calls = model.price_european(
+        _tdist_terminal_slice(strikes=strikes, optiontypes=np.array(["C"] * strikes.size))
+    )
+    puts = model.price_european(
+        _tdist_terminal_slice(strikes=strikes, optiontypes=np.array(["P"] * strikes.size))
+    )
+
+    # This is about 900 float64 eps at unit scale and matches the direct-integration allowance.
+    roundoff_tolerance = 2.0e-13
+    assert np.max(np.diff(calls)) <= roundoff_tolerance
+    assert np.min(np.diff(puts)) >= -roundoff_tolerance
+    assert np.min(np.diff(calls, n=2)) >= -roundoff_tolerance
+    assert np.min(np.diff(puts, n=2)) >= -roundoff_tolerance
+
+
+def test_tdist_terminal_model_returns_float_arrays_for_integer_strikes() -> None:
+    """Integer input storage must not truncate terminal prices or implied volatilities."""
+    model = _tdist_terminal_model()
+    integer_slice = _tdist_terminal_slice(
+        strikes=np.array([1, 2]),
+        optiontypes=np.array(["C", "C"]),
+    )
+    float_slice = _tdist_terminal_slice(
+        strikes=np.array([1.0, 2.0]),
+        optiontypes=np.array(["C", "C"]),
+    )
+
+    integer_prices = model.price_european(integer_slice)
+    integer_ivols = model.implied_vols(integer_slice)
+
+    assert np.issubdtype(integer_prices.dtype, np.floating)
+    assert np.issubdtype(integer_ivols.dtype, np.floating)
+    assert integer_prices[1] > 0.0
+    np.testing.assert_allclose(
+        integer_prices,
+        model.price_european(float_slice),
+        rtol=0.0,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        integer_ivols,
+        model.implied_vols(float_slice),
+        rtol=0.0,
+        atol=0.0,
+    )
+
+
+def test_tdist_terminal_model_requires_exact_slice_maturity() -> None:
+    """A one-maturity parameter set cannot silently price another maturity."""
+    mismatched_ttm = np.nextafter(_TDIST_TTM, np.inf)
+
+    with pytest.raises(ValueError, match="exactly match"):
+        _tdist_terminal_model().price_european(_tdist_terminal_slice(ttm=mismatched_ttm))
+
+
+def test_tdist_terminal_model_requires_consistent_discount_rate() -> None:
+    """The slice discount rate must agree with the drift's floored martingale equation."""
+    inconsistent_slice = _tdist_terminal_slice(discfactor=np.exp(-0.015))
+
+    with pytest.raises(ValueError, match="discount rate"):
+        _tdist_terminal_model().price_european(inconsistent_slice)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("drift", np.nan),
+        ("drift", np.inf),
+        ("drift", True),
+        ("vol", 0.0),
+        ("vol", -0.1),
+        ("vol", np.nan),
+        ("vol", np.bool_(True)),
+        ("nu", 2.0),
+        ("nu", 1.9),
+        ("nu", np.inf),
+        ("ttm", 0.0),
+        ("ttm", -0.1),
+        ("ttm", np.nan),
+    ],
+)
+def test_tdist_terminal_model_rejects_invalid_parameters(field: str, value: float) -> None:
+    """The adapter rejects non-finite or mathematically invalid bound parameters."""
+    with pytest.raises(ValueError, match=field):
+        _tdist_terminal_model(**{field: value})
+
+
+def test_tdist_terminal_model_requires_tdist_params() -> None:
+    """The bound parameter payload must use the established dataclass."""
+    with pytest.raises(TypeError, match="TdistParams"):
+        TdistTerminalModel(params=object())
+
+
+def test_tdist_terminal_model_detaches_from_caller_params() -> None:
+    """Mutating the caller's legacy payload cannot change the bound terminal law."""
+    params = TdistParams(drift=_TDIST_DRIFT, vol=0.3, nu=5.0, ttm=_TDIST_TTM)
+    model = TdistTerminalModel(params=params)
+    option_slice = _tdist_terminal_slice()
+    prices = model.price_european(option_slice)
+
+    assert model.params is not params
+    params.drift = 1.0
+    params.vol = 1.0
+    params.nu = 3.0
+    params.ttm = 1.0
+
+    assert model.params == TdistParams(
+        drift=_TDIST_DRIFT,
+        vol=0.3,
+        nu=5.0,
+        ttm=_TDIST_TTM,
+    )
+    np.testing.assert_allclose(model.price_european(option_slice), prices, rtol=0.0, atol=0.0)
+
+
+def test_tdist_terminal_model_detaches_returned_params() -> None:
+    """Mutating an inspected parameter copy cannot change the bound terminal law."""
+    model = _tdist_terminal_model()
+    option_slice = _tdist_terminal_slice()
+    prices = model.price_european(option_slice)
+    inspected_params = model.params
+
+    inspected_params.drift = 1.0
+    inspected_params.vol = 1.0
+    inspected_params.nu = 3.0
+    inspected_params.ttm = 1.0
+
+    assert model.params == TdistParams(
+        drift=_TDIST_DRIFT,
+        vol=0.3,
+        nu=5.0,
+        ttm=_TDIST_TTM,
+    )
+    np.testing.assert_allclose(model.price_european(option_slice), prices, rtol=0.0, atol=0.0)
+
+
+@pytest.mark.parametrize("optiontype", ["IC", "IP"])
+def test_tdist_terminal_model_does_not_claim_inverse_payoff_support(optiontype: str) -> None:
+    """Historical inverse codes remain outside the new terminal-model contract."""
+    option_slice = _tdist_terminal_slice(
+        strikes=np.array([1.0]),
+        optiontypes=np.array([optiontype]),
+    )
+
+    with pytest.raises(NotImplementedError, match="inverse"):
+        _tdist_terminal_model().price_european(option_slice)
 
 
 def test_student_t_calibration_recovers_synthetic_surface() -> None:


### PR DESCRIPTION
Implements the approved bounded T1 Student-t terminal distribution/smile adapter without root export or numerical relocation. Validates immutable parameter snapshots, exact maturity, martingale discount consistency, C/P-only semantics and floating outputs. Evidence: independent Student-t payoff quadrature including the zero atom; frozen prices and Black IVs; parity and no-arbitrage shape gates; 39 focused and 395 OCA-5.2 fast tests passed; deliberate guard mutations failed; Ruff and wheel-content checks passed.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced TdistTerminalModel for Student-t terminal-law and Black-smile adaptation.</li>
<li>Refined Student-t analytics to model arithmetic-return shocks with an atom at zero.</li>
<li>Updated T-distribution functions (PDF, CDF, cumulative mean) with improved parameter handling.</li>
<li>Added comprehensive contract tests for the new distribution pricer.</li>
</ul></div>