### PR TITLE
Add path products and valuation boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Entries start at 1.2.0. For earlier releases see the git log.
   continuous LogSV simulation under money-market-account and inverse measures, returning raw
   zero-drift price, volatility, and quadratic-variation paths through the unchanged legacy
   simulation kernel.
+- `stochvolmodels.products.payoffs` and `stochvolmodels.valuation` add explicit European and
+  integrated-variance path payoffs, raw and self-normalized likelihood-ratio valuation, optional
+  legacy additive forward recentering, independent-group standard errors, and ESS diagnostics.
 
 ## [2.3.0] - 2026-08-24
 

--- a/scripts/check_wheel_contents.py
+++ b/scripts/check_wheel_contents.py
@@ -49,6 +49,8 @@ def check_wheel(wheel_path: Path) -> None:
         "stochvolmodels/models/logsv.py",
         "stochvolmodels/models/tgarch.py",
         "stochvolmodels/products/__init__.py",
+        "stochvolmodels/products/payoffs.py",
+        "stochvolmodels/valuation.py",
     }
     missing_runtime_files = required_runtime_files.difference(members)
     assert not missing_runtime_files, (
@@ -59,8 +61,8 @@ def check_wheel(wheel_path: Path) -> None:
         for member in members
         if member.startswith("stochvolmodels/tests/test_") and member.endswith(".py")
     }
