### PR TITLE
feat: add discrete TGARCH terminal path model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Entries start at 1.2.0. For earlier releases see the git log.
 - `ModelPaths` and the provisional `PathModel`, `TransformModel`,
   `TerminalDistributionModel`, `TerminalSmileModel`, and `Payoff` capability contracts establish
   the path, terminal-model, and pathwise-product boundaries for book analytics.
+- `stochvolmodels.models.tgarch` adds a distinct discrete TGARCH terminal path model with
+  physical, exact finite-step pricing, and limit-pricing measures, including raw
+  P-to-exact-Q likelihood ratios and simulation diagnostics.
 
 ## [2.3.0] - 2026-08-24
 

--- a/scripts/check_wheel_contents.py
+++ b/scripts/check_wheel_contents.py
@@ -46,6 +46,7 @@ def check_wheel(wheel_path: Path) -> None:
         "stochvolmodels/__init__.py",
         "stochvolmodels/data/model_paths.py",
         "stochvolmodels/models/__init__.py",
+        "stochvolmodels/models/tgarch.py",
         "stochvolmodels/products/__init__.py",
     }
     missing_runtime_files = required_runtime_files.difference(members)
@@ -57,8 +58,8 @@ def check_wheel(wheel_path: Path) -> None:
         for member in members
         if member.startswith("stochvolmodels/tests/test_") and member.endswith(".py")
     }