-    assert len(test_modules) == 29, (
-        f"expected exactly 29 automated test modules, found {len(test_modules)}"
+    assert len(test_modules) == 30, (
+        f"expected exactly 30 automated test modules, found {len(test_modules)}"
     )
     assert not any(member.endswith("_test.py") for member in members), (
         "automated tests must use the test_*.py form"

--- a/src/stochvolmodels/products/payoffs.py
+++ b/src/stochvolmodels/products/payoffs.py
@@ -1,0 +1,330 @@
+"""Concrete pathwise payoffs for European and variance options."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from numbers import Real
+
+import numpy as np
+from numpy.typing import NDArray
+
+from stochvolmodels.data.model_paths import ModelPaths
+from stochvolmodels.utils.config import OptionType
+
+__all__ = (
+    "EuropeanOptionPayoff",
+    "IntegratedVarianceOptionPayoff",
+    "VarianceQuote",
+)
+
+FloatArray = NDArray[np.float64]
+_INTEGRATED_VARIANCE_UNIT = "integrated variance"
+
+
+class VarianceQuote(str, Enum):
+    """Quote convention for an integrated-variance option underlying."""
+
+    INTEGRATED = "integrated"
+    ANNUALIZED = "annualized"
+
+
+def _validated_label(value: object, name: str) -> str:
+    """Require a non-empty string without surrounding whitespace."""
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    if not value or value != value.strip():
+        raise ValueError(f"{name} must be non-empty and trimmed")
+    return value
+
+
+def _finite_float(value: object, name: str) -> float:
+    """Return a finite real scalar while rejecting booleans."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite real number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    return result
+
+
+def _positive_float(value: object, name: str) -> float:
+    """Return a strictly positive finite scalar."""
+    result = _finite_float(value, name)
+    if result <= 0.0:
+        raise ValueError(f"{name} must be strictly positive, got {result}")
+    return result
+
+
+def _nonnegative_float(value: object, name: str) -> float:
+    """Return a non-negative finite scalar."""
+    result = _finite_float(value, name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {result}")
+    return result
+
+
+def _as_option_type(value: OptionType | str) -> OptionType:
+    """Canonicalize a standard call or put code."""
+    try:
+        option_type = OptionType(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"option_type must be C or P, got {value!r}") from exc
+    if option_type not in (OptionType.CALL, OptionType.PUT):
+        raise ValueError(f"option_type must be C or P, got {value!r}")
+    return option_type
+
+
+def _as_variance_quote(value: VarianceQuote | str) -> VarianceQuote:
+    """Canonicalize an explicit integrated-variance quote convention."""
+    try:
+        return VarianceQuote(value)
+    except (TypeError, ValueError) as exc:
+        allowed = ", ".join(item.value for item in VarianceQuote)
+        raise ValueError(f"quote must be one of {{{allowed}}}, got {value!r}") from exc
+
+
+def _require_model_paths(paths: object) -> ModelPaths:
+    """Require the canonical path payload rather than an implicit duck type."""
+    if not isinstance(paths, ModelPaths):
+        raise TypeError("paths must be a ModelPaths instance")
+    return paths
+
+
+def _observation_index(paths: ModelPaths, expiry: float) -> int:
+    """Return the unique observation index matching expiry exactly."""
+    matches = np.flatnonzero(paths.observation_times == expiry)
+    if matches.size != 1:
+        raise ValueError(f"expiry {expiry} must match exactly one observation time")
+    return int(matches[0])
+
+
+def _validated_vector(values: object, *, name: str, n_paths: int) -> FloatArray:
+    """Copy a finite real path vector into a float64 array."""
+    if not isinstance(values, np.ndarray):
+        raise TypeError(f"{name} must be a NumPy array")
+    if values.dtype.kind not in "iuf":
+        raise TypeError(f"{name} must have a real numeric dtype")
+    if values.ndim != 1 or values.shape != (n_paths,):
+        raise ValueError(f"{name} must have shape ({n_paths},)")
+    if not np.all(np.isfinite(values)):
+        raise ValueError(f"{name} must contain only finite values")
+    result = np.array(values, dtype=np.float64, copy=True)
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} cannot be represented as finite float64 values")
+    return result
+
+
+def _vanilla_payoff(
+    underlying: FloatArray,
+    *,
+    strike: float,
+    option_type: OptionType,
+) -> FloatArray:
+    """Return a new read-only standard call or put payoff vector."""
+    if not np.all(np.isfinite(underlying)):
+        raise ValueError("option underlying must contain only finite values")
+    with np.errstate(over="ignore", invalid="ignore"):
+        if option_type is OptionType.CALL:
+            result = np.maximum(underlying - strike, 0.0)
+        else:
+            result = np.maximum(strike - underlying, 0.0)
+    result = np.asarray(result, dtype=np.float64)
+    if not np.all(np.isfinite(result)):
+        raise FloatingPointError("option payoff cannot be represented as finite float64 values")
+    result.setflags(write=False)
+    return result
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class EuropeanOptionPayoff:
+    """Standard European call or put on one explicitly selected path asset.
+
+    Parameters
+    ----------
+    asset_id
+        Identifier on the explicit asset axis of :class:`ModelPaths`.
+    expiry
+        Positive observation time in years. It must occur exactly on the path grid.
+    strike
+        Non-negative strike in the selected asset's units.
+    option_type
+        Standard call (``C``) or put (``P``). Inverse option codes are rejected.
+    unit
+        Explicit common payoff and settlement unit.
+    """
+
+    asset_id: str
+    expiry: float
+    strike: float
+    option_type: OptionType | str
+    unit: str
+
+    def __post_init__(self) -> None:
+        """Validate and canonicalize the product definition."""
+        object.__setattr__(self, "asset_id", _validated_label(self.asset_id, "asset_id"))
+        object.__setattr__(self, "expiry", _positive_float(self.expiry, "expiry"))
+        object.__setattr__(self, "strike", _nonnegative_float(self.strike, "strike"))
+        object.__setattr__(self, "option_type", _as_option_type(self.option_type))
+        object.__setattr__(self, "unit", _validated_label(self.unit, "unit"))
+
+    @property
+    def required_asset_ids(self) -> tuple[str, ...]:
+        """Return the single path asset required by this payoff."""
+        return (self.asset_id,)
+
+    @property
+    def payoff_unit(self) -> str:
+        """Return the unit of the unconverted payoff values."""
+        return self.unit
+
+    @property
+    def settlement_unit(self) -> str:
+        """Return the settlement unit, identical to the payoff unit in D2."""
+        return self.unit
+
+    def _payoff_from_asset_values(
+        self,
+        values: np.ndarray,
+        *,
+        n_paths: int | None = None,
+    ) -> FloatArray:
+        """Evaluate finite terminal values supplied by the valuation compatibility policy."""
+        if not isinstance(values, np.ndarray):
+            raise TypeError("asset values must be a NumPy array")
+        expected_paths = values.shape[0] if n_paths is None and values.ndim == 1 else n_paths
+        if expected_paths is None:
+            raise ValueError("asset values must be one-dimensional")
+        underlying = _validated_vector(
+            values,
+            name="selected terminal asset values",
+            n_paths=expected_paths,
+        )
+        return _vanilla_payoff(
+            underlying,
+            strike=self.strike,
+            option_type=self.option_type,
+        )
+
+    def __call__(self, paths: ModelPaths) -> FloatArray:
+        """Evaluate the payoff on the selected asset and exact expiry."""
+        path_values = _require_model_paths(paths)
+        asset_indices = [
+            index
+            for index, asset_id in enumerate(path_values.asset_ids)
+            if asset_id == self.asset_id
+        ]
+        if len(asset_indices) != 1:
+            raise ValueError(f"asset_id {self.asset_id!r} must occur exactly once in paths")
+        time_index = _observation_index(path_values, self.expiry)
+        selected = path_values.assets[:, time_index, asset_indices[0]]
+        return self._payoff_from_asset_values(selected, n_paths=path_values.assets.shape[0])
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class IntegratedVarianceOptionPayoff:
+    """Call or put on an integrated or annualized variance increment.
+
+    Parameters
+    ----------
+    state_name
+        Name of a scalar cumulative state whose unit is exactly ``integrated variance``.
+    expiry
+        Positive observation time in years. It must occur exactly on the path grid.
+    strike
+        Non-negative strike in the selected quote convention.
+    option_type
+        Standard call (``C``) or put (``P``). Inverse option codes are rejected.
+    quote
+        Whether the underlying is the raw integrated increment or that increment divided by
+        expiry.
+    unit
+        Explicit common payoff and settlement unit.
+    """
+
+    state_name: str
+    expiry: float
+    strike: float
+    option_type: OptionType | str
+    quote: VarianceQuote | str
+    unit: str
+
+    def __post_init__(self) -> None:
+        """Validate and canonicalize the product definition."""
+        object.__setattr__(
+            self,
+            "state_name",
+            _validated_label(self.state_name, "state_name"),
+        )
+        object.__setattr__(self, "expiry", _positive_float(self.expiry, "expiry"))
+        object.__setattr__(self, "strike", _nonnegative_float(self.strike, "strike"))
+        object.__setattr__(self, "option_type", _as_option_type(self.option_type))
+        object.__setattr__(self, "quote", _as_variance_quote(self.quote))
+        object.__setattr__(self, "unit", _validated_label(self.unit, "unit"))
+
+    @property
+    def required_asset_ids(self) -> tuple[str, ...]:
+        """Return no asset requirements because this payoff consumes a named state."""
+        return ()
+
+    @property
+    def payoff_unit(self) -> str:
+        """Return the unit of the unconverted payoff values."""
+        return self.unit
+
+    @property
+    def settlement_unit(self) -> str:
+        """Return the settlement unit, identical to the payoff unit in D2."""
+        return self.unit
+
+    def __call__(self, paths: ModelPaths) -> FloatArray:
+        """Evaluate the payoff on the selected cumulative variance state."""
+        path_values = _require_model_paths(paths)
+        if self.state_name not in path_values.states:
+            raise ValueError(f"state {self.state_name!r} is not present in paths")
+
+        state = path_values.states[self.state_name]
+        if state.ndim != 2:
+            raise ValueError(
+                f"state {self.state_name!r} must be scalar with shape (n_paths, n_times)"
+            )
+        state_unit = path_values.state_units[self.state_name]
+        if state_unit != _INTEGRATED_VARIANCE_UNIT:
+            raise ValueError(
+                f"state {self.state_name!r} must have unit {_INTEGRATED_VARIANCE_UNIT!r}"
+            )
+
+        time_index = _observation_index(path_values, self.expiry)
+        n_paths = path_values.assets.shape[0]
+        state_interval = state[:, : time_index + 1]
+        if not np.all(np.isfinite(state_interval)):
+            raise ValueError("integrated variance state must contain only finite values to expiry")
+        if np.any(state_interval < 0.0):
+            raise ValueError("integrated variance state must be non-negative to expiry")
+        if np.any(np.diff(state_interval, axis=1) < 0.0):
+            raise ValueError("integrated variance state must be non-decreasing to expiry")
+        initial = _validated_vector(
+            state[:, 0],
+            name=f"states[{self.state_name!r}] at time zero",
+            n_paths=n_paths,
+        )
+        terminal = _validated_vector(
+            state[:, time_index],
+            name=f"states[{self.state_name!r}] at expiry",
+            n_paths=n_paths,
+        )
+        variance_increment = terminal - initial
+        if not np.all(np.isfinite(variance_increment)):
+            raise ValueError("integrated variance increments must contain only finite values")
+        if np.any(variance_increment < 0.0):
+            raise ValueError("integrated variance increments must be non-negative")
+        if self.quote is VarianceQuote.ANNUALIZED:
+            with np.errstate(over="ignore", invalid="ignore"):
+                variance_increment = variance_increment / self.expiry
+
+        return _vanilla_payoff(
+            variance_increment,
+            strike=self.strike,
+            option_type=self.option_type,
+        )

--- a/src/stochvolmodels/tests/test_path_valuation.py
+++ b/src/stochvolmodels/tests/test_path_valuation.py
@@ -1,0 +1,862 @@
+"""Contracts for pathwise products and discounted path valuation."""
+
+from __future__ import annotations
+
+import math
+import subprocess
+import sys
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import stochvolmodels
+from stochvolmodels.data.model_paths import ModelPaths
+from stochvolmodels.products import Payoff
+from stochvolmodels.products.payoffs import (
+    EuropeanOptionPayoff,
+    IntegratedVarianceOptionPayoff,
+    VarianceQuote,
+)
+from stochvolmodels.utils.config import OptionType
+from stochvolmodels.utils.mc_payoffs import compute_mc_vars_payoff
+from stochvolmodels.valuation import (
+    LegacyAdditiveForwardRecenter,
+    PathEstimator,
+    RecenterMean,
+    value_paths,
+    value_paths_self_normalized,
+)
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _FixedPayoff:
+    """Return caller-supplied values through the structural payoff protocol."""
+
+    required_asset_ids: tuple[str, ...] = ()
+    expiry = 1.0
+
+    def __init__(
+        self,
+        values: object,
+        *,
+        payoff_unit: str = "USD",
+        settlement_unit: str = "USD",
+    ) -> None:
+        self.values = values
+        self.payoff_unit = payoff_unit
+        self.settlement_unit = settlement_unit
+
+    def __call__(self, paths: ModelPaths) -> object:
+        del paths
+        return self.values
+
+
+def _paths(
+    terminal_values: np.ndarray | list[float],
+    *,
+    observation_times: np.ndarray | None = None,
+    sampling_measure: str = "Q",
+    target_measure: str | None = None,
+    numeraire: str = "money_market_account",
+    log_likelihood_ratios: np.ndarray | None = None,
+    states: dict[str, np.ndarray] | None = None,
+    state_units: dict[str, str] | None = None,
+) -> ModelPaths:
+    """Build a minimal, fully declared path payload for deterministic tests."""
+    terminal = np.asarray(terminal_values, dtype=float)
+    times = np.array([0.0, 1.0]) if observation_times is None else observation_times
+    assets = np.ones((terminal.size, times.size, 1))
+    assets[:, -1, 0] = terminal
+    return ModelPaths(
+        observation_times=times,
+        assets=assets,
+        asset_ids=("asset",),
+        sampling_measure=sampling_measure,
+        target_measure=sampling_measure if target_measure is None else target_measure,
+        numeraire=numeraire,
+        scheme="deterministic_test_fixture",
+        states={} if states is None else states,
+        state_units={} if state_units is None else state_units,
+        log_likelihood_ratios=log_likelihood_ratios,
+    )
+
+
+def _call(*, expiry: float = 1.0, strike: float = 0.0) -> EuropeanOptionPayoff:
+    """Return the standard asset call used by estimator tests."""
+    return EuropeanOptionPayoff(
+        asset_id="asset",
+        expiry=expiry,
+        strike=strike,
+        option_type=OptionType.CALL,
+        unit="USD",
+    )
+
+
+def test_european_payoffs_are_explicit_structural_read_only_products() -> None:
+    """Select one asset and expiry while preserving C/P payoff identities and units."""
+    paths = _paths([0.5, 1.5, 3.0])
+    call = _call(strike=1.0)
+    put = EuropeanOptionPayoff(
+        asset_id="asset",
+        expiry=1.0,
+        strike=1.0,
+        option_type="P",
+        unit="USD",
+    )
+
+    call_values = call(paths)
+    put_values = put(paths)
+    assert isinstance(call, Payoff)
+    assert isinstance(put, Payoff)
+    assert call.required_asset_ids == put.required_asset_ids == ("asset",)
+    assert call.payoff_unit == call.settlement_unit == "USD"
+    assert call.option_type is OptionType.CALL
+    assert put.option_type is OptionType.PUT
+    np.testing.assert_array_equal(call_values, [0.0, 0.5, 2.0])
+    np.testing.assert_array_equal(put_values, [0.5, 0.0, 0.0])
+    np.testing.assert_array_equal(call_values - put_values, paths.assets[:, -1, 0] - 1.0)
+    assert call_values.dtype == np.float64
+    assert not call_values.flags.writeable
+    with pytest.raises(ValueError):
+        call_values[0] = 99.0
+    with pytest.raises(FrozenInstanceError):
+        call.strike = 2.0  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"asset_id": " asset"},
+        {"unit": ""},
+        {"expiry": 0.0},
+        {"expiry": np.inf},
+        {"expiry": True},
+        {"expiry": "1.0"},
+        {"strike": -0.1},
+        {"strike": np.nan},
+        {"strike": False},
+        {"option_type": "IC"},
+        {"option_type": OptionType.INVERSE_PUT},
+        {"option_type": "X"},
+    ],
+)
+def test_european_constructor_rejects_ambiguous_or_unsupported_inputs(
+    changes: dict[str, object],
+) -> None:
+    """Only finite, standard C/P products with explicit trimmed labels are admitted."""
+    request: dict[str, object] = {
+        "asset_id": "asset",
+        "expiry": 1.0,
+        "strike": 1.0,
+        "option_type": "C",
+        "unit": "USD",
+    }
+    request.update(changes)
+    with pytest.raises((TypeError, ValueError)):
+        EuropeanOptionPayoff(**request)  # type: ignore[arg-type]
+
+
+def test_european_evaluation_rejects_missing_expiry_asset_and_failed_paths() -> None:
+    """Path selection is exact and never silently omits an invalid terminal row."""
+    with pytest.raises(ValueError, match="expiry"):
+        _call(expiry=0.5)(_paths([1.0, 2.0]))
+    missing_asset = _paths([1.0, 2.0])
+    missing_asset.asset_ids = ("other",)
+    with pytest.raises(ValueError, match="asset"):
+        _call()(missing_asset)
+    with pytest.raises(ValueError, match="finite"):
+        _call()(_paths([1.0, np.nan]))
+
+
+def test_variance_payoffs_subtract_initial_state_and_annualize_exactly_once() -> None:
+    """Integrated and annualized strikes consume the cumulative-state increment."""
+    times = np.array([0.0, 0.5])
+    qvar = np.array([[0.1, 0.3], [0.2, 0.7], [1.0, 1.2]])
+    paths = _paths(
+        [1.0, 1.0, 1.0],
+        observation_times=times,
+        states={"qvar": qvar},
+        state_units={"qvar": "integrated variance"},
+    )
+    integrated = IntegratedVarianceOptionPayoff(
+        state_name="qvar",
+        expiry=0.5,
+        strike=0.15,
+        option_type="C",
+        quote=VarianceQuote.INTEGRATED,
+        unit="variance-years",
+    )
+    annualized = IntegratedVarianceOptionPayoff(
+        state_name="qvar",
+        expiry=0.5,
+        strike=0.3,
+        option_type=OptionType.CALL,
+        quote="annualized",
+        unit="variance",
+    )
+    integrated_put = IntegratedVarianceOptionPayoff(
+        state_name="qvar",
+        expiry=0.5,
+        strike=0.15,
+        option_type="P",
+        quote=VarianceQuote.INTEGRATED,
+        unit="variance-years",
+    )
+
+    assert isinstance(integrated, Payoff)
+    assert integrated.required_asset_ids == annualized.required_asset_ids == ()
+    assert integrated.quote is VarianceQuote.INTEGRATED
+    assert annualized.quote is VarianceQuote.ANNUALIZED
+    np.testing.assert_allclose(integrated(paths), [0.05, 0.35, 0.05], rtol=0.0, atol=1e-15)
+    np.testing.assert_allclose(annualized(paths), [0.1, 0.7, 0.1], rtol=0.0, atol=1e-15)
+    np.testing.assert_allclose(
+        integrated(paths) - integrated_put(paths),
+        qvar[:, -1] - qvar[:, 0] - 0.15,
+        rtol=0.0,
+        atol=1e-15,
+    )
+    assert not annualized(paths).flags.writeable
+
+
+def test_variance_payoff_enforces_state_shape_unit_increment_and_quote() -> None:
+    """A variance option cannot infer a state convention from its name or shape."""
+    request = {
+        "state_name": "qvar",
+        "expiry": 1.0,
+        "strike": 0.0,
+        "option_type": "C",
+        "quote": VarianceQuote.INTEGRATED,
+        "unit": "variance-years",
+    }
+    with pytest.raises((TypeError, ValueError), match="quote"):
+        IntegratedVarianceOptionPayoff(**{**request, "quote": "per_day"})
+    for changes in (
+        {"state_name": " qvar"},
+        {"expiry": 0.0},
+        {"strike": -1.0},
+        {"option_type": "IC"},
+        {"unit": ""},
+    ):
+        with pytest.raises((TypeError, ValueError)):
+            IntegratedVarianceOptionPayoff(**{**request, **changes})
+
+    missing = _paths([1.0, 1.0])
+    with pytest.raises(ValueError, match="state"):
+        IntegratedVarianceOptionPayoff(**request)(missing)
+
+    wrong_unit = _paths(
+        [1.0, 1.0],
+        states={"qvar": np.array([[0.0, 0.2], [0.0, 0.3]])},
+        state_units={"qvar": "annualized variance"},
+    )
+    with pytest.raises(ValueError, match="integrated variance"):
+        IntegratedVarianceOptionPayoff(**request)(wrong_unit)
+
+    vector_state = _paths(
+        [1.0, 1.0],
+        states={"qvar": np.zeros((2, 2, 1))},
+        state_units={"qvar": "integrated variance"},
+    )
+    with pytest.raises(ValueError, match="scalar"):
+        IntegratedVarianceOptionPayoff(**request)(vector_state)
+
+    decreasing = _paths(
+        [1.0, 1.0],
+        states={"qvar": np.array([[0.2, 0.1], [0.0, 0.3]])},
+        state_units={"qvar": "integrated variance"},
+    )
+    with pytest.raises(ValueError, match="non-decreasing"):
+        IntegratedVarianceOptionPayoff(**request)(decreasing)
+
+    times = np.array([0.0, 0.5, 1.0])
+    for invalid_state in (
+        np.array([[0.0, np.nan, 0.3], [0.0, 0.1, 0.2]]),
+        np.array([[0.0, 0.3, 0.2], [0.0, 0.1, 0.2]]),
+        np.array([[-0.1, 0.0, 0.2], [0.0, 0.1, 0.2]]),
+    ):
+        invalid_paths = _paths(
+            [1.0, 1.0],
+            observation_times=times,
+            states={"qvar": invalid_state},
+            state_units={"qvar": "integrated variance"},
+        )
+        with pytest.raises(ValueError, match="integrated variance"):
+            IntegratedVarianceOptionPayoff(**request)(invalid_paths)
+
+
+def test_payoff_arithmetic_overflow_is_rejected() -> None:
+    """Finite inputs cannot escape a public payoff as infinite float64 values."""
+    maximum = np.finfo(np.float64).max
+    put = EuropeanOptionPayoff(
+        asset_id="asset",
+        expiry=1.0,
+        strike=maximum,
+        option_type="P",
+        unit="USD",
+    )
+    with pytest.raises(FloatingPointError, match="finite"):
+        put(_paths([-maximum, 1.0]))
+
+    expiry = float(np.nextafter(0.0, 1.0))
+    variance_paths = _paths(
+        [1.0, 1.0],
+        observation_times=np.array([0.0, expiry]),
+        states={"qvar": np.array([[0.0, maximum], [0.0, 1.0]])},
+        state_units={"qvar": "integrated variance"},
+    )
+    annualized = IntegratedVarianceOptionPayoff(
+        state_name="qvar",
+        expiry=expiry,
+        strike=0.0,
+        option_type="C",
+        quote=VarianceQuote.ANNUALIZED,
+        unit="variance",
+    )
+    with pytest.raises(ValueError, match="finite"):
+        annualized(variance_paths)
+
+
+def test_hand_computed_direct_raw_and_self_normalized_estimators() -> None:
+    """Fix point estimates, modern standard errors and ESS without model numerics."""
+    values = np.array([1.0, 2.0, 4.0])
+    direct = value_paths(paths=_paths(values), payoff=_call())
+    log_weights = np.log(np.array([0.5, 1.0, 2.0]))
+    weighted_paths = _paths(
+        values,
+        sampling_measure="P",
+        target_measure="Q",
+        log_likelihood_ratios=log_weights,
+    )
+    raw = value_paths(paths=weighted_paths, payoff=_call())
+    normalized = value_paths_self_normalized(paths=weighted_paths, payoff=_call())
+
+    assert direct.estimator is PathEstimator.MONTE_CARLO
+    assert direct.value == pytest.approx(7.0 / 3.0)
+    assert direct.standard_error == pytest.approx(math.sqrt(7.0) / 3.0)
+    assert direct.standard_error_basis == "iid_paths"
+    assert direct.n_paths == direct.n_independent_groups == 3
+    assert direct.group_size == 1
+    assert direct.path_effective_sample_size == 3.0
+    assert direct.group_effective_sample_size == 3.0
+    assert direct.path_ess_fraction == direct.group_ess_fraction == 1.0
+    assert direct.mean_likelihood_ratio is None
+    assert direct.log_mean_likelihood_ratio is None
+    assert direct.recenter_shift is None
+    assert direct.settlement_unit == "USD"
+
+    assert raw.estimator is PathEstimator.RAW_LIKELIHOOD_RATIO
+    assert raw.value == pytest.approx(3.5)
+    assert raw.standard_error == pytest.approx(math.sqrt(21.0) / 2.0)
+    assert normalized.estimator is PathEstimator.SELF_NORMALIZED_LIKELIHOOD_RATIO
+    assert normalized.value == pytest.approx(3.0)
+    assert normalized.standard_error == pytest.approx(6.0 / 7.0)
+    for result in (raw, normalized):
+        assert result.path_effective_sample_size == pytest.approx(7.0 / 3.0)
+        assert result.path_ess_fraction == pytest.approx(7.0 / 9.0)
+        assert result.group_effective_sample_size == pytest.approx(7.0 / 3.0)
+        assert result.group_ess_fraction == pytest.approx(7.0 / 9.0)
+        assert result.mean_likelihood_ratio == pytest.approx(7.0 / 6.0)
+        assert result.log_mean_likelihood_ratio == pytest.approx(math.log(7.0 / 6.0))
+    with pytest.raises(FrozenInstanceError):
+        direct.value = 0.0  # type: ignore[misc]
+
+
+def test_raw_scale_is_preserved_but_ratio_estimator_and_ess_are_scale_free() -> None:
+    """Adding a log-weight constant cannot silently normalize the raw estimator."""
+    values = np.array([1.0, 2.0, 4.0])
+    logs = np.log(np.array([0.5, 1.0, 2.0]))
+    base_paths = _paths(
+        values,
+        sampling_measure="P",
+        target_measure="Q",
+        log_likelihood_ratios=logs,
+    )
+    scaled_paths = _paths(
+        values,
+        sampling_measure="P",
+        target_measure="Q",
+        log_likelihood_ratios=logs + math.log(10.0),
+    )
+    raw = value_paths(paths=base_paths, payoff=_call())
+    raw_scaled = value_paths(paths=scaled_paths, payoff=_call())
+    normalized = value_paths_self_normalized(paths=base_paths, payoff=_call())
+    normalized_scaled = value_paths_self_normalized(paths=scaled_paths, payoff=_call())
+
+    assert raw_scaled.value == pytest.approx(10.0 * raw.value)
+    assert raw_scaled.standard_error == pytest.approx(10.0 * raw.standard_error)
+    assert raw_scaled.mean_likelihood_ratio == pytest.approx(10.0 * raw.mean_likelihood_ratio)
+    assert raw_scaled.log_mean_likelihood_ratio == pytest.approx(
+        raw.log_mean_likelihood_ratio + math.log(10.0)
+    )
+    assert normalized_scaled.value == pytest.approx(normalized.value)
+    assert normalized_scaled.standard_error == pytest.approx(normalized.standard_error)
+    assert normalized_scaled.path_effective_sample_size == pytest.approx(
+        normalized.path_effective_sample_size
+    )
+    assert normalized_scaled.group_effective_sample_size == pytest.approx(
+        normalized.group_effective_sample_size
+    )
+
+
+def test_weighted_payoff_scaling_preserves_finite_extreme_contributions() -> None:
+    """A tiny shifted weight cannot erase a large but finite payoff contribution."""
+    paths = _paths(
+        [0.0, 1.0e300],
+        sampling_measure="P",
+        target_measure="Q",
+        log_likelihood_ratios=np.array([1000.0, 0.0]),
+    )
+    raw = value_paths(paths=paths, payoff=_call())
+    normalized = value_paths_self_normalized(paths=paths, payoff=_call())
+    expected_normalized = math.exp(math.log(1.0e300) - 1000.0)
+
+    assert raw.value == pytest.approx(5.0e299)
+    assert raw.standard_error == pytest.approx(5.0e299)
+    assert normalized.value == pytest.approx(expected_normalized, rel=2e-13)
+    assert normalized.standard_error == pytest.approx(2.0 * expected_normalized, rel=2e-13)
+
+
+def test_zero_weights_are_allowed_but_self_normalized_inference_needs_two_groups() -> None:
+    """Zero-mass paths remain aligned while a one-group ratio SE is rejected."""
+    paths = _paths(
+        [1.0, 2.0, 4.0],
+        sampling_measure="P",
+        target_measure="Q",
+        log_likelihood_ratios=np.array([0.0, -np.inf, 0.0]),
+    )
+    raw = value_paths(paths=paths, payoff=_call())
+    normalized = value_paths_self_normalized(paths=paths, payoff=_call())
+    assert raw.value == pytest.approx(5.0 / 3.0)
+    assert normalized.value == pytest.approx(2.5)
+    assert normalized.path_effective_sample_size == pytest.approx(2.0)
+
+    degenerate = _paths(
+        [1.0, 2.0, 4.0],
+        sampling_measure="P",
+        target_measure="Q",
+        log_likelihood_ratios=np.array([0.0, -np.inf, -np.inf]),
+    )
+    with pytest.raises(ValueError, match="positive.*group"):
+        value_paths_self_normalized(paths=degenerate, payoff=_call())
+
+
+def test_explicit_independent_groups_determine_the_standard_error() -> None:
+    """Antithetic structure comes only from caller IDs, never opaque provenance."""
+    paths = _paths([1.0, 3.0, 3.0, 1.0])
+    ungrouped = value_paths(paths=paths, payoff=_call())
+    grouped = value_paths(
+        paths=paths,
+        payoff=_call(),
+        independent_group_ids=np.array([0, 1, 0, 1]),
+    )
+
+    assert ungrouped.standard_error > 0.0
+    assert grouped.value == 2.0
+    assert grouped.standard_error == 0.0
+    assert grouped.standard_error_basis == "independent_groups"
+    assert grouped.n_paths == 4
+    assert grouped.n_independent_groups == 2
+    assert grouped.group_size == 2
+    assert grouped.path_effective_sample_size == 4.0
+    assert grouped.group_effective_sample_size == 2.0
+
+
+def test_grouped_raw_and_self_normalized_inference_use_group_weight_residuals() -> None:
+    """Fix grouped LR point estimates, ratio influence SE, and both ESS definitions."""
+    paths = _paths(
+        [1.0, 3.0, 2.0, 4.0],
+        sampling_measure="P",
+        target_measure="Q",
+        log_likelihood_ratios=np.log(np.array([1.0, 2.0, 3.0, 4.0])),
+    )
+    group_ids = np.array([0, 1, 0, 1])
+    raw = value_paths(paths=paths, payoff=_call(), independent_group_ids=group_ids)
+    normalized = value_paths_self_normalized(
+        paths=paths,
+        payoff=_call(),
+        independent_group_ids=group_ids,
+    )
+
+    assert raw.value == pytest.approx(7.25)
+    assert raw.standard_error == pytest.approx(3.75)
+    assert normalized.value == pytest.approx(2.9)
+    assert normalized.standard_error == pytest.approx(0.92)
+    assert normalized.path_effective_sample_size == pytest.approx(10.0 / 3.0)
+    assert normalized.group_effective_sample_size == pytest.approx(25.0 / 13.0)
+    assert normalized.n_independent_groups == 2
+    assert normalized.group_size == 2
+
+
+@pytest.mark.parametrize(
+    "group_ids",
+    [
+        [0, 1, 0, 1],
+        np.array([0.0, 1.0, 0.0, 1.0]),
+        np.array([False, True, False, True]),
+        np.array([0, 1]),
+        np.array([[0, 1], [0, 1]]),
+        np.array([0, 0, 0, 0]),
+        np.array([0, 0, 0, 1]),
+    ],
+)
+def test_malformed_independent_groups_are_rejected(group_ids: object) -> None:
+    """Groups must be an equal-size integer partition with at least two members."""
+    with pytest.raises((TypeError, ValueError)):
+        value_paths(
+            paths=_paths([1.0, 3.0, 3.0, 1.0]),
+            payoff=_call(),
+            independent_group_ids=group_ids,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize("option_type", [OptionType.CALL, OptionType.PUT])
+def test_explicit_unweighted_recenter_matches_legacy_additive_values(
+    option_type: OptionType,
+) -> None:
+    """Legacy compatibility shifts the asset before C/P payoff and keeps ddof=1 inference."""
+    forward = 2.0
+    terminal_spots = np.array([1.0, 2.0, 4.0])
+    strike = 1.5
+    discount = 0.9
+    paths = _paths(terminal_spots)
+    payoff = EuropeanOptionPayoff(
+        asset_id="asset",
+        expiry=1.0,
+        strike=strike,
+        option_type=option_type,
+        unit="USD",
+    )
+    recenter = LegacyAdditiveForwardRecenter(
+        target_forward=forward,
+        mean=RecenterMean.UNWEIGHTED,
+    )
+    result = value_paths(
+        paths=paths,
+        payoff=payoff,
+        discount_factor=discount,
+        recenter=recenter,
+    )
+    raw = value_paths(paths=paths, payoff=payoff, discount_factor=discount)
+    legacy_price, legacy_se = compute_mc_vars_payoff.py_func(
+        x0=np.log(terminal_spots / forward),
+        sigma0=np.ones(terminal_spots.size),
+        qvar0=np.zeros(terminal_spots.size),
+        ttm=1.0,
+        forward=forward,
+        strikes_ttm=np.array([strike]),
+        optiontypes_ttm=np.array([option_type.value]),
+        discfactor=discount,
+    )
+    shifted = terminal_spots + forward - np.mean(terminal_spots)
+    if option_type is OptionType.CALL:
+        adjusted_payoff = np.maximum(shifted - strike, 0.0)
+        raw_payoff = np.maximum(terminal_spots - strike, 0.0)
+    else:
+        adjusted_payoff = np.maximum(strike - shifted, 0.0)
+        raw_payoff = np.maximum(strike - terminal_spots, 0.0)
+
+    assert result.value == pytest.approx(legacy_price[0], rel=0.0, abs=1e-15)
+    assert result.value == pytest.approx(discount * np.mean(adjusted_payoff))
+    assert raw.value == pytest.approx(discount * np.mean(raw_payoff))
+    assert result.recenter_shift == pytest.approx(-1.0 / 3.0)
+    assert result.standard_error == pytest.approx(
+        discount * np.std(adjusted_payoff, ddof=1) / math.sqrt(adjusted_payoff.size)
+    )
+    assert result.standard_error != pytest.approx(legacy_se[0])
+    assert result.standard_error_basis == "legacy_conditional_iid_paths"
+
+
+def test_normalized_weighted_recenter_is_explicit_and_self_normalized_only() -> None:
+    """The weighted shift pins the SN asset mean without claiming a raw-LR target."""
+    terminal_spots = np.array([1.0, 2.0, 10.0])
+    logs = np.log(np.array([8.0, 1.0, 1.0]))
+    paths = _paths(
+        terminal_spots,
+        sampling_measure="P",
+        target_measure="Q",
+        log_likelihood_ratios=logs,
+    )
+    recenter = LegacyAdditiveForwardRecenter(
+        target_forward=3.0,
+        mean=RecenterMean.NORMALIZED_LIKELIHOOD_WEIGHTED,
+    )
+    result = value_paths_self_normalized(paths=paths, payoff=_call(), recenter=recenter)
+    scaled_paths = _paths(
+        terminal_spots,
+        sampling_measure="P",
+        target_measure="Q",
+        log_likelihood_ratios=logs + math.log(10.0),
+    )
+    scaled = value_paths_self_normalized(
+        paths=scaled_paths,
+        payoff=_call(),
+        recenter=recenter,
+    )
+
+    assert result.recenter_shift == pytest.approx(1.0)
+    assert result.value == pytest.approx(3.0)
+    assert result.standard_error_basis == "legacy_conditional_iid_paths"
+    assert scaled.recenter_shift == pytest.approx(result.recenter_shift)
+    assert scaled.value == pytest.approx(result.value)
+    assert scaled.standard_error == pytest.approx(result.standard_error)
+    with pytest.raises(ValueError, match="self-normalized"):
+        value_paths(paths=paths, payoff=_call(), recenter=recenter)
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"target_forward": 0.0}, "target_forward"),
+        ({"target_forward": True}, "target_forward"),
+        ({"target_forward": np.inf}, "target_forward"),
+        ({"mean": "weighted"}, "mean"),
+    ],
+)
+def test_legacy_recenter_policy_rejects_invalid_conventions(
+    changes: dict[str, object],
+    message: str,
+) -> None:
+    """Legacy compatibility requires a positive forward and named mean basis."""
+    request: dict[str, object] = {
+        "target_forward": 1.0,
+        "mean": RecenterMean.UNWEIGHTED,
+    }
+    request.update(changes)
+    with pytest.raises(ValueError, match=message):
+        LegacyAdditiveForwardRecenter(**request)  # type: ignore[arg-type]
+
+
+def test_measure_numeraire_weight_payoff_and_recenter_failures_are_explicit() -> None:
+    """Invalid economic declarations fail instead of changing estimators or dropping rows."""
+    payoff = _call()
+    invalid_requests = [
+        (_paths([1.0, 2.0], sampling_measure="P"), payoff, {}),
+        (
+            _paths([1.0, 2.0], sampling_measure="P", target_measure="Q"),
+            payoff,
+            {},
+        ),
+        (
+            _paths(
+                [1.0, 2.0],
+                log_likelihood_ratios=np.zeros(2),
+            ),
+            payoff,
+            {},
+        ),
+        (_paths([1.0, 2.0], numeraire="spot"), payoff, {}),
+        (
+            _paths(
+                [1.0, 2.0],
+                sampling_measure="P",
+                target_measure="Q",
+                log_likelihood_ratios=np.full(2, -np.inf),
+            ),
+            payoff,
+            {},
+        ),
+        (_paths([1.0, 2.0]), _FixedPayoff(np.array([1.0, np.nan])), {}),
+        (
+            _paths([1.0, 2.0]),
+            _FixedPayoff(np.array([1.0, 2.0]), settlement_unit="EUR"),
+            {},
+        ),
+        (_paths([1.0, 2.0]), _FixedPayoff([1.0, 2.0]), {}),
+        (_paths([1.0, 2.0]), payoff, {"discount_factor": 0.0}),
+    ]
+    for paths, candidate_payoff, keywords in invalid_requests:
+        with pytest.raises((TypeError, ValueError)):
+            value_paths(paths=paths, payoff=candidate_payoff, **keywords)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="self-normalized"):
+        value_paths_self_normalized(paths=_paths([1.0, 2.0]), payoff=payoff)
+    with pytest.raises(ValueError, match="likelihood"):
+        value_paths(
+            paths=_paths([1.0, 2.0]),
+            payoff=payoff,
+            recenter=LegacyAdditiveForwardRecenter(
+                target_forward=1.0,
+                mean=RecenterMean.NORMALIZED_LIKELIHOOD_WEIGHTED,
+            ),
+        )
+
+
+def test_direct_modules_do_not_expand_the_package_root() -> None:
+    """Keep the provisional D2 API on direct public submodules."""
+    for name in (
+        "EuropeanOptionPayoff",
+        "IntegratedVarianceOptionPayoff",
+        "VarianceQuote",
+        "PathValuationResult",
+        "value_paths",
+    ):
+        assert name not in stochvolmodels.__all__
+        assert not hasattr(stochvolmodels, name)
+
+
+def test_direct_module_imports_stay_outside_heavy_pricing_layers() -> None:
+    """The bounded product/valuation import loads no pricer or optional analytic stack."""
+    source_root = str(PACKAGE_ROOT.parent)
+    code = f"""
+import sys
+sys.path.insert(0, {source_root!r})
+import stochvolmodels.products.payoffs
+import stochvolmodels.valuation
+forbidden = (
+    "numba",
+    "pandas",
+    "scipy",
+    "stochvolmodels.pricers",
+    "vanilla_option_pricers",
+)
+loaded = sorted(
+    root
+    for root in forbidden
+    if any(name == root or name.startswith(root + ".") for name in sys.modules)
+)
+assert not loaded, loaded
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+@pytest.mark.paper_replication
+def test_logsv_raw_european_and_variance_values_match_independent_analytics() -> None:
+    """Raw MMA paths reproduce transform prices and the analytic variance moment within four SE."""
+    from stochvolmodels.data.option_chain import OptionChain
+    from stochvolmodels.models.logsv import LogSvMeasure, LogSvModel
+    from stochvolmodels.pricers.logsv.logsv_params import LogSvParams
+    from stochvolmodels.pricers.logsv.vol_moments_ode import compute_analytic_qvar
+    from stochvolmodels.pricers.logsv_pricer import LogSVPricer
+
+    maturity = 0.25
+    discount = 0.98
+    params = LogSvParams(
+        sigma0=0.2,
+        theta=0.22,
+        kappa1=3.0,
+        kappa2=12.0,
+        beta=-0.3,
+        volvol=0.4,
+        H=0.5,
+    )
+    paths = LogSvModel(params).simulate_paths(
+        measure=LogSvMeasure.MMA,
+        observation_times=np.array([0.0, maturity]),
+        spot0=1.0,
+        n_paths=40_000,
+        steps_per_year=360,
+        seed=20260829,
+    )
+    strikes = np.array([0.9, 1.0, 1.1])
+    option_types = np.array(["P", "C", "C"])
+    chain = OptionChain.slice_to_chain(
+        ttm=maturity,
+        forward=1.0,
+        strikes=strikes,
+        optiontypes=option_types,
+        discfactor=discount,
+        id="3m",
+    )
+    analytic_prices = np.asarray(LogSVPricer().price_chain(chain, params)[0])
+
+    for strike, option_type, analytic_price in zip(strikes, option_types, analytic_prices):
+        payoff = EuropeanOptionPayoff(
+            asset_id="zero_drift_price",
+            expiry=maturity,
+            strike=float(strike),
+            option_type=str(option_type),
+            unit="forward units",
+        )
+        result = value_paths(paths=paths, payoff=payoff, discount_factor=discount)
+        assert result.estimator is PathEstimator.MONTE_CARLO
+        assert result.recenter_shift is None
+        assert abs(result.value - analytic_price) <= 4.0 * result.standard_error
+
+    variance_payoff = IntegratedVarianceOptionPayoff(
+        state_name="quadratic_variance",
+        expiry=maturity,
+        strike=0.0,
+        option_type="C",
+        quote=VarianceQuote.ANNUALIZED,
+        unit="annualized variance",
+    )
+    variance_result = value_paths(paths=paths, payoff=variance_payoff)
+    expected_variance = compute_analytic_qvar(params, ttm=maturity, n_terms=8)
+    assert abs(variance_result.value - expected_variance) <= 4.0 * variance_result.standard_error
+
+
+@pytest.mark.slow
+def test_tgarch_direct_q_and_raw_weighted_p_agree_with_antithetic_groups() -> None:
+    """The new raw LR boundary preserves the discrete-model pricing-measure comparison."""
+    from stochvolmodels.models.tgarch import TgarchMeasure, TgarchModel, TgarchParams
+
+    maturity = 0.25
+    n_paths = 65_536
+    params = TgarchParams(
+        theta=0.6,
+        kappa1=3.0,
+        kappa2=3.0,
+        beta=1.0,
+        eps=1.5,
+        sigma0=0.6,
+        r=0.0,
+        gamma0=0.0,
+        gamma1=0.5,
+        eta0=0.0,
+        eta1=-0.38,
+        spot0=1.0,
+    )
+    model = TgarchModel(params)
+    request = {
+        "maturity": maturity,
+        "max_dt": 1.0 / 52.0,
+        "n_paths": n_paths,
+        "seed": 20260825,
+        "chunk_steps": 8,
+    }
+    p_paths = model.simulate_paths(
+        measure=TgarchMeasure.P,
+        track_log_weights=True,
+        **request,
+    )
+    q_paths = model.simulate_paths(
+        measure=TgarchMeasure.Q_EXACT,
+        **{**request, "seed": 20260826},
+    )
+    pair_count = n_paths // 2
+    pair_ids = np.concatenate([np.arange(pair_count), np.arange(pair_count)])
+    payoff = EuropeanOptionPayoff(
+        asset_id="spot",
+        expiry=maturity,
+        strike=params.spot0,
+        option_type="C",
+        unit="spot units",
+    )
+    weighted_p = value_paths(
+        paths=p_paths,
+        payoff=payoff,
+        discount_factor=math.exp(-params.r * maturity),
+        independent_group_ids=pair_ids,
+    )
+    direct_q = value_paths(
+        paths=q_paths,
+        payoff=payoff,
+        discount_factor=math.exp(-params.r * maturity),
+        independent_group_ids=pair_ids,
+    )
+    combined_error = math.hypot(weighted_p.standard_error, direct_q.standard_error)
+
+    assert weighted_p.estimator is PathEstimator.RAW_LIKELIHOOD_RATIO
+    assert direct_q.estimator is PathEstimator.MONTE_CARLO
+    assert weighted_p.group_size == direct_q.group_size == 2
+    assert abs(weighted_p.value - direct_q.value) <= 4.0 * combined_error

--- a/src/stochvolmodels/valuation.py
+++ b/src/stochvolmodels/valuation.py
@@ -1,0 +1,715 @@
+"""Discounted path valuation with explicit measure and estimator conventions."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from numbers import Real
+
+import numpy as np
+from numpy.typing import NDArray
+
+from stochvolmodels.data.model_paths import ModelPaths
+from stochvolmodels.products import Payoff
+from stochvolmodels.products.payoffs import EuropeanOptionPayoff
+
+__all__ = (
+    "LegacyAdditiveForwardRecenter",
+    "PathEstimator",
+    "PathValuationResult",
+    "RecenterMean",
+    "value_paths",
+    "value_paths_self_normalized",
+)
+
+FloatArray = NDArray[np.float64]
+IntArray = NDArray[np.integer]
+
+_LOG_MAX_FLOAT = math.log(np.finfo(np.float64).max)
+_LOG_MIN_SUBNORMAL = math.log(float(np.nextafter(0.0, 1.0)))
+
+
+class PathEstimator(str, Enum):
+    """Estimator used for a pathwise expectation."""
+
+    MONTE_CARLO = "monte_carlo"
+    RAW_LIKELIHOOD_RATIO = "raw_likelihood_ratio"
+    SELF_NORMALIZED_LIKELIHOOD_RATIO = "self_normalized_likelihood_ratio"
+
+
+class RecenterMean(str, Enum):
+    """Sample mean used by the explicit legacy forward-recentering policy."""
+
+    UNWEIGHTED = "unweighted"
+    NORMALIZED_LIKELIHOOD_WEIGHTED = "normalized_likelihood_weighted"
+
+
+def _finite_positive_float(value: object, name: str) -> float:
+    """Return a finite positive float while rejecting booleans."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite real scalar")
+    result = float(value)
+    if not math.isfinite(result) or result <= 0.0:
+        raise ValueError(f"{name} must be finite and strictly positive")
+    return result
+
+
+def _as_recenter_mean(value: object) -> RecenterMean:
+    """Canonicalize a recenter-mean selection."""
+    try:
+        return RecenterMean(value)
+    except (TypeError, ValueError) as exc:
+        allowed = ", ".join(item.value for item in RecenterMean)
+        raise ValueError(f"mean must be one of {{{allowed}}}") from exc
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class LegacyAdditiveForwardRecenter:
+    """Opt in to the historical additive terminal-forward recentering.
+
+    Parameters
+    ----------
+    target_forward
+        Positive target mean for the selected terminal asset.
+    mean
+        Arithmetic sample mean, or a normalized-likelihood-weighted mean available only
+        through :func:`value_paths_self_normalized`.
+    """
+
+    target_forward: float
+    mean: RecenterMean
+
+    def __post_init__(self) -> None:
+        """Validate and canonicalize the immutable policy."""
+        object.__setattr__(
+            self,
+            "target_forward",
+            _finite_positive_float(self.target_forward, "target_forward"),
+        )
+        object.__setattr__(self, "mean", _as_recenter_mean(self.mean))
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PathValuationResult:
+    """Immutable pathwise value, uncertainty, and weighting diagnostics."""
+
+    value: float
+    standard_error: float
+    estimator: PathEstimator
+    standard_error_basis: str
+    n_paths: int
+    n_independent_groups: int
+    group_size: int
+    settlement_unit: str
+    path_effective_sample_size: float
+    path_ess_fraction: float
+    group_effective_sample_size: float
+    group_ess_fraction: float
+    mean_likelihood_ratio: float | None
+    log_mean_likelihood_ratio: float | None
+    recenter_shift: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class _Grouping:
+    """Resolved equal-size independent-group structure."""
+
+    inverse: IntArray
+    n_groups: int
+    group_size: int
+    explicit: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _Weights:
+    """Shifted likelihood weights and raw-scale diagnostics.
+
+    ``log_ratios`` stores raw ``log(d target_measure / d sampling_measure)``.
+    """
+
+    log_ratios: FloatArray
+    scaled: FloatArray
+    log_scale: float
+    mean: float
+    log_mean: float
+    path_ess: float
+
+
+@dataclass(frozen=True, slots=True)
+class _ScaledSignedValues:
+    """Signed values represented relative to a common exponential log scale."""
+
+    scaled: FloatArray
+    log_scale: float
+
+
+def _validate_label(value: object, name: str) -> str:
+    """Return a non-empty, trimmed label."""
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    if not value or value != value.strip():
+        raise ValueError(f"{name} must be non-empty and trimmed")
+    return value
+
+
+def _validate_payoff_contract(paths: ModelPaths, payoff: Payoff) -> str:
+    """Validate payoff metadata shared by all concrete products."""
+    if not isinstance(payoff, Payoff):
+        raise TypeError("payoff must implement the Payoff protocol")
+
+    required_asset_ids = payoff.required_asset_ids
+    if not isinstance(required_asset_ids, tuple):
+        raise TypeError("payoff.required_asset_ids must be a tuple")
+    for asset_id in required_asset_ids:
+        _validate_label(asset_id, "required asset ID")
+    if len(set(required_asset_ids)) != len(required_asset_ids):
+        raise ValueError("payoff.required_asset_ids must be unique")
+    missing = tuple(asset_id for asset_id in required_asset_ids if asset_id not in paths.asset_ids)
+    if missing:
+        raise ValueError(f"payoff requires unavailable asset IDs: {missing!r}")
+
+    expiry = _finite_positive_float(payoff.expiry, "payoff.expiry")
+    if np.count_nonzero(paths.observation_times == expiry) != 1:
+        raise ValueError("payoff expiry must exactly match one path observation time")
+
+    payoff_unit = _validate_label(payoff.payoff_unit, "payoff.payoff_unit")
+    settlement_unit = _validate_label(payoff.settlement_unit, "payoff.settlement_unit")
+    if payoff_unit != settlement_unit:
+        raise ValueError("payoff and settlement units must agree")
+    return settlement_unit
+
+
+def _resolve_grouping(
+    independent_group_ids: np.ndarray | None,
+    *,
+    n_paths: int,
+) -> _Grouping:
+    """Validate and encode caller-declared equal-size independent groups."""
+    if independent_group_ids is None:
+        if n_paths < 2:
+            raise ValueError("path valuation requires at least two independent paths")
+        return _Grouping(
+            inverse=np.arange(n_paths, dtype=np.int64),
+            n_groups=n_paths,
+            group_size=1,
+            explicit=False,
+        )
+
+    if not isinstance(independent_group_ids, np.ndarray):
+        raise TypeError("independent_group_ids must be a NumPy array")
+    if independent_group_ids.ndim != 1 or independent_group_ids.shape != (n_paths,):
+        raise ValueError("independent_group_ids must have shape (n_paths,)")
+    if independent_group_ids.dtype.kind not in "iu":
+        raise TypeError("independent_group_ids must have an integer dtype")
+
+    _, inverse, counts = np.unique(
+        independent_group_ids,
+        return_inverse=True,
+        return_counts=True,
+    )
+    if counts.size < 2:
+        raise ValueError("independent_group_ids must define at least two groups")
+    if np.any(counts != counts[0]):
+        raise ValueError("independent groups must all have the same positive size")
+    return _Grouping(
+        inverse=np.asarray(inverse, dtype=np.int64),
+        n_groups=int(counts.size),
+        group_size=int(counts[0]),
+        explicit=True,
+    )
+
+
+def _stable_ess(nonnegative_values: FloatArray, name: str) -> float:
+    """Return Kish ESS after normalizing non-negative finite values."""
+    if nonnegative_values.ndim != 1 or nonnegative_values.size == 0:
+        raise ValueError(f"{name} must be a non-empty vector")
+    if not np.all(np.isfinite(nonnegative_values)) or np.any(nonnegative_values < 0.0):
+        raise ValueError(f"{name} must contain finite non-negative values")
+    total = float(np.sum(nonnegative_values))
+    if not math.isfinite(total) or total <= 0.0:
+        raise ValueError(f"{name} cannot contain all-zero weights")
+    probabilities = nonnegative_values / total
+    squared_sum = float(np.dot(probabilities, probabilities))
+    if not math.isfinite(squared_sum) or squared_sum <= 0.0:
+        raise FloatingPointError(f"could not compute a finite {name} ESS")
+    return 1.0 / squared_sum
+
+
+def _resolve_weights(paths: ModelPaths) -> _Weights:
+    """Shift raw ``log(d target / d sampling)`` ratios without losing raw scale."""
+    log_ratios = paths.log_likelihood_ratios
+    if log_ratios is None:  # pragma: no cover - guarded by estimator selection
+        raise ValueError("likelihood ratios are required for this estimator")
+    if not isinstance(log_ratios, np.ndarray):
+        raise TypeError("log_likelihood_ratios must be a NumPy array")
+    if log_ratios.ndim != 1 or log_ratios.shape != (paths.assets.shape[0],):
+        raise ValueError("log_likelihood_ratios must have shape (n_paths,)")
+    if log_ratios.dtype.kind not in "iuf":
+        raise TypeError("log_likelihood_ratios must have a real numeric dtype")
+    if np.any(np.isnan(log_ratios)) or np.any(np.isposinf(log_ratios)):
+        raise ValueError("log_likelihood_ratios cannot contain NaN or positive infinity")
+
+    log_values = np.asarray(log_ratios, dtype=np.float64)
+    log_scale = float(np.max(log_values))
+    if log_scale == -math.inf:
+        raise ValueError("likelihood ratios cannot all be zero")
+    with np.errstate(under="ignore"):
+        scaled = np.exp(log_values - log_scale)
+    scaled = np.asarray(scaled, dtype=np.float64)
+    scaled_total = float(np.sum(scaled))
+    if not math.isfinite(scaled_total) or scaled_total <= 0.0:
+        raise FloatingPointError("could not normalize likelihood ratios")
+    mean_scaled = scaled_total / scaled.size
+    log_mean = log_scale + math.log(mean_scaled)
+    try:
+        mean = math.exp(log_mean)
+    except OverflowError:
+        mean = math.inf
+    path_ess = _stable_ess(scaled, "path likelihood")
+    return _Weights(
+        log_ratios=log_values,
+        scaled=scaled,
+        log_scale=log_scale,
+        mean=mean,
+        log_mean=log_mean,
+        path_ess=path_ess,
+    )
+
+
+def _stable_mean(values: FloatArray, name: str) -> float:
+    """Return an overflow-resistant arithmetic mean of finite values."""
+    if values.ndim != 1 or values.size == 0:
+        raise ValueError(f"{name} must be a non-empty vector")
+    if not np.all(np.isfinite(values)):
+        raise ValueError(f"{name} must contain only finite values")
+    try:
+        result = math.fsum(float(value) / values.size for value in values)
+    except OverflowError as exc:
+        raise FloatingPointError(f"{name} mean is not representable") from exc
+    if not math.isfinite(result):
+        raise FloatingPointError(f"{name} mean is not representable")
+    return result
+
+
+def _scaled_signed_weighted_values(
+    values: FloatArray,
+    weights: _Weights,
+    name: str,
+) -> _ScaledSignedValues:
+    """Scale signed ``weight * value`` terms by their largest joint log magnitude."""
+    if values.ndim != 1 or values.shape != weights.log_ratios.shape:
+        raise ValueError(f"{name} must have shape (n_paths,)")
+    if not np.all(np.isfinite(values)):
+        raise ValueError(f"{name} must contain only finite values")
+
+    active = (values != 0.0) & np.isfinite(weights.log_ratios)
+    scaled = np.zeros(values.shape, dtype=np.float64)
+    if not np.any(active):
+        return _ScaledSignedValues(scaled=scaled, log_scale=weights.log_scale)
+
+    with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+        joint_logs = weights.log_ratios[active] + np.log(np.abs(values[active]))
+    if not np.all(np.isfinite(joint_logs)):
+        raise FloatingPointError(f"{name} weighted log magnitudes are not representable")
+    log_scale = float(np.max(joint_logs))
+    with np.errstate(under="ignore"):
+        magnitudes = np.exp(joint_logs - log_scale)
+    scaled[active] = np.copysign(magnitudes, values[active])
+    if not np.all(np.isfinite(scaled)):
+        raise FloatingPointError(f"{name} weighted contributions are not representable")
+    return _ScaledSignedValues(scaled=scaled, log_scale=log_scale)
+
+
+def _restore_log_scale(scaled_value: float, log_scale: float, name: str) -> float:
+    """Restore one log-scaled scalar and reject float overflow or underflow."""
+    if scaled_value == 0.0:
+        return 0.0
+    log_absolute_value = math.log(abs(scaled_value)) + log_scale
+    if not math.isfinite(log_absolute_value) or log_absolute_value > _LOG_MAX_FLOAT:
+        raise FloatingPointError(f"{name} is not representable")
+    if log_absolute_value < _LOG_MIN_SUBNORMAL:
+        raise FloatingPointError(f"{name} is not representable")
+    restored = math.copysign(math.exp(log_absolute_value), scaled_value)
+    if not math.isfinite(restored) or restored == 0.0:
+        raise FloatingPointError(f"{name} is not representable")
+    return restored
+
+
+def _ratio_from_scaled_means(
+    *,
+    numerator: float,
+    numerator_log_scale: float,
+    denominator: float,
+    denominator_log_scale: float,
+    name: str,
+) -> tuple[float, float, float]:
+    """Restore a ratio whose numerator and denominator have separate log scales."""
+    if not math.isfinite(denominator) or denominator <= 0.0:
+        raise ValueError(f"{name} denominator must be positive")
+    scaled_ratio = numerator / denominator
+    if not math.isfinite(scaled_ratio):
+        raise FloatingPointError(f"{name} scaled ratio is not representable")
+    relative_log_scale = numerator_log_scale - denominator_log_scale
+    value = _restore_log_scale(scaled_ratio, relative_log_scale, name)
+    return value, scaled_ratio, relative_log_scale
+
+
+def _weighted_ratio(values: FloatArray, weights: _Weights, name: str) -> float:
+    """Return ``sum(weight * value) / sum(weight)`` with separate stable scales."""
+    numerator = _scaled_signed_weighted_values(values, weights, name)
+    numerator_mean = _stable_mean(numerator.scaled, f"{name} numerator")
+    denominator_mean = _stable_mean(weights.scaled, f"{name} denominator")
+    value, _, _ = _ratio_from_scaled_means(
+        numerator=numerator_mean,
+        numerator_log_scale=numerator.log_scale,
+        denominator=denominator_mean,
+        denominator_log_scale=weights.log_scale,
+        name=name,
+    )
+    return value
+
+
+def _select_estimator(paths: ModelPaths, *, self_normalized: bool) -> PathEstimator:
+    """Enforce the declared sampling/target-measure relationship."""
+    if paths.numeraire != "money_market_account":
+        raise ValueError("path valuation requires the money_market_account numeraire")
+
+    same_measure = paths.sampling_measure == paths.target_measure
+    has_ratios = paths.log_likelihood_ratios is not None
+    if paths.target_measure == "P":
+        raise ValueError("the physical measure P is not a valid pricing target")
+
+    if self_normalized:
+        if same_measure or not has_ratios:
+            raise ValueError(
+                "self-normalized valuation requires distinct measures and likelihood ratios"
+            )
+        return PathEstimator.SELF_NORMALIZED_LIKELIHOOD_RATIO
+
+    if same_measure:
+        if has_ratios:
+            raise ValueError(
+                "likelihood ratios are invalid when sampling and target measures agree"
+            )
+        return PathEstimator.MONTE_CARLO
+    if not has_ratios:
+        raise ValueError("a measure change requires raw likelihood ratios")
+    return PathEstimator.RAW_LIKELIHOOD_RATIO
+
+
+def _evaluate_payoff(
+    *,
+    paths: ModelPaths,
+    payoff: Payoff,
+    recenter: LegacyAdditiveForwardRecenter | None,
+    weights: _Weights | None,
+) -> tuple[FloatArray, float | None]:
+    """Evaluate raw or explicitly recentered payoff values."""
+    recenter_shift: float | None = None
+    if recenter is None:
+        values = payoff(paths)
+    else:
+        if not isinstance(recenter, LegacyAdditiveForwardRecenter):
+            raise TypeError("recenter must be a LegacyAdditiveForwardRecenter policy")
+        if not isinstance(payoff, EuropeanOptionPayoff):
+            raise TypeError("legacy recentering is supported only for EuropeanOptionPayoff")
+
+        asset_index = paths.asset_ids.index(payoff.asset_id)
+        time_matches = np.flatnonzero(paths.observation_times == payoff.expiry)
+        if time_matches.size != 1:  # pragma: no cover - shared contract guards this
+            raise ValueError("payoff expiry must exactly match one path observation time")
+        terminal_asset = np.asarray(
+            paths.assets[:, int(time_matches[0]), asset_index],
+            dtype=np.float64,
+        )
+        if not np.all(np.isfinite(terminal_asset)):
+            raise ValueError("selected terminal asset values must be finite")
+
+        if recenter.mean is RecenterMean.UNWEIGHTED:
+            sample_mean = _stable_mean(terminal_asset, "recenter terminal asset")
+        else:
+            if weights is None:
+                raise ValueError("weighted legacy recentering requires likelihood ratios")
+            sample_mean = _weighted_ratio(
+                terminal_asset,
+                weights,
+                "weighted recenter sample mean",
+            )
+        if not math.isfinite(sample_mean):
+            raise FloatingPointError("could not compute a finite recenter sample mean")
+
+        recenter_shift = recenter.target_forward - sample_mean
+        with np.errstate(over="ignore", invalid="ignore"):
+            adjusted_asset = terminal_asset + recenter_shift
+        if not np.all(np.isfinite(adjusted_asset)) or np.any(adjusted_asset <= 0.0):
+            raise ValueError("legacy-recentered terminal asset values must be finite and positive")
+        values = payoff._payoff_from_asset_values(adjusted_asset, n_paths=paths.assets.shape[0])
+
+    if not isinstance(values, np.ndarray):
+        raise TypeError("payoff output must be a NumPy array")
+    if values.ndim != 1 or values.shape != (paths.assets.shape[0],):
+        raise ValueError("payoff output must have shape (n_paths,)")
+    if values.dtype.kind not in "iuf":
+        raise TypeError("payoff output must have a real numeric dtype")
+    result = np.asarray(values, dtype=np.float64)
+    if not np.all(np.isfinite(result)):
+        raise ValueError("payoff output must contain only finite values")
+    return result, recenter_shift
+
+
+def _group_means(values: FloatArray, grouping: _Grouping) -> FloatArray:
+    """Return equal-size group means while reducing avoidable sum overflow."""
+    order = np.argsort(grouping.inverse, kind="stable")
+    arranged = values[order].reshape(grouping.n_groups, grouping.group_size)
+    with np.errstate(over="ignore", invalid="ignore"):
+        means = np.sum(arranged / grouping.group_size, axis=1)
+    means = np.asarray(means, dtype=np.float64)
+    if not np.all(np.isfinite(means)):
+        raise FloatingPointError("independent-group contributions must be finite")
+    return means
+
+
+def _mean_and_standard_error(values: FloatArray) -> tuple[float, float]:
+    """Return a stable mean and sample-standard-deviation standard error."""
+    n_values = values.size
+    if n_values < 2:  # pragma: no cover - grouping validation guards this
+        raise ValueError("at least two independent groups are required")
+    mean = _stable_mean(values, "estimator contributions")
+
+    scale = max(float(np.max(np.abs(values))), abs(mean))
+    if scale == 0.0:
+        return mean, 0.0
+    normalized_mean = mean / scale
+    squared_deviations = math.fsum(
+        (float(value) / scale - normalized_mean) ** 2 for value in values
+    )
+    standard_error = scale * math.sqrt(squared_deviations / (n_values - 1) / n_values)
+    if not math.isfinite(standard_error):
+        raise FloatingPointError("estimator standard error is not representable")
+    return mean, standard_error
+
+
+def _standard_error_basis(grouping: _Grouping, *, legacy: bool) -> str:
+    """Describe the declared independent sampling units."""
+    if legacy:
+        return (
+            "legacy_conditional_independent_groups"
+            if grouping.explicit
+            else "legacy_conditional_iid_paths"
+        )
+    return "independent_groups" if grouping.explicit else "iid_paths"
+
+
+def _value_paths(
+    *,
+    paths: ModelPaths,
+    payoff: Payoff,
+    discount_factor: float,
+    recenter: LegacyAdditiveForwardRecenter | None,
+    independent_group_ids: np.ndarray | None,
+    self_normalized: bool,
+) -> PathValuationResult:
+    """Implement raw and self-normalized public entry points."""
+    if not isinstance(paths, ModelPaths):
+        raise TypeError("paths must be a ModelPaths instance")
+    settlement_unit = _validate_payoff_contract(paths, payoff)
+    discount = _finite_positive_float(discount_factor, "discount_factor")
+    estimator = _select_estimator(paths, self_normalized=self_normalized)
+    if (
+        isinstance(recenter, LegacyAdditiveForwardRecenter)
+        and recenter.mean is RecenterMean.NORMALIZED_LIKELIHOOD_WEIGHTED
+        and estimator is not PathEstimator.SELF_NORMALIZED_LIKELIHOOD_RATIO
+    ):
+        raise ValueError(
+            "normalized-likelihood-weighted recentering is supported only by the "
+            "self-normalized valuation entry point"
+        )
+    grouping = _resolve_grouping(
+        independent_group_ids,
+        n_paths=paths.assets.shape[0],
+    )
+
+    weights = None if estimator is PathEstimator.MONTE_CARLO else _resolve_weights(paths)
+    payoff_values, recenter_shift = _evaluate_payoff(
+        paths=paths,
+        payoff=payoff,
+        recenter=recenter,
+        weights=weights,
+    )
+    with np.errstate(over="ignore", invalid="ignore"):
+        discounted_payoff = discount * payoff_values
+    if not np.all(np.isfinite(discounted_payoff)):
+        raise FloatingPointError("discounted payoff values must be representable")
+
+    n_paths = paths.assets.shape[0]
+    if estimator is PathEstimator.MONTE_CARLO:
+        group_contributions = _group_means(discounted_payoff, grouping)
+        value, standard_error = _mean_and_standard_error(group_contributions)
+        path_ess = float(n_paths)
+        group_ess = float(grouping.n_groups)
+        mean_ratio = None
+        log_mean_ratio = None
+    else:
+        if weights is None:  # pragma: no cover - estimator selection guards this
+            raise RuntimeError("missing likelihood weights")
+        group_weights = _group_means(weights.scaled, grouping)
+        group_ess = _stable_ess(group_weights, "group likelihood")
+        path_ess = weights.path_ess
+        mean_ratio = weights.mean
+        log_mean_ratio = weights.log_mean
+
+        weighted_payoff = _scaled_signed_weighted_values(
+            discounted_payoff,
+            weights,
+            "discounted payoff",
+        )
+        group_numerators = _group_means(weighted_payoff.scaled, grouping)
+
+        if estimator is PathEstimator.RAW_LIKELIHOOD_RATIO:
+            scaled_value, scaled_standard_error = _mean_and_standard_error(group_numerators)
+            value = _restore_log_scale(
+                scaled_value,
+                weighted_payoff.log_scale,
+                "raw likelihood-ratio value",
+            )
+            standard_error = _restore_log_scale(
+                scaled_standard_error,
+                weighted_payoff.log_scale,
+                "raw likelihood-ratio standard error",
+            )
+        else:
+            positive_groups = np.unique(grouping.inverse[np.isfinite(weights.log_ratios)]).size
+            if positive_groups < 2:
+                raise ValueError(
+                    "self-normalized valuation requires at least two positive independent "
+                    "groups under the likelihood weights"
+                )
+            mean_numerator, _ = _mean_and_standard_error(group_numerators)
+            mean_denominator, _ = _mean_and_standard_error(group_weights)
+            value, scaled_ratio, relative_log_scale = _ratio_from_scaled_means(
+                numerator=mean_numerator,
+                numerator_log_scale=weighted_payoff.log_scale,
+                denominator=mean_denominator,
+                denominator_log_scale=weights.log_scale,
+                name="self-normalized estimator value",
+            )
+            with np.errstate(over="ignore", invalid="ignore"):
+                residuals = group_numerators - scaled_ratio * group_weights
+            if not np.all(np.isfinite(residuals)):
+                raise FloatingPointError(
+                    "self-normalized estimator residuals are not representable"
+                )
+            _, residual_standard_error = _mean_and_standard_error(residuals)
+            scaled_standard_error = residual_standard_error / mean_denominator
+            standard_error = _restore_log_scale(
+                scaled_standard_error,
+                relative_log_scale,
+                "self-normalized estimator standard error",
+            )
+
+    return PathValuationResult(
+        value=value,
+        standard_error=standard_error,
+        estimator=estimator,
+        standard_error_basis=_standard_error_basis(
+            grouping,
+            legacy=recenter is not None,
+        ),
+        n_paths=n_paths,
+        n_independent_groups=grouping.n_groups,
+        group_size=grouping.group_size,
+        settlement_unit=settlement_unit,
+        path_effective_sample_size=path_ess,
+        path_ess_fraction=path_ess / n_paths,
+        group_effective_sample_size=group_ess,
+        group_ess_fraction=group_ess / grouping.n_groups,
+        mean_likelihood_ratio=mean_ratio,
+        log_mean_likelihood_ratio=log_mean_ratio,
+        recenter_shift=recenter_shift,
+    )
+
+
+def value_paths(
+    *,
+    paths: ModelPaths,
+    payoff: Payoff,
+    discount_factor: float = 1.0,
+    recenter: LegacyAdditiveForwardRecenter | None = None,
+    independent_group_ids: np.ndarray | None = None,
+) -> PathValuationResult:
+    """Value a payoff by ordinary MC or raw likelihood-ratio MC.
+
+    The estimator is selected from the measures and raw log likelihood ratios declared
+    by ``paths``. Each ratio is interpreted as
+    ``log(d target_measure / d sampling_measure)``. Likelihood weights are never normalized
+    by this entry point.
+
+    Parameters
+    ----------
+    paths
+        Simulated paths with explicit sampling, target-measure, and numeraire metadata.
+    payoff
+        Pathwise payoff returning one finite value per path.
+    discount_factor
+        Positive deterministic factor from payoff expiry to valuation time.
+    recenter
+        Optional explicit legacy additive forward-mean policy.
+    independent_group_ids
+        Optional equal-size grouping of dependent rows, such as antithetic pairs.
+
+    Returns
+    -------
+    PathValuationResult
+        Discounted value, independent-group standard error, and ESS diagnostics.
+    """
+    return _value_paths(
+        paths=paths,
+        payoff=payoff,
+        discount_factor=discount_factor,
+        recenter=recenter,
+        independent_group_ids=independent_group_ids,
+        self_normalized=False,
+    )
+
+
+def value_paths_self_normalized(
+    *,
+    paths: ModelPaths,
+    payoff: Payoff,
+    discount_factor: float = 1.0,
+    recenter: LegacyAdditiveForwardRecenter | None = None,
+    independent_group_ids: np.ndarray | None = None,
+) -> PathValuationResult:
+    """Value a payoff by a self-normalized likelihood-ratio estimator.
+
+    This separately named ratio estimator requires distinct sampling and target
+    measures plus raw ``log(d target_measure / d sampling_measure)`` ratios. It does not
+    change the semantics of :func:`value_paths`.
+
+    Parameters
+    ----------
+    paths
+        Simulated paths with explicit measure-change likelihood ratios.
+    payoff
+        Pathwise payoff returning one finite value per path.
+    discount_factor
+        Positive deterministic factor from payoff expiry to valuation time.
+    recenter
+        Optional explicit legacy additive forward-mean policy.
+    independent_group_ids
+        Optional equal-size grouping of dependent rows, such as antithetic pairs.
+
+    Returns
+    -------
+    PathValuationResult
+        Ratio value, independent-group ratio standard error, and ESS diagnostics.
+    """
+    return _value_paths(
+        paths=paths,
+        payoff=payoff,
+        discount_factor=discount_factor,
+        recenter=recenter,
+        independent_group_ids=independent_group_ids,
+        self_normalized=True,
+    )


### PR DESCRIPTION
## Summary

- add direct-submodule European and explicit integrated/annualized-variance path payoffs;
- add raw Monte Carlo and raw likelihood-ratio valuation, plus a separately named self-normalized
  estimator;
- add explicit legacy additive forward recentering, caller-declared independent groups, grouped
  `ddof=1` standard errors, and path/group ESS diagnostics;
- preserve `ModelPaths`, the provisional `Payoff` protocol, all model/pricer kernels, the package
  root, and the legacy payoff helper unchanged.

Raw likelihood ratios retain their absolute `log(d target / d sampling)` scale. Signed weighted
payoffs use a joint log scale so a shifted likelihood weight cannot underflow when its product with
a large payoff remains finite. Self-normalized ratio-influence errors restore numerator and
denominator scales separately.

## Local verification

- 42 focused D2 cases;
- 577 non-slow source cases;
- 8 slow numerical cases;
- 7 paper-replication contracts;
- 103 capability/root-API/import/repository contracts;
- six deliberate numerical mutations rejected and restored;
- critical, dependency-boundary, changed-file, Python 3.10 and format Ruff gates;
- 436/436 docstrings;
- whole/stable coverage 56.46% / 88.89% versus 44.50% / 86.50% gates;
- offline quickstart;
- 98-file wheel with 30 test modules;
- 145 focused installed-wheel cases;
- clean external installed wheel: 562 non-slow passed with 15 intended repository-only skips, and
  all 8 slow cases passed.

Verification used public `option-chain-analytics==5.2.0`.

## Scope

Exactly five tracked files. No control variate, inverse settlement, spot-numeraire conversion,
provenance inference, chapter rewrite, dependency, root re-export, version bump, release, or
regression-baseline change.