-    assert len(test_modules) == 27, (
-        f"expected exactly 27 automated test modules, found {len(test_modules)}"
+    assert len(test_modules) == 28, (
+        f"expected exactly 28 automated test modules, found {len(test_modules)}"
     )
     assert not any(member.endswith("_test.py") for member in members), (
         "automated tests must use the test_*.py form"

--- a/src/stochvolmodels/models/tgarch.py
+++ b/src/stochvolmodels/models/tgarch.py
@@ -1,0 +1,624 @@
+"""Terminal path simulation for a discrete threshold-volatility model.
+
+This TGARCH recursion is a distinct discrete model, not a discretization scheme for
+``LogSVPricer``. Times are measured in years, rates and volatilities are annualized, and asset
+returns are log returns. The bounded first lift stores only the initial and terminal observations.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from stochvolmodels.data.model_paths import ModelPaths
+
+__all__ = (
+    "TgarchLimitParams",
+    "TgarchMeasure",
+    "TgarchModel",
+    "TgarchParams",
+    "derive_tgarch_limit_params",
+)
+
+M1 = math.sqrt(2.0 / math.pi)
+S1 = math.sqrt(1.0 - 2.0 / math.pi)
+SIGMA_FLOOR = 1.0e-6
+
+_DEFAULT_CHUNK_STEPS = 8
+_LEGACY_SOURCE_SHA256 = "4a07de7c20591276a9f241b1c18b96e2f2c3fd1b953e29375ab5096b3fb35f38"
+_SOURCE_TAG = "tgarch-study-round2-v1"
+_SOURCE_COMMIT = "add76d1909b4223d005e31fcf377845501021362"
+
+FloatArray = NDArray[np.float64]
+
+
+class TgarchMeasure(str, Enum):
+    """Sampling law for the discrete terminal recursion."""
+
+    P = "P"
+    Q_EXACT = "Q_EXACT"
+    Q_LIMIT = "Q_LIMIT"
+
+
+def _finite_float(value: object, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a finite real number, not bool")
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite real number") from exc
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    return result
+
+
+def _positive_float(value: object, name: str, *, allow_zero: bool = False) -> float:
+    result = _finite_float(value, name)
+    if allow_zero:
+        if result < 0.0:
+            raise ValueError(f"{name} must be non-negative, got {result}")
+    elif result <= 0.0:
+        raise ValueError(f"{name} must be strictly positive, got {result}")
+    return result
+
+
+def _positive_int(value: object, name: str, *, minimum: int = 1) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f"{name} must be an integer")
+    result = int(value)
+    if result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}, got {result}")
+    return result
+
+
+def _validated_seed(seed: object) -> int:
+    if isinstance(seed, (bool, np.bool_)) or not isinstance(seed, (int, np.integer)):
+        raise ValueError("seed must be a non-negative integer")
+    result = int(seed)
+    if result < 0:
+        raise ValueError(f"seed must be non-negative, got {result}")
+    return result
+
+
+def _as_measure(measure: TgarchMeasure | str) -> TgarchMeasure:
+    try:
+        return TgarchMeasure(measure)
+    except (TypeError, ValueError) as exc:
+        allowed = ", ".join(item.value for item in TgarchMeasure)
+        raise ValueError(f"measure must be one of {{{allowed}}}, got {measure!r}") from exc
+
+
+@dataclass(frozen=True, slots=True)
+class TgarchParams:
+    """Parameters of the physical recursion and its pricing kernel.
+
+    Parameters
+    ----------
+    theta
+        Long-run annualized volatility level.
+    kappa1, kappa2
+        Linear and quadratic physical mean-reversion coefficients.
+    beta
+        Signed loading of volatility on the return innovation.
+    eps
+        Residual loading on the standardized absolute-return innovation.
+    sigma0
+        Initial annualized volatility.
+    r
+        Continuously compounded annualized short rate.
+    gamma0, gamma1
+        Intercept and slope of the conditional Sharpe-ratio kernel.
+    eta0, eta1
+        Intercept and slope of the finite-step variance-preference kernel.
+    spot0
+        Initial asset level.
+    """
+
+    theta: float
+    kappa1: float
+    kappa2: float
+    beta: float
+    eps: float
+    sigma0: float
+    r: float = 0.0
+    gamma0: float = 0.0
+    gamma1: float = 0.0
+    eta0: float = 0.0
+    eta1: float = 0.0
+    spot0: float = 1.0
+
+    def __post_init__(self) -> None:
+        """Validate and canonicalize scalar parameters."""
+        for name in ("theta", "kappa1", "eps", "sigma0", "spot0"):
+            object.__setattr__(self, name, _positive_float(getattr(self, name), name))
+        object.__setattr__(
+            self,
+            "kappa2",
+            _positive_float(self.kappa2, "kappa2", allow_zero=True),
+        )
+        for name in ("beta", "r", "gamma0", "gamma1", "eta0", "eta1"):
+            object.__setattr__(self, name, _finite_float(getattr(self, name), name))
+
+    @property
+    def vartheta(self) -> float:
+        """Return total volatility of volatility ``sqrt(beta**2 + eps**2)``."""
+        return math.hypot(self.beta, self.eps)
+
+    @property
+    def d0(self) -> float:
+        """Return the constant physical volatility-drift coefficient."""
+        return self.kappa1 * self.theta
+
+    @property
+    def d1(self) -> float:
+        """Return the linear physical volatility-drift coefficient."""
+        return self.kappa2 * self.theta - self.kappa1
+
+    @property
+    def d2(self) -> float:
+        """Return the quadratic physical volatility-drift coefficient."""
+        return -self.kappa2
+
+    @property
+    def s0(self) -> float:
+        """Return ``spot0`` under the conventional option-pricing alias."""
+        return self.spot0
+
+    @property
+    def epsilon(self) -> float:
+        """Return ``eps`` under its unabbreviated alias."""
+        return self.eps
+
+    def gamma(self, sigma: float | FloatArray) -> float | FloatArray:
+        """Evaluate the conditional Sharpe-ratio kernel."""
+        return self.gamma0 + self.gamma1 * sigma
+
+    def eta(self, sigma: float | FloatArray) -> float | FloatArray:
+        """Evaluate the finite-step variance-preference kernel."""
+        return self.eta0 + self.eta1 * sigma
+
+    def drift(self, sigma: float | FloatArray) -> float | FloatArray:
+        """Evaluate the physical annualized volatility drift."""
+        return (self.kappa1 + self.kappa2 * sigma) * (self.theta - sigma)
+
+
+@dataclass(frozen=True, slots=True)
+class TgarchLimitParams:
+    """Hatted drift parameters for the finite-step limit-Q recursion."""
+
+    kappa1_hat: float
+    kappa2_hat: float
+    theta_hat: float
+    d0: float
+    d1_hat: float
+    lambda0_bar: float
+    lambda1_bar: float
+    vartheta: float
+
+    def __post_init__(self) -> None:
+        """Validate the hatted factorization and cross-parameter identities."""
+        for name in ("kappa1_hat", "theta_hat", "d0", "vartheta"):
+            object.__setattr__(self, name, _positive_float(getattr(self, name), name))
+        object.__setattr__(
+            self,
+            "kappa2_hat",
+            _positive_float(self.kappa2_hat, "kappa2_hat", allow_zero=True),
+        )
+        for name in ("d1_hat", "lambda0_bar", "lambda1_bar"):
+            object.__setattr__(self, name, _finite_float(getattr(self, name), name))
+
+        implied_d0 = self.kappa1_hat * self.theta_hat
+        implied_d1 = self.kappa2_hat * self.theta_hat - self.kappa1_hat
+        d0_scale = max(1.0, abs(self.d0), abs(implied_d0))
+        d1_scale = max(1.0, abs(self.d1_hat), abs(implied_d1))
+        if abs(implied_d0 - self.d0) > 5.0e-11 * d0_scale:
+            raise ValueError("inconsistent limit parameters: d0 != kappa1_hat * theta_hat")
+        if abs(implied_d1 - self.d1_hat) > 5.0e-11 * d1_scale:
+            raise ValueError(
+                "inconsistent limit parameters: d1_hat != kappa2_hat * theta_hat - kappa1_hat"
+            )
+
+    @classmethod
+    def from_drift_coefficients(
+        cls,
+        *,
+        d0: float,
+        d1_hat: float,
+        kappa2_hat: float,
+        lambda0_bar: float,
+        lambda1_bar: float,
+        vartheta: float,
+    ) -> TgarchLimitParams:
+        """Construct the stable hatted factorization from polynomial coefficients."""
+        d0_value = _positive_float(d0, "d0")
+        d1_value = _finite_float(d1_hat, "d1_hat")
+        kappa2_value = _positive_float(kappa2_hat, "kappa2_hat", allow_zero=True)
+        if kappa2_value == 0.0:
+            if d1_value >= 0.0:
+                raise ValueError("kappa2_hat=0 requires d1_hat<0 for a mean-reverting limit")
+            kappa1_hat = -d1_value
+            theta_hat = d0_value / kappa1_hat
+        else:
+            discriminant = math.sqrt(d1_value * d1_value + 4.0 * kappa2_value * d0_value)
+            if d1_value >= 0.0:
+                theta_hat = (d1_value + discriminant) / (2.0 * kappa2_value)
+            else:
+                theta_hat = 2.0 * d0_value / (discriminant - d1_value)
+            kappa1_hat = d0_value / theta_hat
+        return cls(
+            kappa1_hat=kappa1_hat,
+            kappa2_hat=kappa2_value,
+            theta_hat=theta_hat,
+            d0=d0_value,
+            d1_hat=d1_value,
+            lambda0_bar=lambda0_bar,
+            lambda1_bar=lambda1_bar,
+            vartheta=vartheta,
+        )
+
+    @property
+    def d2_hat(self) -> float:
+        """Return the quadratic limit-Q volatility-drift coefficient."""
+        return -self.kappa2_hat
+
+    def drift(self, sigma: float | FloatArray) -> float | FloatArray:
+        """Evaluate the limit-Q annualized volatility drift."""
+        return self.d0 + self.d1_hat * sigma - self.kappa2_hat * sigma * sigma
+
+
+def derive_tgarch_limit_params(params: TgarchParams) -> TgarchLimitParams:
+    """Map the pricing-kernel coefficients into the hatted limit-Q drift."""
+    if not isinstance(params, TgarchParams):
+        raise ValueError("params must be a TgarchParams instance")
+    lambda0_bar = params.gamma1
+    lambda1_bar = -(M1 / S1) * params.eta1
+    lambda_intercept = -params.beta * params.gamma0 + params.eps * M1 * params.eta0 / S1
+    lambda_slope = -params.beta * params.gamma1 + params.eps * M1 * params.eta1 / S1
+    d1_hat = params.d1 + lambda_intercept
+    kappa2_hat = params.kappa2 - lambda_slope
+    if kappa2_hat < 0.0:
+        raise ValueError(
+            "derived kappa2_hat is negative; the requested Q limit is outside the "
+            f"well-posed parameter region (kappa2_hat={kappa2_hat:.12g})"
+        )
+    return TgarchLimitParams.from_drift_coefficients(
+        d0=params.d0,
+        d1_hat=d1_hat,
+        kappa2_hat=kappa2_hat,
+        lambda0_bar=lambda0_bar,
+        lambda1_bar=lambda1_bar,
+        vartheta=params.vartheta,
+    )
+
+
+def _step_grid(horizon: float, max_dt: float) -> tuple[int, float]:
+    horizon_value = _positive_float(horizon, "maturity")
+    max_dt_value = _positive_float(max_dt, "max_dt")
+    n_steps = max(1, int(math.ceil(horizon_value / max_dt_value - 2.0e-14)))
+    return n_steps, horizon_value / n_steps
+
+
+def _resolve_limit_params(
+    params: TgarchParams,
+    measure: TgarchMeasure,
+    limit_params: TgarchLimitParams | None,
+) -> TgarchLimitParams | None:
+    if limit_params is not None and not isinstance(limit_params, TgarchLimitParams):
+        raise ValueError("limit_params must be a TgarchLimitParams instance or None")
+    if measure is not TgarchMeasure.Q_LIMIT:
+        return limit_params
+    result = derive_tgarch_limit_params(params) if limit_params is None else limit_params
+    d0_scale = max(1.0, abs(params.d0), abs(result.d0))
+    vol_scale = max(1.0, params.vartheta, result.vartheta)
+    if abs(result.d0 - params.d0) > 5.0e-11 * d0_scale:
+        raise ValueError("limit_params violates the cross-measure d0 restriction")
+    if abs(result.vartheta - params.vartheta) > 5.0e-11 * vol_scale:
+        raise ValueError("limit_params.vartheta must match the physical diffusion scale")
+    return result
+
+
+def _exact_q_law(
+    sigma: FloatArray,
+    dt: float,
+    params: TgarchParams,
+) -> tuple[FloatArray, FloatArray]:
+    sqrt_dt = math.sqrt(dt)
+    denominator = 1.0 - 2.0 * sqrt_dt * params.eta(sigma)
+    if np.any(denominator <= 0.0) or not np.isfinite(denominator).all():
+        worst = float(np.min(denominator))
+        raise ValueError(
+            "the exact-Q kernel is inadmissible: 1 - 2*sqrt(dt)*eta(sigma) "
+            f"must be positive on every path (minimum={worst:.12g})"
+        )
+    variance = 1.0 / denominator
+    mean = -sqrt_dt * params.gamma(sigma) - 0.5 * sigma * sqrt_dt * (variance - 1.0)
+    return np.asarray(mean, dtype=np.float64), np.asarray(variance, dtype=np.float64)
+
+
+def _antithetic_normal_block(
+    rng: np.random.Generator,
+    *,
+    block_steps: int,
+    n_paths: int,
+) -> FloatArray:
+    pair_count = n_paths // 2
+    has_singleton = n_paths % 2
+    independent_count = pair_count + has_singleton
+    draws = rng.standard_normal((block_steps, independent_count), dtype=np.float64)
+    result = np.empty((block_steps, n_paths), dtype=np.float64)
+    if pair_count:
+        result[:, :pair_count] = draws[:, :pair_count]
+        result[:, pair_count : 2 * pair_count] = -draws[:, :pair_count]
+    if has_singleton:
+        result[:, -1] = draws[:, -1]
+    return result
+
+
+def _effective_sample_size(log_weights: FloatArray) -> float:
+    shift = float(np.max(log_weights))
+    scaled = np.exp(log_weights - shift)
+    numerator = float(np.sum(scaled)) ** 2
+    denominator = float(np.dot(scaled, scaled))
+    if denominator == 0.0 or not math.isfinite(numerator):
+        raise FloatingPointError("could not compute a finite effective sample size")
+    return numerator / denominator
+
+
+@dataclass(frozen=True, slots=True)
+class _TerminalState:
+    dt: float
+    n_steps: int
+    spot: FloatArray
+    log_spot: FloatArray
+    sigma: FloatArray
+    floor_hits: int
+    spot_overflow_count: int
+    log_weights: FloatArray | None
+    effective_sample_size: float | None
+    ess_fraction: float | None
+    low_ess: bool
+
+
+def _simulate_terminal(
+    *,
+    params: TgarchParams,
+    measure: TgarchMeasure,
+    maturity: float,
+    max_dt: float,
+    n_paths: int,
+    seed: int,
+    limit_params: TgarchLimitParams | None,
+    track_log_weights: bool,
+    chunk_steps: int,
+) -> _TerminalState:
+    n_steps, dt = _step_grid(maturity, max_dt)
+    limit = _resolve_limit_params(params, measure, limit_params)
+    rng = np.random.Generator(np.random.PCG64(seed))
+    sigma = np.full(n_paths, params.sigma0, dtype=np.float64)
+    log_spot = np.full(n_paths, math.log(params.spot0), dtype=np.float64)
+    log_weights = np.zeros(n_paths, dtype=np.float64) if track_log_weights else None
+    sqrt_dt = math.sqrt(dt)
+    floor_hits = 0
+
+    for block_start in range(0, n_steps, chunk_steps):
+        block_size = min(chunk_steps, n_steps - block_start)
+        base_block = _antithetic_normal_block(
+            rng,
+            block_steps=block_size,
+            n_paths=n_paths,
+        )
+        for block_index in range(block_size):
+            base_z = base_block[block_index]
+            if measure is TgarchMeasure.Q_EXACT:
+                q_mean, q_variance = _exact_q_law(sigma, dt, params)
+                z = q_mean + np.sqrt(q_variance) * base_z
+                log_drift = params.r + params.gamma(sigma) * sigma - 0.5 * sigma * sigma
+                sigma_drift = params.drift(sigma)
+            elif measure is TgarchMeasure.P:
+                z = base_z
+                log_drift = params.r + params.gamma(sigma) * sigma - 0.5 * sigma * sigma
+                sigma_drift = params.drift(sigma)
+                if log_weights is not None:
+                    q_mean, q_variance = _exact_q_law(sigma, dt, params)
+                    log_weights += -0.5 * np.log(q_variance) - 0.5 * (
+                        (z - q_mean) * (z - q_mean) / q_variance - z * z
+                    )
+            else:
+                if limit is None:  # pragma: no cover - guarded by _resolve_limit_params
+                    raise RuntimeError("missing Q-limit parameters")
+                z = base_z
+                log_drift = params.r - 0.5 * sigma * sigma
+                sigma_drift = limit.drift(sigma)
+
+            log_spot += log_drift * dt + sigma * sqrt_dt * z
+            w = (np.abs(z) - M1) / S1
+            sigma_next = (
+                sigma
+                + sigma_drift * dt
+                + sigma * sqrt_dt * (params.beta * z + params.eps * w)
+            )
+            hit = sigma_next < SIGMA_FLOOR
+            floor_hits += int(np.count_nonzero(hit))
+            np.maximum(sigma_next, SIGMA_FLOOR, out=sigma_next)
+            sigma = sigma_next
+
+        if not np.isfinite(sigma).all() or not np.isfinite(log_spot).all():
+            step = block_start + block_size
+            raise FloatingPointError(f"non-finite state encountered after simulation step {step}")
+        if log_weights is not None and not np.isfinite(log_weights).all():
+            step = block_start + block_size
+            raise FloatingPointError(
+                f"non-finite log weight encountered after simulation step {step}"
+            )
+
+    with np.errstate(over="ignore", under="ignore"):
+        terminal_spot = np.exp(log_spot)
+    spot_overflow_count = int(np.isposinf(terminal_spot).sum())
+    effective_sample_size: float | None = None
+    ess_fraction: float | None = None
+    low_ess = False
+    if log_weights is not None:
+        effective_sample_size = _effective_sample_size(log_weights)
+        ess_fraction = effective_sample_size / n_paths
+        low_ess = ess_fraction < 0.2
+
+    return _TerminalState(
+        dt=dt,
+        n_steps=n_steps,
+        spot=terminal_spot,
+        log_spot=log_spot,
+        sigma=sigma,
+        floor_hits=floor_hits,
+        spot_overflow_count=spot_overflow_count,
+        log_weights=log_weights,
+        effective_sample_size=effective_sample_size,
+        ess_fraction=ess_fraction,
+        low_ess=low_ess,
+    )
+
+
+def _readonly(array: FloatArray) -> FloatArray:
+    array.setflags(write=False)
+    return array
+
+
+@dataclass(frozen=True, slots=True)
+class TgarchModel:
+    """Two-observation terminal adapter for the discrete TGARCH recursion."""
+
+    params: TgarchParams
+
+    def __post_init__(self) -> None:
+        """Require a validated TGARCH parameter payload."""
+        if not isinstance(self.params, TgarchParams):
+            raise ValueError("params must be a TgarchParams instance")
+
+    def simulate_paths(
+        self,
+        *,
+        measure: TgarchMeasure | str,
+        maturity: float,
+        max_dt: float,
+        n_paths: int,
+        seed: int,
+        limit_params: TgarchLimitParams | None = None,
+        track_log_weights: bool = False,
+        chunk_steps: int = _DEFAULT_CHUNK_STEPS,
+    ) -> ModelPaths:
+        """Simulate initial and terminal asset/state observations.
+
+        ``max_dt`` is an upper bound. Equal steps use realized size
+        ``maturity / ceil(maturity / max_dt)``. P-to-exact-Q log likelihood ratios are raw and
+        available only for paths sampled under P; they are never self-normalized.
+
+        Parameters
+        ----------
+        measure
+            Physical, exact finite-step pricing, or limiting pricing law.
+        maturity
+            Positive terminal horizon in years.
+        max_dt
+            Positive upper bound for a simulation step in years.
+        n_paths
+            Positive number of terminal paths, including antithetic partners.
+        seed
+            Non-negative seed for ``Generator(PCG64(seed))``.
+        limit_params
+            Optional validated limit-Q drift parameters. Derived from ``params`` by default under
+            Q_LIMIT; a valid payload is ignored under the other measures for legacy compatibility.
+        track_log_weights
+            Accumulate raw ``log(dQ_EXACT/dP)`` values on P paths.
+        chunk_steps
+            Positive number of time steps drawn per PCG64 block. Its value is part of the random
+            ordering contract.
+
+        Returns
+        -------
+        ModelPaths
+            Initial and terminal spot, log-spot, volatility, measures and diagnostics.
+        """
+        measure_value = _as_measure(measure)
+        maturity_value = _positive_float(maturity, "maturity")
+        max_dt_value = _positive_float(max_dt, "max_dt")
+        n_paths_value = _positive_int(n_paths, "n_paths")
+        seed_value = _validated_seed(seed)
+        chunk_value = _positive_int(chunk_steps, "chunk_steps")
+        if not isinstance(track_log_weights, (bool, np.bool_)):
+            raise ValueError("track_log_weights must be bool")
+        track_weights_value = bool(track_log_weights)
+        if track_weights_value and measure_value is not TgarchMeasure.P:
+            raise ValueError("P-to-Q log weights can only be accumulated on P simulations")
+
+        terminal = _simulate_terminal(
+            params=self.params,
+            measure=measure_value,
+            maturity=maturity_value,
+            max_dt=max_dt_value,
+            n_paths=n_paths_value,
+            seed=seed_value,
+            limit_params=limit_params,
+            track_log_weights=track_weights_value,
+            chunk_steps=chunk_value,
+        )
+
+        observation_times = _readonly(np.array([0.0, maturity_value], dtype=np.float64))
+        assets = np.empty((n_paths_value, 2, 1), dtype=np.float64)
+        assets[:, 0, 0] = self.params.spot0
+        assets[:, 1, 0] = terminal.spot
+        log_spot = np.empty((n_paths_value, 2), dtype=np.float64)
+        log_spot[:, 0] = math.log(self.params.spot0)
+        log_spot[:, 1] = terminal.log_spot
+        sigma = np.empty((n_paths_value, 2), dtype=np.float64)
+        sigma[:, 0] = self.params.sigma0
+        sigma[:, 1] = terminal.sigma
+
+        target_measure = (
+            TgarchMeasure.Q_EXACT.value
+            if measure_value is TgarchMeasure.P and track_weights_value
+            else measure_value.value
+        )
+        provenance: dict[str, Any] = {
+            "requested_max_dt": max_dt_value,
+            "realized_dt": terminal.dt,
+            "n_steps": terminal.n_steps,
+            "seed": seed_value,
+            "generator": "numpy.random.Generator",
+            "bit_generator": "PCG64",
+            "chunk_steps": chunk_value,
+            "antithetic_layout": "first_half_draws_then_negatives_singleton_last",
+            "source_tag": _SOURCE_TAG,
+            "source_commit": _SOURCE_COMMIT,
+            "legacy_source_sha256": _LEGACY_SOURCE_SHA256,
+            "numpy_version": np.__version__,
+        }
+        diagnostics: dict[str, Any] = {
+            "sigma_floor": SIGMA_FLOOR,
+            "floor_hits": terminal.floor_hits,
+            "spot_overflow_count": terminal.spot_overflow_count,
+            "effective_sample_size": terminal.effective_sample_size,
+            "ess_fraction": terminal.ess_fraction,
+            "low_ess": terminal.low_ess,
+            "weight_convention": "raw_log_dQ_EXACT_dP" if track_weights_value else None,
+        }
+        log_weights = terminal.log_weights
+        if log_weights is not None:
+            _readonly(log_weights)
+        return ModelPaths(
+            observation_times=observation_times,
+            assets=_readonly(assets),
+            asset_ids=("spot",),
+            sampling_measure=measure_value.value,
+            target_measure=target_measure,
+            numeraire="money_market_account",
+            scheme="tgarch_terminal_recursion",
+            states={"log_spot": _readonly(log_spot), "sigma": _readonly(sigma)},
+            state_units={"log_spot": "log price", "sigma": "annualized volatility"},
+            log_likelihood_ratios=log_weights,
+            provenance=provenance,
+            diagnostics=diagnostics,
+        )

--- a/src/stochvolmodels/tests/test_tgarch_paths.py
+++ b/src/stochvolmodels/tests/test_tgarch_paths.py
@@ -1,0 +1,778 @@
+"""Numerical and payload contracts for the terminal TGARCH path model."""
+
+from __future__ import annotations
+
+import math
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import stochvolmodels
+import stochvolmodels.models as model_capabilities
+from stochvolmodels.models import PathModel
+from stochvolmodels.models import (
+    TerminalDistributionModel,
+    TerminalSmileModel,
+    TransformModel,
+)
+from stochvolmodels.models.tgarch import (
+    TgarchMeasure,
+    TgarchModel,
+    TgarchParams,
+    derive_tgarch_limit_params,
+)
+
+
+REFERENCE_SOURCE_SHA256 = (
+    "4a07de7c20591276a9f241b1c18b96e2f2c3fd1b953e29375ab5096b3fb35f38"
+)
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+REFERENCE_TERMINALS = {
+    ("crypto", TgarchMeasure.P): {
+        "spot": [
+            0.8602685056600672,
+            0.8638368188335316,
+            0.9471816269440217,
+            0.8530545753920327,
+            1.0365692702077187,
+            1.075263429328865,
+            0.9639498770029068,
+            1.115874381682727,
+        ],
+        "log_spot": [
+            -0.1505107225800212,
+            -0.1463713951065363,
+            -0.05426441227023124,
+            -0.15893175300719192,
+            0.03591648154119099,
+            0.07256568209812608,
+            -0.03671598053363115,
+            0.10963829640743573,
+        ],
+        "sigma": [
+            0.5182583435715801,
+            0.5395749801274664,
+            0.6507130760607134,
+            0.44654185118227663,
+            0.6541550576094471,
+            0.8527595600461183,
+            0.6715673872914589,
+            0.5765180470526559,
+        ],
+        "log_weights": [
+            -0.04262308533848233,
+            -0.046517056783785045,
+            -0.027566564516974368,
+            0.11932231387408981,
+            -0.16245111496375653,
+            -0.17736181249716082,
+            -0.01977010397910056,
+            0.010043357767623287,
+        ],
+        "ess": 7.937715366423826,
+        "ess_fraction": 0.9922144208029783,
+    },
+    ("crypto", TgarchMeasure.Q_EXACT): {
+        "spot": [
+            0.8358021720572095,
+            0.8519536840247589,
+            0.9299124760945747,
+            0.8429078612953754,
+            1.00436678994413,
+            1.0312882383378925,
+            0.9363752280847721,
+            1.0819726269064622,
+        ],
+        "log_spot": [
+            -0.17936333019542516,
+            -0.16022311510374748,
+            -0.07266480898988556,
+            -0.17089762553580523,
+            0.004357283182893579,
+            0.0308087375797029,
+            -0.06573899813139689,
+            0.07878588149656882,
+        ],
+        "sigma": [
+            0.4927230454994407,
+            0.5166365397032728,
+            0.6007507956754092,
+            0.42001657964689754,
+            0.585628683627495,
+            0.7775680904171415,
+            0.6274128657745263,
+            0.5373764645155664,
+        ],
+    },
+    ("crypto", TgarchMeasure.Q_LIMIT): {
+        "spot": [
+            0.8336258363498804,
+            0.8493744212406097,
+            0.9229376358976386,
+            0.8383968684440025,
+            0.9921549970695158,
+            1.0246013233458469,
+            0.9296000316485745,
+            1.0786114003344536,
+        ],
+        "log_spot": [
+            -0.1819706147614576,
+            -0.16325517547138674,
+            -0.08019361350347337,
+            -0.1762637005797748,
+            -0.007875936856679651,
+            0.024303584095278205,
+            -0.07300085883912238,
+            0.07567447343165692,
+        ],
+        "sigma": [
+            0.46824131348302167,
+            0.49109111234152947,
+            0.591259227085676,
+            0.41035750990538605,
+            0.5838058506299707,
+            0.7759262127723531,
+            0.6067197949695515,
+            0.5256513864257265,
+        ],
+    },
+    ("equity", TgarchMeasure.P): {
+        "spot": [
+            0.9825253762635643,
+            0.9761127327016111,
+            1.0141682009541342,
+            0.9667563748647888,
+            1.0637000263638765,
+            1.0586798012436665,
+            1.0221959793039181,
+            1.0551053073824515,
+        ],
+        "log_spot": [
+            -0.017629107314183715,
+            -0.02417719442198783,
+            0.014068770065641212,
+            -0.03380875439721766,
+            0.061753421060549485,
+            0.05702266135612664,
+            0.021953233969153017,
+            0.053640579370726735,
+        ],
+        "sigma": [
+            0.22380581905498861,
+            0.2843414906881642,
+            0.22073978143526998,
+            0.20807051449351657,
+            0.1759923051266912,
+            0.17550591212883956,
+            0.21275095951647324,
+            0.15843552737384953,
+        ],
+        "log_weights": [
+            -0.04454818789063366,
+            -0.04351394613522393,
+            -0.021279199854717528,
+            0.040990109394855576,
+            -0.0768392037539565,
+            -0.07513337583812273,
+            -0.03070388171548223,
+            -0.012652196185570817,
+        ],
+        "ess": 7.9897826540643475,
+        "ess_fraction": 0.9987228317580434,
+    },
+    ("equity", TgarchMeasure.Q_EXACT): {
+        "spot": [
+            0.9759812146114837,
+            0.9722439977140559,
+            1.009510123668692,
+            0.9633595083801669,
+            1.0585416651738524,
+            1.0530903106963325,
+            1.0175673303689623,
+            1.0508285949555236,
+        ],
+        "log_spot": [
+            -0.024311940078576226,
+            -0.028148479568776728,
+            0.009465187119373535,
+            -0.037328615584009794,
+            0.05689217328749401,
+            0.051728994617934336,
+            0.017414808498107982,
+            0.04957899101659052,
+        ],
+        "sigma": [
+            0.22456142878578783,
+            0.28527755751966594,
+            0.2198286493293046,
+            0.20808529514827157,
+            0.17498513695559775,
+            0.17495838956048707,
+            0.21266394151682025,
+            0.1584440735065741,
+        ],
+    },
+    ("equity", TgarchMeasure.Q_LIMIT): {
+        "spot": [
+            0.9760030824473953,
+            0.9718442347654737,
+            1.0095219254214949,
+            0.9626414682548575,
+            1.0589561497243387,
+            1.053374321639686,
+            1.0175040104006166,
+            1.0512431513969238,
+        ],
+        "log_spot": [
+            -0.024289534328749755,
+            -0.028559739662364976,
+            0.009476877625037666,
+            -0.038074243615653675,
+            0.05728365851393809,
+            0.05199865112269081,
+            0.017352579752512906,
+            0.0499734175603028,
+        ],
+        "sigma": [
+            0.22378280505775017,
+            0.28431798164790695,
+            0.22072018548498093,
+            0.20805388246346718,
+            0.17597738781173133,
+            0.17549124191972262,
+            0.21273347267104423,
+            0.15842359006464002,
+        ],
+    },
+}
+
+
+def _study_params(name: str) -> TgarchParams:
+    """Return one of the two parameter sets used by the companion study."""
+    common = {
+        "r": 0.0,
+        "gamma0": 0.0,
+        "gamma1": 0.5,
+        "eta0": 0.0,
+        "eta1": -0.38,
+        "spot0": 1.0,
+    }
+    if name == "crypto":
+        return TgarchParams(
+            theta=0.6,
+            kappa1=3.0,
+            kappa2=3.0,
+            beta=1.0,
+            eps=1.5,
+            sigma0=0.6,
+            **common,
+        )
+    if name == "equity":
+        return TgarchParams(
+            theta=0.2,
+            kappa1=4.0,
+            kappa2=4.0,
+            beta=-1.0,
+            eps=1.0,
+            sigma0=0.2,
+            **common,
+        )
+    raise ValueError(f"unknown parameter set: {name}")
+
+
+def _simulate(
+    name: str,
+    measure: TgarchMeasure,
+    *,
+    n_paths: int = 8,
+    seed: int = 20260825,
+    chunk_steps: int = 8,
+    track_log_weights: bool | None = None,
+):
+    """Run the bounded terminal adapter with the study grid."""
+    if track_log_weights is None:
+        track_log_weights = measure is TgarchMeasure.P
+    return TgarchModel(_study_params(name)).simulate_paths(
+        measure=measure,
+        maturity=0.25,
+        max_dt=1.0 / 52.0,
+        n_paths=n_paths,
+        seed=seed,
+        chunk_steps=chunk_steps,
+        track_log_weights=track_log_weights,
+    )
+
+
+def _paired_standard_error(values: np.ndarray) -> float:
+    """Return the standard error respecting first-half antithetic pairing."""
+    pair_count = values.size // 2
+    pair_means = 0.5 * (values[:pair_count] + values[pair_count:])
+    return float(np.std(pair_means, ddof=1) / math.sqrt(pair_count))
+
+
+def _stable_raw_weights(log_weights: np.ndarray) -> np.ndarray:
+    """Exponentiate raw ratios using the companion study's shifted calculation."""
+    maximum = float(np.max(log_weights))
+    scaled = np.exp(log_weights - maximum)
+    return math.exp(maximum) * scaled
+
+
+def _controlled_call_pair_values(
+    terminal_spot: np.ndarray,
+    *,
+    strike: float,
+    discount: float,
+    expected_discounted_spot: float,
+    weights: np.ndarray | None = None,
+) -> np.ndarray:
+    """Reproduce E2's separately fitted discounted-terminal-spot control variate."""
+    half = terminal_spot.size // 2
+    left = terminal_spot[:half]
+    right = terminal_spot[half:]
+    payoff_left = discount * np.maximum(left - strike, 0.0)
+    payoff_right = discount * np.maximum(right - strike, 0.0)
+    spot_left = discount * left
+    spot_right = discount * right
+    if weights is not None:
+        weight_left = weights[:half]
+        weight_right = weights[half:]
+        payoff_left = weight_left * payoff_left
+        payoff_right = weight_right * payoff_right
+        spot_left = weight_left * spot_left
+        spot_right = weight_right * spot_right
+    pair_payoff = 0.5 * (payoff_left + payoff_right)
+    pair_spot = 0.5 * (spot_left + spot_right)
+    spot_variance = float(np.var(pair_spot, ddof=1))
+    coefficient = (
+        0.0
+        if spot_variance <= 1.0e-30
+        else float(np.cov(pair_payoff, pair_spot, ddof=1)[0, 1] / spot_variance)
+    )
+    return pair_payoff - coefficient * (pair_spot - expected_discounted_spot)
+
+
+@pytest.mark.parametrize("parameter_name", ["crypto", "equity"])
+@pytest.mark.parametrize("measure", list(TgarchMeasure))
+@pytest.mark.parametrize("chunk_steps", [8, 3])
+def test_terminal_paths_match_pre_lift_legacy_capture(
+    parameter_name: str,
+    measure: TgarchMeasure,
+    chunk_steps: int,
+) -> None:
+    """Both chunk contracts reproduce raw arrays captured from the authoritative simulator."""
+    paths = _simulate(parameter_name, measure, chunk_steps=chunk_steps)
+    expected = REFERENCE_TERMINALS[(parameter_name, measure)]
+
+    np.testing.assert_allclose(paths.assets[:, -1, 0], expected["spot"], rtol=2e-15, atol=0.0)
+    np.testing.assert_allclose(
+        paths.states["log_spot"][:, -1], expected["log_spot"], rtol=2e-15, atol=0.0
+    )
+    np.testing.assert_allclose(
+        paths.states["sigma"][:, -1], expected["sigma"], rtol=2e-15, atol=0.0
+    )
+    assert paths.diagnostics["floor_hits"] == 0
+    assert paths.diagnostics["spot_overflow_count"] == 0
+    assert paths.provenance["chunk_steps"] == chunk_steps
+    assert paths.provenance["legacy_source_sha256"] == REFERENCE_SOURCE_SHA256
+
+    if measure is TgarchMeasure.P:
+        np.testing.assert_allclose(
+            paths.log_likelihood_ratios,
+            expected["log_weights"],
+            rtol=2e-15,
+            atol=0.0,
+        )
+        assert paths.diagnostics["effective_sample_size"] == pytest.approx(
+            expected["ess"], rel=2e-15
+        )
+        assert paths.diagnostics["ess_fraction"] == pytest.approx(
+            expected["ess_fraction"], rel=2e-15
+        )
+    else:
+        assert paths.log_likelihood_ratios is None
+        assert paths.diagnostics["effective_sample_size"] is None
+        assert paths.diagnostics["ess_fraction"] is None
+
+
+def test_odd_path_capture_preserves_singleton_last_random_ordering() -> None:
+    """An unpaired seventh path uses the fourth independent draw and remains last."""
+    paths = _simulate("crypto", TgarchMeasure.P, n_paths=7)
+
+    np.testing.assert_allclose(
+        paths.assets[:, -1, 0],
+        [
+            0.8602685056600672,
+            0.8638368188335316,
+            0.9471816269440217,
+            1.0365692702077187,
+            1.075263429328865,
+            0.9639498770029068,
+            0.8530545753920327,
+        ],
+        rtol=2e-15,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        paths.states["log_spot"][:, -1],
+        [
+            -0.1505107225800212,
+            -0.1463713951065363,
+            -0.05426441227023124,
+            0.03591648154119099,
+            0.07256568209812608,
+            -0.03671598053363115,
+            -0.15893175300719192,
+        ],
+        rtol=2e-15,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        paths.states["sigma"][:, -1],
+        [
+            0.5182583435715801,
+            0.5395749801274664,
+            0.6507130760607134,
+            0.6541550576094471,
+            0.8527595600461183,
+            0.6715673872914589,
+            0.44654185118227663,
+        ],
+        rtol=2e-15,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        paths.log_likelihood_ratios,
+        [
+            -0.04262308533848233,
+            -0.04651705678378504,
+            -0.02756656451697437,
+            -0.16245111496375653,
+            -0.17736181249716082,
+            -0.01977010397910056,
+            0.11932231387408981,
+        ],
+        rtol=2e-15,
+        atol=0.0,
+    )
+
+
+def test_floor_capture_preserves_post_update_floor_and_hit_count() -> None:
+    """A one-step legacy fixture applies the floor after returns and counts both hits."""
+    params = TgarchParams(
+        theta=0.2,
+        kappa1=1.0,
+        kappa2=0.0,
+        beta=0.0,
+        eps=5.0,
+        sigma0=0.05,
+    )
+    paths = TgarchModel(params).simulate_paths(
+        measure=TgarchMeasure.P,
+        maturity=0.25,
+        max_dt=0.25,
+        n_paths=4,
+        seed=1,
+    )
+
+    np.testing.assert_allclose(
+        paths.assets[:, -1, 0],
+        [1.0083618715739915, 1.0204339250905095, 0.9910878459851447, 0.9793629657923952],
+        rtol=2e-15,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        paths.states["log_spot"][:, -1],
+        [
+            0.008327104801619651,
+            0.02022795358752896,
+            -0.008952104801619652,
+            -0.02085295358752896,
+        ],
+        rtol=2e-15,
+        atol=0.0,
+    )
+    np.testing.assert_array_equal(
+        paths.states["sigma"][:, -1],
+        [1.0e-6, 0.09242144537075174, 1.0e-6, 0.09242144537075174],
+    )
+    assert paths.diagnostics["sigma_floor"] == 1.0e-6
+    assert paths.diagnostics["floor_hits"] == 2
+
+
+def test_terminal_model_returns_two_observation_capability_payload() -> None:
+    """The first lift labels state, measures, RNG ordering and realized grid explicitly."""
+    model = TgarchModel(_study_params("crypto"))
+    assert isinstance(model, PathModel)
+
+    paths = _simulate("crypto", TgarchMeasure.P)
+
+    np.testing.assert_array_equal(paths.observation_times, [0.0, 0.25])
+    assert paths.assets.shape == (8, 2, 1)
+    assert paths.asset_ids == ("spot",)
+    np.testing.assert_array_equal(paths.assets[:, 0, 0], 1.0)
+    np.testing.assert_array_equal(paths.states["log_spot"][:, 0], 0.0)
+    np.testing.assert_array_equal(paths.states["sigma"][:, 0], 0.6)
+    assert paths.state_units == {"log_spot": "log price", "sigma": "annualized volatility"}
+    assert paths.sampling_measure == "P"
+    assert paths.target_measure == "Q_EXACT"
+    assert paths.numeraire == "money_market_account"
+    assert paths.scheme == "tgarch_terminal_recursion"
+    assert paths.provenance == {
+        "requested_max_dt": 1.0 / 52.0,
+        "realized_dt": 1.0 / 52.0,
+        "n_steps": 13,
+        "seed": 20260825,
+        "generator": "numpy.random.Generator",
+        "bit_generator": "PCG64",
+        "chunk_steps": 8,
+        "antithetic_layout": "first_half_draws_then_negatives_singleton_last",
+        "source_tag": "tgarch-study-round2-v1",
+        "source_commit": "add76d1909b4223d005e31fcf377845501021362",
+        "legacy_source_sha256": REFERENCE_SOURCE_SHA256,
+        "numpy_version": np.__version__,
+    }
+    assert paths.diagnostics["weight_convention"] == "raw_log_dQ_EXACT_dP"
+    assert paths.diagnostics["low_ess"] is False
+
+
+def test_tgarch_submodule_fresh_import_stays_outside_heavy_pricing_layers() -> None:
+    """The bounded model import loads NumPy and path data, not pricers or optional analytics."""
+    source_root = str(PACKAGE_ROOT.parent)
+    code = f"""
+import sys
+sys.path.insert(0, {source_root!r})
+import stochvolmodels.models.tgarch
+forbidden = ("numba", "pandas", "qis", "scipy", "vanilla_option_pricers")
+loaded = sorted(
+    root
+    for root in forbidden
+    if any(name == root or name.startswith(root + ".") for name in sys.modules)
+)
+assert not loaded, loaded
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_tgarch_types_remain_submodule_only() -> None:
+    """The bounded lift does not widen either provisional capabilities or the root API."""
+    assert "TgarchModel" not in stochvolmodels.__all__
+    assert not hasattr(stochvolmodels, "TgarchModel")
+    assert not hasattr(model_capabilities, "TgarchModel")
+    model = TgarchModel(_study_params("equity"))
+    assert isinstance(model, PathModel)
+    assert not isinstance(model, TransformModel)
+    assert not isinstance(model, TerminalDistributionModel)
+    assert not isinstance(model, TerminalSmileModel)
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"theta": 0.0}, "theta"),
+        ({"kappa1": np.inf}, "kappa1"),
+        ({"kappa2": -1.0}, "kappa2"),
+        ({"beta": np.nan}, "beta"),
+        ({"eps": True}, "eps"),
+        ({"sigma0": 0.0}, "sigma0"),
+        ({"spot0": -1.0}, "spot0"),
+    ],
+)
+def test_tgarch_parameter_validation(changes: dict[str, object], message: str) -> None:
+    """Representative bool, non-finite and non-positive parameters fail at construction."""
+    with pytest.raises(ValueError, match=message):
+        replace(_study_params("equity"), **changes)
+
+
+def test_model_measure_and_limit_payload_validation() -> None:
+    """Model ownership, measure labels and limit payloads reject invented inputs."""
+    with pytest.raises(ValueError, match="TgarchParams"):
+        TgarchModel(object())  # type: ignore[arg-type]
+
+    request = {
+        "maturity": 0.25,
+        "max_dt": 1.0 / 52.0,
+        "n_paths": 8,
+        "seed": 20260825,
+    }
+    model = TgarchModel(_study_params("equity"))
+    with pytest.raises(ValueError, match="measure must be one of"):
+        model.simulate_paths(measure="Q", **request)
+    with pytest.raises(ValueError, match="TgarchLimitParams"):
+        model.simulate_paths(
+            measure=TgarchMeasure.Q_LIMIT,
+            limit_params=object(),  # type: ignore[arg-type]
+            **request,
+        )
+
+    invalid_limit_map = replace(
+        _study_params("equity"),
+        beta=-1.0,
+        gamma1=10.0,
+        eta1=0.0,
+    )
+    with pytest.raises(ValueError, match="derived kappa2_hat is negative"):
+        derive_tgarch_limit_params(invalid_limit_map)
+
+
+def test_unweighted_p_paths_keep_the_physical_target_and_no_ratios() -> None:
+    """Physical samples are not relabelled exact Q unless raw ratios are requested."""
+    paths = _simulate("equity", TgarchMeasure.P, track_log_weights=False)
+
+    assert paths.sampling_measure == "P"
+    assert paths.target_measure == "P"
+    assert paths.log_likelihood_ratios is None
+    assert paths.diagnostics["weight_convention"] is None
+
+
+@pytest.mark.parametrize("measure", [TgarchMeasure.Q_EXACT, TgarchMeasure.Q_LIMIT])
+def test_log_weights_are_rejected_outside_physical_sampling(measure: TgarchMeasure) -> None:
+    """The sole lifted density ratio is raw exact-Q over P on P-sampled paths."""
+    with pytest.raises(ValueError, match="only be accumulated on P"):
+        _simulate("equity", measure, track_log_weights=True)
+
+
+def test_zero_kernel_measures_have_identical_terminal_laws() -> None:
+    """P, exact Q and limit Q agree pathwise when both pricing-kernel loadings vanish."""
+    params = replace(
+        _study_params("crypto"),
+        gamma0=0.0,
+        gamma1=0.0,
+        eta0=0.0,
+        eta1=0.0,
+    )
+    model = TgarchModel(params)
+    kwargs = {
+        "maturity": 0.25,
+        "max_dt": 1.0 / 52.0,
+        "n_paths": 128,
+        "seed": 20260826,
+        "chunk_steps": 3,
+    }
+    paths = {measure: model.simulate_paths(measure=measure, **kwargs) for measure in TgarchMeasure}
+    reference = paths[TgarchMeasure.P]
+
+    for measure in (TgarchMeasure.Q_EXACT, TgarchMeasure.Q_LIMIT):
+        np.testing.assert_allclose(paths[measure].assets, reference.assets, rtol=2e-11, atol=2e-11)
+        np.testing.assert_allclose(
+            paths[measure].states["log_spot"],
+            reference.states["log_spot"],
+            rtol=2e-11,
+            atol=2e-11,
+        )
+        np.testing.assert_allclose(
+            paths[measure].states["sigma"],
+            reference.states["sigma"],
+            rtol=2e-11,
+            atol=2e-11,
+        )
+        assert paths[measure].diagnostics["floor_hits"] == reference.diagnostics["floor_hits"]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("parameter_name", ["crypto", "equity"])
+def test_exact_q_discounted_spot_is_a_three_se_martingale(parameter_name: str) -> None:
+    """The exact Gaussian variance compensator preserves the discounted-spot martingale."""
+    paths = _simulate(
+        parameter_name,
+        TgarchMeasure.Q_EXACT,
+        n_paths=65_536,
+        seed=20260827,
+    )
+    params = _study_params(parameter_name)
+    discounted_spot = paths.assets[:, -1, 0] * math.exp(-params.r * 0.25)
+    error = float(np.mean(discounted_spot) - params.spot0)
+    standard_error = _paired_standard_error(discounted_spot)
+
+    assert abs(error) <= 3.0 * standard_error + 2.0e-13 * params.spot0
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("parameter_name", ["crypto", "equity"])
+def test_raw_weighted_p_and_direct_exact_q_prices_agree_within_three_se(
+    parameter_name: str,
+) -> None:
+    """An ATM call reproduces the companion study's paired direct-Q/weighted-P gate."""
+    p_paths = _simulate(
+        parameter_name,
+        TgarchMeasure.P,
+        n_paths=65_536,
+        seed=20260825,
+    )
+    q_paths = _simulate(
+        parameter_name,
+        TgarchMeasure.Q_EXACT,
+        n_paths=65_536,
+        seed=20260825,
+    )
+    params = _study_params(parameter_name)
+    discount = math.exp(-params.r * 0.25)
+    likelihood_ratios = _stable_raw_weights(p_paths.log_likelihood_ratios)
+    weighted_p_pairs = _controlled_call_pair_values(
+        p_paths.assets[:, -1, 0],
+        strike=params.spot0,
+        discount=discount,
+        expected_discounted_spot=params.spot0,
+        weights=likelihood_ratios,
+    )
+    direct_q_pairs = _controlled_call_pair_values(
+        q_paths.assets[:, -1, 0],
+        strike=params.spot0,
+        discount=discount,
+        expected_discounted_spot=params.spot0,
+    )
+    differences = direct_q_pairs - weighted_p_pairs
+    error = float(np.mean(differences))
+    standard_error = float(np.std(differences, ddof=1) / math.sqrt(differences.size))
+
+    assert abs(error) <= 3.0 * standard_error + 2.0e-13 * params.spot0
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"maturity": 0.0}, "maturity"),
+        ({"max_dt": 0.0}, "max_dt"),
+        ({"n_paths": True}, "n_paths"),
+        ({"seed": -1}, "seed"),
+        ({"chunk_steps": 0}, "chunk_steps"),
+    ],
+)
+def test_terminal_request_validation(changes: dict[str, object], message: str) -> None:
+    """Grid, path count, seed and chunking reject ambiguous or inadmissible values."""
+    kwargs = {
+        "measure": TgarchMeasure.P,
+        "maturity": 0.25,
+        "max_dt": 1.0 / 52.0,
+        "n_paths": 8,
+        "seed": 20260825,
+        "chunk_steps": 8,
+    }
+    kwargs.update(changes)
+
+    with pytest.raises(ValueError, match=message):
+        TgarchModel(_study_params("equity")).simulate_paths(**kwargs)
+
+
+def test_exact_q_rejects_an_inadmissible_variance_kernel() -> None:
+    """The finite-step Gaussian law requires positive conditional variance pathwise."""
+    params = replace(_study_params("equity"), eta0=4.0, eta1=0.0)
+
+    with pytest.raises(ValueError, match="exact-Q kernel is inadmissible"):
+        TgarchModel(params).simulate_paths(
+            measure=TgarchMeasure.Q_EXACT,
+            maturity=0.25,
+            max_dt=1.0 / 52.0,
+            n_paths=8,
+            seed=20260825,
+        )


### PR DESCRIPTION
## Summary

- add a distinct discrete TGARCH terminal path model; it is not a `LogSVPricer` scheme
- expose physical, exact finite-step pricing, and limit-pricing sampling laws
- preserve the companion study's PCG64/antithetic ordering, including odd-path and chunk contracts
- provide raw `log(dQ_EXACT/dP)` ratios on physical samples plus ESS, floor, overflow, grid, RNG, and source provenance
- return the provisional zero-copy `ModelPaths` payload without widening the package-root API

## Numerical evidence

- authoritative source: tag `tgarch-study-round2-v1`, commit `add76d1909b4223d005e31fcf377845501021362`
- source SHA-256: `4a07de7c20591276a9f241b1c18b96e2f2c3fd1b953e29375ab5096b3fb35f38`
- frozen pre-lift arrays cover both study calibrations, `P` / `Q_EXACT` / `Q_LIMIT`, chunk sizes 8 and 3, raw likelihood ratios, odd path counts, and a two-floor-hit fixture
- removing the exact-Q variance compensator fails the crypto martingale gate (`0.00437536` error versus `0.00221148` three-SE bound)
- reversing the likelihood ratio fails the frozen ratios and both direct-Q versus weighted-P price comparisons

## Verification

- OCA: public `option-chain-analytics==5.2.0`
- focused TGARCH source suite: 39 passed
- full fast source suite: 405 passed; one pre-existing OHLC warning
- full slow numerical suite: 6 passed
- critical Ruff, full targeted Ruff, and Python 3.10 target gate: passed
- wheel manifest: PASS, 93 files and 28 test modules
- installed-wheel TGARCH suite outside the checkout: 39 passed, 372 deselected
- wheel SHA-256: `82C3669FAA98F96B70A7EBDE68E1F70165E11349883AEEC342E3EAE3B2B5129F`

## Scope

This is the approved bounded terminal lift. It does not add a transform or terminal-distribution interface, does not root-export TGARCH, and does not change existing pricer numerics.
