### PR TITLE
Adopt package analytics in the discrete-volatility book chapter

### DIFF
--- a/volatility_book/ch_discrete_vol/__init__.py
+++ b/volatility_book/ch_discrete_vol/__init__.py
@@ -1,0 +1,9 @@
+"""Discrete TGARCH recursion and continuous-limit research study."""
+
+from volatility_book.ch_discrete_vol.experiments import (
+    StudyProfile,
+    StudyResults,
+    run_all_experiments,
+)
+
+__all__ = ["StudyProfile", "StudyResults", "run_all_experiments"]

--- a/volatility_book/ch_discrete_vol/acceptance_manifest.json
+++ b/volatility_book/ch_discrete_vol/acceptance_manifest.json
@@ -1,0 +1,380 @@
+{
+  "schema_version": 1,
+  "manifest_id": "stochvolmodels.discrete_volatility_chapter.acceptance",
+  "acceptance_status": "D3.1_VERIFIED_LOCAL",
+  "scope": {
+    "chapter": "volatility_book/ch_discrete_vol",
+    "purpose": "Static reproducibility and acceptance contract for the repository-only discrete-volatility chapter.",
+    "numerical_baseline": "D3.1 package adoption at commit e8872ccf8d1635be80b124baad928873e9f36941",
+    "network_or_licensed_inputs": false,
+    "generated_artifacts_are_tracked": false,
+    "runtime_cited_numbers_manifest": "A separate generated cited_numbers*.json artifact produced by Round 3; it is not this static acceptance manifest."
+  },
+  "path_contract": {
+    "repository_relative_output_root": "outputs/volatility_book/ch_discrete_vol",
+    "gitignore_rule": "/outputs/",
+    "tracked_background_note": "volatility_book/ch_discrete_vol/notes/tgarch_quadratic_drift_note.tex",
+    "default_upstream_full_results": {
+      "round1": "outputs/volatility_book/ch_discrete_vol/round1/results.json",
+      "round2": "outputs/volatility_book/ch_discrete_vol/round2/round2_results.json"
+    },
+    "stage_output_directories": {
+      "round1": {
+        "full": "outputs/volatility_book/ch_discrete_vol/round1",
+        "reference": "outputs/volatility_book/ch_discrete_vol/round1_reference",
+        "smoke": "outputs/volatility_book/ch_discrete_vol/round1_smoke"
+      },
+      "round2": {
+        "full": "outputs/volatility_book/ch_discrete_vol/round2",
+        "reference": "outputs/volatility_book/ch_discrete_vol/round2_reference",
+        "smoke": "outputs/volatility_book/ch_discrete_vol/round2_smoke"
+      },
+      "round3": {
+        "full": "outputs/volatility_book/ch_discrete_vol/round3",
+        "reference": "outputs/volatility_book/ch_discrete_vol/round3_reference",
+        "smoke": "outputs/volatility_book/ch_discrete_vol/round3_smoke"
+      }
+    },
+    "round2_reference_upstream": "outputs/volatility_book/ch_discrete_vol/round1_reference/results.json",
+    "default_round3_outputs": {
+      "full": "outputs/volatility_book/ch_discrete_vol/round3",
+      "reference": "outputs/volatility_book/ch_discrete_vol/round3_reference",
+      "smoke": "outputs/volatility_book/ch_discrete_vol/round3_smoke"
+    },
+    "round3_profiles_consume_full_upstream_results": true,
+    "explicit_cli_overrides_preserved": {
+      "round1": [
+        "--output-dir"
+      ],
+      "round2": [
+        "--output-dir",
+        "--round1-json",
+        "--r1-json",
+        "--background-note"
+      ],
+      "round3": [
+        "--output-dir",
+        "--round1-json",
+        "--round2-json",
+        "--background-note"
+      ]
+    }
+  },
+  "generated_dependency_chain": [
+    {
+      "order": 1,
+      "stage": "round1_full",
+      "command_argv": [
+        "python",
+        "-m",
+        "volatility_book.ch_discrete_vol.run_study",
+        "--profile",
+        "full",
+        "--output-dir",
+        "outputs/volatility_book/ch_discrete_vol/round1"
+      ],
+      "inputs": [
+        "tracked chapter sources and embedded synthetic parameter sets"
+      ],
+      "outputs": [
+        "outputs/volatility_book/ch_discrete_vol/round1/results.json",
+        "outputs/volatility_book/ch_discrete_vol/round1/results.md",
+        "outputs/volatility_book/ch_discrete_vol/round1/figures.pdf"
+      ]
+    },
+    {
+      "order": 2,
+      "stage": "round1_clean_reference",
+      "command_argv": [
+        "python",
+        "-m",
+        "volatility_book.ch_discrete_vol.run_study",
+        "--profile",
+        "reference",
+        "--output-dir",
+        "outputs/volatility_book/ch_discrete_vol/round1_reference"
+      ],
+      "inputs": [
+        "tracked chapter sources and embedded synthetic parameter sets"
+      ],
+      "outputs": [
+        "outputs/volatility_book/ch_discrete_vol/round1_reference/results.json",
+        "outputs/volatility_book/ch_discrete_vol/round1_reference/results.md",
+        "outputs/volatility_book/ch_discrete_vol/round1_reference/figures.pdf"
+      ]
+    },
+    {
+      "order": 3,
+      "stage": "round2_full",
+      "command_argv": [
+        "python",
+        "-m",
+        "volatility_book.ch_discrete_vol.round2",
+        "--profile",
+        "full",
+        "--output-dir",
+        "outputs/volatility_book/ch_discrete_vol/round2",
+        "--round1-json",
+        "outputs/volatility_book/ch_discrete_vol/round1/results.json",
+        "--r1-json",
+        "outputs/volatility_book/ch_discrete_vol/round1_reference/results.json",
+        "--background-note",
+        "volatility_book/ch_discrete_vol/notes/tgarch_quadratic_drift_note.tex"
+      ],
+      "inputs": [
+        "outputs/volatility_book/ch_discrete_vol/round1/results.json",
+        "outputs/volatility_book/ch_discrete_vol/round1_reference/results.json",
+        "volatility_book/ch_discrete_vol/notes/tgarch_quadratic_drift_note.tex"
+      ],
+      "outputs": [
+        "outputs/volatility_book/ch_discrete_vol/round2/round2_results.json",
+        "outputs/volatility_book/ch_discrete_vol/round2/round2_results.md",
+        "outputs/volatility_book/ch_discrete_vol/round2/round2_figures.pdf"
+      ],
+      "execution_precondition": "The FULL profile requires a clean worktree at an exact tag."
+    },
+    {
+      "order": 4,
+      "stage": "round3_full",
+      "command_argv": [
+        "python",
+        "-m",
+        "volatility_book.ch_discrete_vol.round3",
+        "--profile",
+        "full"
+      ],
+      "inputs": [
+        "outputs/volatility_book/ch_discrete_vol/round1/results.json",
+        "outputs/volatility_book/ch_discrete_vol/round2/round2_results.json",
+        "volatility_book/ch_discrete_vol/notes/tgarch_quadratic_drift_note.tex"
+      ],
+      "outputs": [
+        "outputs/volatility_book/ch_discrete_vol/round3/round3_results.json",
+        "outputs/volatility_book/ch_discrete_vol/round3/round3_results.md",
+        "outputs/volatility_book/ch_discrete_vol/round3/round3_figures.pdf",
+        "outputs/volatility_book/ch_discrete_vol/round3/e3_stationary_samples_round3.npz",
+        "outputs/volatility_book/ch_discrete_vol/round3/cited_numbers.json"
+      ],
+      "execution_precondition": "The FULL profile requires a clean worktree at an exact tag."
+    }
+  ],
+  "verification_commands": {
+    "manifest_json": [
+      "python",
+      "-m",
+      "json.tool",
+      "volatility_book/ch_discrete_vol/acceptance_manifest.json"
+    ],
+    "path_and_provenance_contract": [
+      "python",
+      "-c",
+      "import hashlib; from volatility_book.ch_discrete_vol import round3 as r; from volatility_book.ch_discrete_vol.experiments import StudyProfile; root=r._repo_root(); assert r.DEFAULT_BACKGROUND_NOTE==r.TRACKED_NOTE and r.TRACKED_NOTE.is_file(); assert r.DEFAULT_OUTPUT_ROOT==root/'outputs'/'volatility_book'/'ch_discrete_vol'; assert r.DEFAULT_ROUND1_JSON==r.DEFAULT_OUTPUT_ROOT/'round1'/'results.json'; assert r.DEFAULT_ROUND2_JSON==r.DEFAULT_OUTPUT_ROOT/'round2'/'round2_results.json'; assert r._default_output_dir(StudyProfile.FULL)==r.DEFAULT_OUTPUT_ROOT/'round3'; assert r._default_output_dir(StudyProfile.REFERENCE)==r.DEFAULT_OUTPUT_ROOT/'round3_reference'; assert r._default_output_dir(StudyProfile.SMOKE)==r.DEFAULT_OUTPUT_ROOT/'round3_smoke'; expected=hashlib.sha256(r.ACCEPTANCE_MANIFEST.read_bytes()).hexdigest(); provenance=r._execution_provenance(profile=StudyProfile.SMOKE,background_note=r.TRACKED_NOTE); assert provenance['acceptance_manifest']=={'path':'volatility_book/ch_discrete_vol/acceptance_manifest.json','sha256':expected}"
+    ],
+    "critical_lint": [
+      "ruff",
+      "check",
+      "--select",
+      "E9,F63,F7,F82,F811",
+      "volatility_book/ch_discrete_vol/round3.py"
+    ],
+    "d3_1_acceptance_smoke": [
+      "python",
+      "-m",
+      "volatility_book.ch_discrete_vol.run_study",
+      "--profile",
+      "smoke",
+      "--output-dir",
+      "outputs/volatility_book/ch_discrete_vol/acceptance_smoke"
+    ]
+  },
+  "stable_hash_policy": {
+    "raw_json_or_pdf_sha256_is_a_portable_golden": false,
+    "reason": "Raw artifacts contain runtime, repository revision/status, absolute paths, package versions, platform details, or PDF metadata.",
+    "canonical_json_v1": {
+      "source": "the D3.1 smoke results.json",
+      "delete_rules": [
+        "remove the top-level provenance member",
+        "remove runtime_seconds from every object under experiments"
+      ],
+      "serialization": {
+        "format": "UTF-8 JSON",
+        "sort_keys": true,
+        "separators": [
+          ",",
+          ":"
+        ],
+        "allow_nan": false,
+        "terminal_newline": false
+      }
+    },
+    "projection_v1": {
+      "contract_id": "d3_adoption_audit_v1",
+      "classification": "accepted audit-record hashes",
+      "projection_recipe_embedded": false,
+      "recomputable_from_this_manifest_alone": false,
+      "blocking": false,
+      "serialization": "The audited table or figure-data projection is serialized with the canonical_json_v1 JSON settings before SHA-256.",
+      "scope": "Projection hashes record independently audited table and figure-related inputs. Historical broad selectors can include corroborating non-plotted diagnostics; entry-specific caveats identify them. The tracked manifest does not invent the audit's field selectors, so these hashes are corroborating records rather than self-contained gates."
+    },
+    "tracked_text_sha256": {
+      "policy": "Hash canonical Git blob content, or explicitly normalize text to LF, rather than hashing a text=auto Windows working copy.",
+      "principal_brief_canonical_lf_sha256": "ae82dda4dda826dc199707a2f0aeef117195fd083815738c5248b50b3a0ff814",
+      "round3_brief_canonical_lf_sha256": "66f466de95cab34079635f17afc2163a74290f38ad26017abf8c52f439400a3b",
+      "tracked_note_canonical_lf_sha256": "f8b951c8b9c02ba819eb54595de9fbdcdc328e4a85621b72a7373877860dd1c1"
+    }
+  },
+  "accepted_d3_1_smoke": {
+    "canonical_payload": {
+      "sha256": "02443b3bf27e357a049b41320840f9adfb8bf6215557eb77369977047e096e98",
+      "byte_length": 193875,
+      "recomputable_from_this_manifest": true,
+      "blocking": true
+    },
+    "table_projection": {
+      "sha256": "4ac37f97539137d6dead2c403bcdae262f04b2e3ab2ab31d66fd88d8294511e2"
+    },
+    "figure_data_projection": {
+      "sha256": "c50a09a758166a4d2016a34ef6cffb7377c8d66d8d08759bcd079b3d69718d7b",
+      "classification": "historical D3.0 broad figure-audit projection",
+      "blocking": false,
+      "caveat": "The historical selector also included six non-plotted E2 likelihood-weight and ESS diagnostics. Restoring only their D3.0 roundoff values reproduces this hash; it is not a direct golden for the current D3.1 payload."
+    },
+    "plotted_fields_projection": {
+      "sha256": "1ef975ae1796a2d9a0945a50a9fbfd13de66e83a560321db78d5d3bc8d1d15a3",
+      "classification": "independently audited fields consumed by the plotting functions",
+      "d3_0_and_d3_1_identical": true,
+      "blocking": false
+    },
+    "e1_table_projection": {
+      "sha256": "be00595a73ccbecf737592c16f725ce67f9c3de8091b52b014d94777a03ac59a"
+    },
+    "e2_table_projection": {
+      "sha256": "0b820124665bc4a7a2f697822a2d59ffe22094c26679f96deecad145f830bf04"
+    },
+    "expected_verdicts": {
+      "mandatory_checks": true,
+      "E1": true,
+      "E2": true,
+      "E3": true,
+      "E4": false,
+      "E4_interpretation": "expected documented negative finding",
+      "E5_brief_claim": false,
+      "E5_corrected_claim": true,
+      "E6": false,
+      "E6_interpretation": "expected documented negative finding",
+      "E7": "measurement_only"
+    },
+    "pdf_structure": {
+      "pages": 8,
+      "ordered_experiment_titles": [
+        "E1 - Option prices versus the continuous affine pricer",
+        "E2 - Exact-Q, reweighted-P, and limit-Q kernel consistency",
+        "E3 - Stationary recursion versus the GIG law",
+        "E4 - Spot moments near the sufficient martingale boundary",
+        "E5 - Fixed-step Kesten tails versus the inverse-gamma limit",
+        "E6 - Filtering across observation scales",
+        "E7 - QMLE recovery and identification"
+      ]
+    },
+    "deterministic_contract": {
+      "base_seed": 20260823,
+      "experiment_seeds": {
+        "E1": 20260824,
+        "E2": 20260825,
+        "E3": 20260826,
+        "E4": 20260827,
+        "E5": 20260828,
+        "E6": 20260829,
+        "E7": 20260830
+      },
+      "pricing_paths": 2048,
+      "mandatory_check_paths": 1024,
+      "dt": [
+        "1/52",
+        "1/1008"
+      ],
+      "maturity_years": 0.25,
+      "generator": "numpy.random.Generator(PCG64)",
+      "antithetic_layout": "first-half draws, then their negatives"
+    },
+    "cross_round_blocking_gates": [
+      {
+        "stage": "round2",
+        "gate": "R1",
+        "blocking": true,
+        "accepted_value": true,
+        "historical_full_archive_passed": true,
+        "field": "R1.blocking_gate_passed",
+        "requirement": "The full Round-1 archive and clean reference rerun must pass the R1 stability comparison before R2--R6 start."
+      },
+      {
+        "stage": "round3",
+        "gate": "R6",
+        "blocking": true,
+        "accepted_value": true,
+        "historical_full_archive_passed": true,
+        "field": "R6.blocking_requirement_satisfied",
+        "requirement": "At FULL profile, the complete E1 stability comparison and clean E3 acceptance/sample archive obligation must pass before R7--R9 close."
+      }
+    ]
+  },
+  "archived_provenance_only_hashes": {
+    "classification": "Historical execution evidence; not portable numerical goldens and not fresh-checkout dependencies.",
+    "instability_sources": [
+      "repository revision and status",
+      "absolute execution paths",
+      "package and platform versions",
+      "runtime duration",
+      "PDF metadata where applicable"
+    ],
+    "artifacts": [
+      {
+        "name": "archived round-one results.json",
+        "sha256": "f4c08fe9a5df7b1967a57155d93762ff78d87463f3d774223427a21705629196",
+        "portable_acceptance": false,
+        "blocking": false
+      },
+      {
+        "name": "archived round-two results.json",
+        "sha256": "81533986fc77e6458077109c665ed09f4f236edfb6dd4ce4b75ad4d2d49d18f5",
+        "portable_acceptance": false,
+        "blocking": false
+      },
+      {
+        "name": "archived round-three results.json",
+        "sha256": "bb7ce225f674ef9be313c08c8ed765a0a4e2bd4adda1084c68dbb4430df81091",
+        "portable_acceptance": false,
+        "blocking": false,
+        "caveat": "This archive predates report-only source corrections, so its executed-input ledger is not the current tracked ledger."
+      },
+      {
+        "name": "archived Round-3 stationary samples NPZ",
+        "sha256": "81e3f26d301e1a08dc4716c4b4fca97a2e03e5304ee4658c86b93e5644867de1",
+        "portable_acceptance": false,
+        "blocking": false
+      },
+      {
+        "name": "archived generated cited-number manifest",
+        "sha256": "5a317c7ae4eaa23a2a5f43ffec5301e65ccc89643160632d05f3c44c33a69127",
+        "portable_acceptance": false,
+        "blocking": false,
+        "archived_checks": {
+          "cited_values": 40,
+          "prose_checks": 24,
+          "all_passed": true
+        }
+      }
+    ]
+  },
+  "artifact_policy": {
+    "allowed_tracked_outputs": [],
+    "generated_extensions": [
+      ".json",
+      ".md",
+      ".pdf",
+      ".npz"
+    ],
+    "generated_location": "By default and recommendation, beneath the ignored repository output root. An explicit --output-dir override remains supported and is the caller's responsibility.",
+    "regeneration_policy": "Do not silently replace an accepted portable hash or an archived provenance hash. Record and review any intentional baseline change."
+  }
+}

--- a/volatility_book/ch_discrete_vol/experiments.py
+++ b/volatility_book/ch_discrete_vol/experiments.py
@@ -27,11 +27,14 @@ from scipy.optimize import brentq, minimize
 from scipy.stats import gaussian_kde, geninvgauss, invgamma
 
 import stochvolmodels as svm
+from stochvolmodels.products.payoffs import EuropeanOptionPayoff
+from stochvolmodels.valuation import PathEstimator, PathValuationResult, value_paths
 from volatility_book.ch_discrete_vol.sim import (
     M1,
     S1,
     LimitParams,
     Measure,
+    SimulationResult,
     TgarchParams,
     derived_limit_params,
     filter_discrete_returns,
@@ -279,27 +282,43 @@ def _pair_arrays(values: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     return values[:half], values[half:]
 
 
+def _antithetic_group_ids(n_paths: int) -> np.ndarray:
+    """Declare the simulator's first-half/second-half antithetic provenance."""
+    if isinstance(n_paths, (bool, np.bool_)) or not isinstance(n_paths, (int, np.integer)):
+        raise ValueError("n_paths must be an integer")
+    if n_paths < 4 or n_paths % 2:
+        raise ValueError("antithetic valuation requires an even n_paths of at least four")
+    return np.tile(np.arange(n_paths // 2, dtype=np.int64), 2)
+
+
+def _discounted_pair_values(
+    values: np.ndarray,
+    discount: float,
+    weights: np.ndarray | None = None,
+) -> np.ndarray:
+    """Return discounted antithetic pair contributions, optionally raw-LR weighted."""
+    left, right = _pair_arrays(np.asarray(values, dtype=np.float64))
+    left = discount * left
+    right = discount * right
+    if weights is not None:
+        weight_left, weight_right = _pair_arrays(np.asarray(weights, dtype=np.float64))
+        if weight_left.shape != left.shape:
+            raise ValueError("weights must have the same length as values")
+        left = weight_left * left
+        right = weight_right * right
+    return 0.5 * (left + right)
+
+
 def _controlled_call_pair_values(
-    terminal_spot: np.ndarray,
-    strike: float,
+    call_values: np.ndarray,
+    spot_values: np.ndarray,
     discount: float,
     expected_discounted_spot: float,
     weights: np.ndarray | None = None,
 ) -> tuple[np.ndarray, float]:
     """Return antithetic pair contributions after the terminal-spot control variate."""
-    left, right = _pair_arrays(np.asarray(terminal_spot, dtype=np.float64))
-    payoff_left = discount * np.maximum(left - strike, 0.0)
-    payoff_right = discount * np.maximum(right - strike, 0.0)
-    spot_left = discount * left
-    spot_right = discount * right
-    if weights is not None:
-        weight_left, weight_right = _pair_arrays(np.asarray(weights, dtype=np.float64))
-        payoff_left = weight_left * payoff_left
-        payoff_right = weight_right * payoff_right
-        spot_left = weight_left * spot_left
-        spot_right = weight_right * spot_right
-    pair_payoff = 0.5 * (payoff_left + payoff_right)
-    pair_spot = 0.5 * (spot_left + spot_right)
+    pair_payoff = _discounted_pair_values(call_values, discount, weights)
+    pair_spot = _discounted_pair_values(spot_values, discount, weights)
     spot_variance = float(np.var(pair_spot, ddof=1))
     if spot_variance <= 1.0e-30:
         coefficient = 0.0
@@ -314,6 +333,104 @@ def _mean_and_se(pair_values: np.ndarray) -> tuple[float, float]:
     if values.ndim != 1 or values.size < 2:
         raise ValueError("at least two antithetic pair values are required")
     return float(np.mean(values)), float(np.std(values, ddof=1) / math.sqrt(values.size))
+
+
+def _assert_close(actual: float, expected: float, label: str) -> None:
+    """Enforce a tight machine-roundoff invariant between adopted and local estimators."""
+    if not math.isfinite(actual) or not math.isfinite(expected):
+        raise RuntimeError(f"{label} must be finite: actual={actual!r}, expected={expected!r}")
+    if not math.isclose(actual, expected, rel_tol=2.0e-13, abs_tol=2.0e-15):
+        raise RuntimeError(f"{label} mismatch: actual={actual!r}, expected={expected!r}")
+
+
+def _value_european_leg(
+    *,
+    simulated: SimulationResult,
+    payoff: EuropeanOptionPayoff,
+    discount: float,
+    independent_group_ids: np.ndarray,
+    expected_estimator: PathEstimator,
+) -> tuple[np.ndarray, PathValuationResult]:
+    """Evaluate one package-owned payoff and validate its raw valuation contract."""
+    payoff_values = payoff(simulated.paths)
+    result = value_paths(
+        paths=simulated.paths,
+        payoff=payoff,
+        discount_factor=discount,
+        independent_group_ids=independent_group_ids,
+    )
+    expected_groups = simulated.n_paths // 2
+    if result.estimator is not expected_estimator:
+        raise RuntimeError(
+            f"unexpected estimator: {result.estimator.value}, expected {expected_estimator.value}"
+        )
+    if result.standard_error_basis != "independent_groups":
+        raise RuntimeError("antithetic valuation must use independent-group standard errors")
+    if (
+        result.n_paths != simulated.n_paths
+        or result.n_independent_groups != expected_groups
+        or result.group_size != 2
+    ):
+        raise RuntimeError("valuation did not preserve the declared antithetic grouping")
+    if result.settlement_unit != payoff.settlement_unit:
+        raise RuntimeError("valuation settlement unit differs from the payoff unit")
+    if result.recenter_shift is not None:
+        raise RuntimeError("chapter valuations must not apply legacy forward recentering")
+    if expected_estimator is PathEstimator.MONTE_CARLO:
+        if result.mean_likelihood_ratio is not None or result.log_mean_likelihood_ratio is not None:
+            raise RuntimeError("direct Monte Carlo valuation unexpectedly used likelihood ratios")
+        _assert_close(result.path_effective_sample_size, float(simulated.n_paths), "path ESS")
+        _assert_close(result.group_effective_sample_size, float(expected_groups), "group ESS")
+    else:
+        if expected_estimator is not PathEstimator.RAW_LIKELIHOOD_RATIO:
+            raise RuntimeError("chapter valuation supports only raw likelihood-ratio weighting")
+        if result.mean_likelihood_ratio is None or result.log_mean_likelihood_ratio is None:
+            raise RuntimeError("raw likelihood-ratio diagnostics are missing")
+        if not (
+            0.0 < result.path_effective_sample_size <= simulated.n_paths * (1.0 + 1.0e-12)
+            and 0.0
+            < result.group_effective_sample_size
+            <= expected_groups * (1.0 + 1.0e-12)
+        ):
+            raise RuntimeError("raw likelihood-ratio ESS lies outside its valid range")
+    _assert_close(
+        result.path_ess_fraction,
+        result.path_effective_sample_size / simulated.n_paths,
+        "path ESS fraction",
+    )
+    _assert_close(
+        result.group_ess_fraction,
+        result.group_effective_sample_size / expected_groups,
+        "group ESS fraction",
+    )
+    return payoff_values, result
+
+
+def _assert_pair_valuation(
+    result: PathValuationResult,
+    pair_values: np.ndarray,
+    label: str,
+) -> None:
+    """Cross-check package value and grouped SE against chapter-local pair contributions."""
+    local_value, local_standard_error = _mean_and_se(pair_values)
+    _assert_close(result.value, local_value, f"{label} value")
+    _assert_close(result.standard_error, local_standard_error, f"{label} standard error")
+
+
+def _assert_control_identity(
+    *,
+    adjusted_value: float,
+    call_result: PathValuationResult,
+    spot_result: PathValuationResult,
+    coefficient: float,
+    expected_discounted_spot: float,
+    label: str,
+) -> None:
+    """Check the raw fitted-control identity without normalizing likelihood weights."""
+    expected = call_result.value - coefficient * (
+        spot_result.value - expected_discounted_spot
+    )
+    _assert_close(adjusted_value, expected, f"{label} controlled value")
 
 
 def _ivols_and_se(
@@ -403,6 +520,23 @@ def run_e1(
             )
             discount = math.exp(-params.r * maturity)
             forward = params.spot0 * math.exp(params.r * maturity)
+            spot_payoff = EuropeanOptionPayoff(
+                asset_id="spot",
+                expiry=maturity,
+                strike=0.0,
+                option_type="C",
+                unit="spot units",
+            )
+            call_payoffs = tuple(
+                EuropeanOptionPayoff(
+                    asset_id="spot",
+                    expiry=maturity,
+                    strike=float(strike),
+                    option_type="C",
+                    unit="spot units",
+                )
+                for strike in strikes
+            )
             for dt in config.dt_grid:
                 n_paths = config.pricing_paths(dt)
                 simulated = simulate_terminal(
@@ -413,20 +547,51 @@ def run_e1(
                     n_paths=n_paths,
                     seed=seed,
                 )
-                pair_values: list[np.ndarray] = []
+                group_ids = _antithetic_group_ids(n_paths)
+                spot_values, spot_result = _value_european_leg(
+                    simulated=simulated,
+                    payoff=spot_payoff,
+                    discount=discount,
+                    independent_group_ids=group_ids,
+                    expected_estimator=PathEstimator.MONTE_CARLO,
+                )
+                _assert_pair_valuation(
+                    spot_result,
+                    _discounted_pair_values(spot_values, discount),
+                    "E1 discounted spot",
+                )
                 coefficients: list[float] = []
                 prices = np.empty(strikes.size)
                 price_se = np.empty(strikes.size)
-                for index, strike in enumerate(strikes):
+                for index, call_payoff in enumerate(call_payoffs):
+                    call_values, call_result = _value_european_leg(
+                        simulated=simulated,
+                        payoff=call_payoff,
+                        discount=discount,
+                        independent_group_ids=group_ids,
+                        expected_estimator=PathEstimator.MONTE_CARLO,
+                    )
+                    _assert_pair_valuation(
+                        call_result,
+                        _discounted_pair_values(call_values, discount),
+                        "E1 call",
+                    )
                     adjusted, coefficient = _controlled_call_pair_values(
-                        terminal_spot=simulated.terminal_spot,
-                        strike=float(strike),
+                        call_values=call_values,
+                        spot_values=spot_values,
                         discount=discount,
                         expected_discounted_spot=params.spot0,
                     )
-                    pair_values.append(adjusted)
                     coefficients.append(coefficient)
                     prices[index], price_se[index] = _mean_and_se(adjusted)
+                    _assert_control_identity(
+                        adjusted_value=prices[index],
+                        call_result=call_result,
+                        spot_result=spot_result,
+                        coefficient=coefficient,
+                        expected_discounted_spot=params.spot0,
+                        label="E1",
+                    )
                 mc_ivols, mc_ivol_se = _ivols_and_se(
                     maturity=maturity,
                     forward=forward,
@@ -525,18 +690,17 @@ def run_e1(
     }
 
 
-def _stable_weights(log_weights: np.ndarray) -> tuple[np.ndarray, float, float]:
+def _raw_likelihood_weights(log_weights: np.ndarray | None) -> np.ndarray:
+    """Restore raw likelihood ratios for chapter-local paired-control contributions."""
+    if not isinstance(log_weights, np.ndarray):
+        raise ValueError("log_weights must be a NumPy array")
     logs = np.asarray(log_weights, dtype=np.float64)
     if logs.ndim != 1 or not np.all(np.isfinite(logs)):
         raise ValueError("log_weights must be a finite one-dimensional array")
     maximum = float(np.max(logs))
     scaled = np.exp(logs - maximum)
     scale = math.exp(maximum)
-    weights = scale * scaled
-    mean_weight = float(np.mean(weights))
-    total = float(np.sum(scaled))
-    ess = total * total / float(np.sum(np.square(scaled)))
-    return weights, mean_weight, ess
+    return scale * scaled
 
 
 def run_e2(
@@ -551,6 +715,20 @@ def run_e2(
         limit = derived_limit_params(params)
         strike = params.spot0
         discount = math.exp(-params.r * maturity)
+        call_payoff = EuropeanOptionPayoff(
+            asset_id="spot",
+            expiry=maturity,
+            strike=strike,
+            option_type="C",
+            unit="spot units",
+        )
+        spot_payoff = EuropeanOptionPayoff(
+            asset_id="spot",
+            expiry=maturity,
+            strike=0.0,
+            option_type="C",
+            unit="spot units",
+        )
         for dt in config.dt_grid:
             n_paths = config.pricing_paths(dt)
             exact = simulate_terminal(
@@ -579,23 +757,96 @@ def run_e2(
                 seed=seed,
                 limit_params=limit,
             )
-            weights, mean_weight, ess = _stable_weights(physical.log_weights)
+            group_ids = _antithetic_group_ids(n_paths)
+            weights = _raw_likelihood_weights(physical.log_weights)
+            exact_call_values, exact_call_result = _value_european_leg(
+                simulated=exact,
+                payoff=call_payoff,
+                discount=discount,
+                independent_group_ids=group_ids,
+                expected_estimator=PathEstimator.MONTE_CARLO,
+            )
+            exact_spot_values, exact_spot_result = _value_european_leg(
+                simulated=exact,
+                payoff=spot_payoff,
+                discount=discount,
+                independent_group_ids=group_ids,
+                expected_estimator=PathEstimator.MONTE_CARLO,
+            )
+            weighted_call_values, weighted_call_result = _value_european_leg(
+                simulated=physical,
+                payoff=call_payoff,
+                discount=discount,
+                independent_group_ids=group_ids,
+                expected_estimator=PathEstimator.RAW_LIKELIHOOD_RATIO,
+            )
+            weighted_spot_values, weighted_spot_result = _value_european_leg(
+                simulated=physical,
+                payoff=spot_payoff,
+                discount=discount,
+                independent_group_ids=group_ids,
+                expected_estimator=PathEstimator.RAW_LIKELIHOOD_RATIO,
+            )
+            limit_call_values, limit_call_result = _value_european_leg(
+                simulated=limit_sim,
+                payoff=call_payoff,
+                discount=discount,
+                independent_group_ids=group_ids,
+                expected_estimator=PathEstimator.MONTE_CARLO,
+            )
+            limit_spot_values, limit_spot_result = _value_european_leg(
+                simulated=limit_sim,
+                payoff=spot_payoff,
+                discount=discount,
+                independent_group_ids=group_ids,
+                expected_estimator=PathEstimator.MONTE_CARLO,
+            )
+            _assert_pair_valuation(
+                exact_call_result,
+                _discounted_pair_values(exact_call_values, discount),
+                "E2 exact call",
+            )
+            _assert_pair_valuation(
+                exact_spot_result,
+                _discounted_pair_values(exact_spot_values, discount),
+                "E2 exact spot",
+            )
+            _assert_pair_valuation(
+                weighted_call_result,
+                _discounted_pair_values(weighted_call_values, discount, weights),
+                "E2 weighted call",
+            )
+            _assert_pair_valuation(
+                weighted_spot_result,
+                _discounted_pair_values(weighted_spot_values, discount, weights),
+                "E2 weighted spot",
+            )
+            _assert_pair_valuation(
+                limit_call_result,
+                _discounted_pair_values(limit_call_values, discount),
+                "E2 limit call",
+            )
+            _assert_pair_valuation(
+                limit_spot_result,
+                _discounted_pair_values(limit_spot_values, discount),
+                "E2 limit spot",
+            )
             exact_pairs, exact_cv = _controlled_call_pair_values(
-                terminal_spot=exact.terminal_spot,
-                strike=strike,
+                call_values=exact_call_values,
+                spot_values=exact_spot_values,
                 discount=discount,
                 expected_discounted_spot=params.spot0,
             )
             weighted_pairs, weighted_cv = _controlled_call_pair_values(
-                terminal_spot=physical.terminal_spot,
-                strike=strike,
+                call_values=weighted_call_values,
+                spot_values=weighted_spot_values,
                 discount=discount,
                 expected_discounted_spot=params.spot0,
                 weights=weights,
             )
             limit_pairs, limit_cv = _controlled_call_pair_values(
-                terminal_spot=limit_sim.terminal_spot,
-                strike=strike,
+                call_values=limit_call_values,
+                spot_values=limit_spot_values,
                 discount=discount,
                 expected_discounted_spot=params.spot0,
             )
@@ -606,6 +857,49 @@ def run_e2(
             limit_minus_exact = limit_pairs - exact_pairs
             difference_ab, difference_ab_se = _mean_and_se(exact_minus_weighted)
             difference_ca, difference_ca_se = _mean_and_se(limit_minus_exact)
+            _assert_control_identity(
+                adjusted_value=exact_price,
+                call_result=exact_call_result,
+                spot_result=exact_spot_result,
+                coefficient=exact_cv,
+                expected_discounted_spot=params.spot0,
+                label="E2 exact",
+            )
+            _assert_control_identity(
+                adjusted_value=weighted_price,
+                call_result=weighted_call_result,
+                spot_result=weighted_spot_result,
+                coefficient=weighted_cv,
+                expected_discounted_spot=params.spot0,
+                label="E2 weighted raw-LR",
+            )
+            _assert_control_identity(
+                adjusted_value=limit_price,
+                call_result=limit_call_result,
+                spot_result=limit_spot_result,
+                coefficient=limit_cv,
+                expected_discounted_spot=params.spot0,
+                label="E2 limit",
+            )
+            mean_weight = weighted_call_result.mean_likelihood_ratio
+            spot_mean_weight = weighted_spot_result.mean_likelihood_ratio
+            if mean_weight is None or spot_mean_weight is None:
+                raise RuntimeError("E2 raw likelihood-ratio mean diagnostic is missing")
+            _assert_close(spot_mean_weight, mean_weight, "E2 call/spot mean likelihood ratio")
+            _assert_close(
+                weighted_spot_result.path_effective_sample_size,
+                weighted_call_result.path_effective_sample_size,
+                "E2 call/spot path ESS",
+            )
+            ess = weighted_call_result.path_effective_sample_size
+            if physical.effective_sample_size is None or physical.ess_fraction is None:
+                raise RuntimeError("E2 simulator likelihood-ratio diagnostics are missing")
+            _assert_close(ess, physical.effective_sample_size, "E2 valuation/simulator path ESS")
+            _assert_close(
+                weighted_call_result.path_ess_fraction,
+                physical.ess_fraction,
+                "E2 valuation/simulator ESS fraction",
+            )
             records.append(
                 {
                     "parameter_set": name,
@@ -867,6 +1161,14 @@ def run_e4(
     """
     seed = BASE_SEED + 4
     maturity = 1.0 / 4.0
+    discount = math.exp(-params.r * maturity)
+    spot_payoff = EuropeanOptionPayoff(
+        asset_id="spot",
+        expiry=maturity,
+        strike=0.0,
+        option_type="C",
+        unit="spot units",
+    )
     base = derived_limit_params(params)
     records: list[dict[str, Any]] = []
     for dt in config.dt_grid:
@@ -880,6 +1182,19 @@ def run_e4(
                 n_paths=config.e4_paths,
                 seed=seed,
                 limit_params=limit,
+            )
+            group_ids = _antithetic_group_ids(config.e4_paths)
+            spot_values, spot_result = _value_european_leg(
+                simulated=simulated,
+                payoff=spot_payoff,
+                discount=discount,
+                independent_group_ids=group_ids,
+                expected_estimator=PathEstimator.MONTE_CARLO,
+            )
+            _assert_pair_valuation(
+                spot_result,
+                _discounted_pair_values(spot_values, discount),
+                "E4 discounted spot diagnostic",
             )
             for power in MOMENT_POWERS:
                 pair_values, path_values = _power_pair_values(simulated.terminal_log_spot, power)

--- a/volatility_book/ch_discrete_vol/experiments.py
+++ b/volatility_book/ch_discrete_vol/experiments.py
@@ -1,0 +1,1625 @@
+"""Experiments for the discrete-versus-continuous TGARCH study.
+
+All volatilities and rates are annualised, time is measured in years, and
+returns are log returns.  This repository-only module intentionally keeps
+simulation and reporting outside the public :mod:`stochvolmodels` package.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import json
+import math
+import platform
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, replace
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+from numba import njit
+from scipy.integrate import quad
+from scipy.optimize import brentq, minimize
+from scipy.stats import gaussian_kde, geninvgauss, invgamma
+
+import stochvolmodels as svm
+from volatility_book.ch_discrete_vol.sim import (
+    M1,
+    S1,
+    LimitParams,
+    Measure,
+    TgarchParams,
+    derived_limit_params,
+    filter_discrete_returns,
+    run_unit_checks,
+    simulate_discrete_path,
+    simulate_stationary_sigma,
+    simulate_terminal,
+    simulate_two_shock_limit_path,
+)
+
+DT_GRID = (1.0 / 52.0, 1.0 / 252.0, 1.0 / 1008.0, 1.0 / 4032.0, 1.0 / 16128.0)
+MATURITIES = (1.0 / 12.0, 1.0 / 4.0)
+MONEYNESS_MULTIPLIERS = np.array((-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0))
+KAPPA2_MOMENT_GRID = (0.0, 0.5, 1.0, 2.0, 4.25)
+MOMENT_POWERS = (1.25, 1.5)
+BASE_SEED = 20260823
+
+
+class StudyProfile(str, Enum):
+    """Execution size for development, reference analysis, or the full brief."""
+
+    SMOKE = "smoke"
+    REFERENCE = "reference"
+    FULL = "full"
+
+
+@dataclass(frozen=True)
+class StudyConfig:
+    """Numerical workload selected by :class:`StudyProfile`."""
+
+    profile: StudyProfile
+    dt_grid: tuple[float, ...]
+    maturities: tuple[float, ...]
+    unit_paths: int
+    moment_check_draws: int
+    e4_paths: int
+    bootstrap_replications: int
+    stationary_burn_years: float
+    stationary_sample_years: float
+    e5_sample_years: float
+    e6_years: float
+    e7_replications: int
+    e7_parameter_sets: tuple[str, ...]
+
+    def pricing_paths(self, dt: float) -> int:
+        """Return the brief's path count, or its profile-specific development analogue."""
+        if self.profile is StudyProfile.FULL:
+            return 2**19 if dt >= 1.0 / 1008.0 - 1.0e-15 else 2**17
+        if self.profile is StudyProfile.REFERENCE:
+            return 2**15 if dt >= 1.0 / 1008.0 - 1.0e-15 else 2**14
+        return 2**11
+
+
+@dataclass
+class StudyResults:
+    """In-memory results used by the Markdown, JSON, and PDF writers."""
+
+    profile: str
+    config: dict[str, Any]
+    parameters: dict[str, Any]
+    checks: dict[str, Any]
+    experiments: dict[str, Any]
+    provenance: dict[str, Any]
+    warnings: list[str]
+
+
+def make_study_config(profile: StudyProfile) -> StudyConfig:
+    """Create a validated workload configuration."""
+    if not isinstance(profile, StudyProfile):
+        raise ValueError("profile must be a StudyProfile")
+    if profile is StudyProfile.FULL:
+        return StudyConfig(
+            profile=profile,
+            dt_grid=DT_GRID,
+            maturities=MATURITIES,
+            unit_paths=2**16,
+            moment_check_draws=2**20,
+            e4_paths=2**17,
+            bootstrap_replications=400,
+            stationary_burn_years=50.0,
+            stationary_sample_years=500.0,
+            e5_sample_years=1000.0,
+            e6_years=40.0,
+            e7_replications=200,
+            e7_parameter_sets=("crypto", "equity"),
+        )
+    if profile is StudyProfile.REFERENCE:
+        return StudyConfig(
+            profile=profile,
+            dt_grid=DT_GRID,
+            maturities=MATURITIES,
+            unit_paths=2**13,
+            moment_check_draws=2**18,
+            e4_paths=2**14,
+            bootstrap_replications=200,
+            stationary_burn_years=15.0,
+            stationary_sample_years=150.0,
+            e5_sample_years=300.0,
+            e6_years=20.0,
+            e7_replications=32,
+            e7_parameter_sets=("crypto", "equity"),
+        )
+    return StudyConfig(
+        profile=profile,
+        dt_grid=(1.0 / 52.0, 1.0 / 1008.0),
+        maturities=(1.0 / 4.0,),
+        unit_paths=2**10,
+        moment_check_draws=2**14,
+        e4_paths=2**10,
+        bootstrap_replications=40,
+        stationary_burn_years=2.0,
+        stationary_sample_years=8.0,
+        e5_sample_years=20.0,
+        e6_years=3.0,
+        e7_replications=2,
+        e7_parameter_sets=("crypto",),
+    )
+
+
+def parameter_sets() -> dict[str, TgarchParams]:
+    """Return the two parameter sets specified by the brief."""
+    shared = {
+        "r": 0.0,
+        "gamma0": 0.0,
+        "gamma1": 0.5,
+        "eta0": 0.0,
+        "eta1": -0.38,
+        "spot0": 1.0,
+    }
+    return {
+        "crypto": TgarchParams(
+            theta=0.6,
+            kappa1=3.0,
+            kappa2=3.0,
+            beta=1.0,
+            eps=1.5,
+            sigma0=0.6,
+            **shared,
+        ),
+        "equity": TgarchParams(
+            theta=0.2,
+            kappa1=4.0,
+            kappa2=4.0,
+            beta=-1.0,
+            eps=1.0,
+            sigma0=0.2,
+            **shared,
+        ),
+    }
+
+
+def _as_jsonable(value: Any) -> Any:
+    """Convert NumPy and dataclass values to JSON-compatible Python values."""
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, Enum):
+        return value.value
+    if hasattr(value, "__dataclass_fields__"):
+        return {key: _as_jsonable(item) for key, item in asdict(value).items()}
+    if isinstance(value, dict):
+        return {str(key): _as_jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_as_jsonable(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+    return value
+
+
+def _sha256(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _git_output(repository: Path, *arguments: str) -> str:
+    try:
+        completed = subprocess.run(
+            ["git", "-c", "safe.directory=*", "-C", str(repository), *arguments],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unavailable"
+    return completed.stdout.strip()
+
+
+def collect_provenance(output_dir: Path, profile: StudyProfile) -> dict[str, Any]:
+    """Collect source hashes, versions, seeds, and the enclosing repository revision."""
+    repo = Path(__file__).resolve().parents[2]
+    code_dir = Path(__file__).resolve().parent
+    source_files = ("sim.py", "experiments.py", "reporting.py", "run_study.py")
+    packages = ("numpy", "scipy", "matplotlib", "numba", "pandas", "stochvolmodels")
+    versions: dict[str, str] = {}
+    for package in packages:
+        try:
+            versions[package] = importlib.metadata.version(package)
+        except importlib.metadata.PackageNotFoundError:
+            versions[package] = "not-installed"
+    return {
+        "script": "python -m volatility_book.ch_discrete_vol.run_study",
+        "profile": profile.value,
+        "python": sys.version.replace("\n", " "),
+        "platform": platform.platform(),
+        "package_versions": versions,
+        "repository_head": _git_output(repo, "rev-parse", "HEAD"),
+        "repository_describe": _git_output(repo, "describe", "--tags", "--always", "--dirty"),
+        "repository_status": _git_output(repo, "status", "--short"),
+        "study_folder_git_tag": "N/A: the Volatility Book folder is not a Git repository",
+        "code_sha256": {name: _sha256(code_dir / name) for name in source_files},
+        "input_sha256": {
+            "brief": _sha256(
+                output_dir / "2026-08-23_SOL_BRIEF_discrete_vs_continuous_tgarch_study.md"
+            ),
+            "note": _sha256(output_dir / "tgarch_quadratic_drift_note.tex"),
+        },
+        "seeds": {f"E{index}": BASE_SEED + index for index in range(1, 8)},
+    }
+
+
+def _limit_with_kappa2(base: LimitParams, kappa2_hat: float) -> LimitParams:
+    """Hold ``d0`` and ``d1_hat`` fixed while changing the quadratic coefficient."""
+    if not np.isfinite(kappa2_hat) or kappa2_hat < 0.0:
+        raise ValueError("kappa2_hat must be finite and non-negative")
+    return LimitParams.from_drift_coefficients(
+        d0=base.d0,
+        d1_hat=base.d1_hat,
+        kappa2_hat=kappa2_hat,
+        lambda0_bar=base.lambda0_bar,
+        lambda1_bar=base.lambda1_bar,
+        vartheta=base.vartheta,
+    )
+
+
+def _pair_arrays(values: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    if values.ndim != 1 or values.size % 2 != 0:
+        raise ValueError("antithetic values must be a one-dimensional even-length array")
+    half = values.size // 2
+    return values[:half], values[half:]
+
+
+def _controlled_call_pair_values(
+    terminal_spot: np.ndarray,
+    strike: float,
+    discount: float,
+    expected_discounted_spot: float,
+    weights: np.ndarray | None = None,
+) -> tuple[np.ndarray, float]:
+    """Return antithetic pair contributions after the terminal-spot control variate."""
+    left, right = _pair_arrays(np.asarray(terminal_spot, dtype=np.float64))
+    payoff_left = discount * np.maximum(left - strike, 0.0)
+    payoff_right = discount * np.maximum(right - strike, 0.0)
+    spot_left = discount * left
+    spot_right = discount * right
+    if weights is not None:
+        weight_left, weight_right = _pair_arrays(np.asarray(weights, dtype=np.float64))
+        payoff_left = weight_left * payoff_left
+        payoff_right = weight_right * payoff_right
+        spot_left = weight_left * spot_left
+        spot_right = weight_right * spot_right
+    pair_payoff = 0.5 * (payoff_left + payoff_right)
+    pair_spot = 0.5 * (spot_left + spot_right)
+    spot_variance = float(np.var(pair_spot, ddof=1))
+    if spot_variance <= 1.0e-30:
+        coefficient = 0.0
+    else:
+        coefficient = float(np.cov(pair_payoff, pair_spot, ddof=1)[0, 1] / spot_variance)
+    adjusted = pair_payoff - coefficient * (pair_spot - expected_discounted_spot)
+    return adjusted, coefficient
+
+
+def _mean_and_se(pair_values: np.ndarray) -> tuple[float, float]:
+    values = np.asarray(pair_values, dtype=np.float64)
+    if values.ndim != 1 or values.size < 2:
+        raise ValueError("at least two antithetic pair values are required")
+    return float(np.mean(values)), float(np.std(values, ddof=1) / math.sqrt(values.size))
+
+
+def _ivols_and_se(
+    *,
+    maturity: float,
+    forward: float,
+    discount: float,
+    strikes: np.ndarray,
+    prices: np.ndarray,
+    price_se: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    optiontypes = np.full(strikes.size, "C")
+    ivols = svm.infer_bsm_ivols_from_slice_prices(
+        ttm=maturity,
+        forward=forward,
+        discfactor=discount,
+        strikes=strikes,
+        optiontypes=optiontypes,
+        model_prices=prices,
+    )
+    vegas = np.array(
+        [
+            svm.compute_bsm_vanilla_vega(
+                ttm=maturity,
+                forward=forward,
+                strike=float(strike),
+                vol=float(ivol),
+                discfactor=discount,
+            )
+            for strike, ivol in zip(strikes, ivols)
+        ]
+    )
+    ivol_se = np.divide(
+        price_se,
+        vegas,
+        out=np.full_like(price_se, np.nan),
+        where=vegas > 1.0e-12,
+    )
+    return ivols, ivol_se
+
+
+def _affine_slice(
+    *,
+    params: TgarchParams,
+    limit: LimitParams,
+    maturity: float,
+    strikes: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    model_params = svm.LogSvParams(
+        sigma0=params.sigma0,
+        theta=limit.theta_hat,
+        kappa1=limit.kappa1_hat,
+        kappa2=limit.kappa2_hat,
+        beta=params.beta,
+        volvol=params.eps,
+    )
+    forward = params.spot0 * math.exp(params.r * maturity)
+    discount = math.exp(-params.r * maturity)
+    return svm.LogSVPricer().price_slice(
+        params=model_params,
+        ttm=maturity,
+        forward=forward,
+        strikes=strikes,
+        optiontypes=np.full(strikes.size, "C"),
+        discfactor=discount,
+    )
+
+
+def run_e1(
+    params_by_name: dict[str, TgarchParams],
+    config: StudyConfig,
+) -> dict[str, Any]:
+    """E1: compare exact discrete option IVs with the continuous affine expansion."""
+    records: list[dict[str, Any]] = []
+    seed = BASE_SEED + 1
+    for name, params in params_by_name.items():
+        limit = derived_limit_params(params)
+        for maturity in config.maturities:
+            strikes = params.spot0 * np.exp(
+                params.sigma0 * math.sqrt(maturity) * MONEYNESS_MULTIPLIERS
+            )
+            affine_prices, affine_ivols = _affine_slice(
+                params=params,
+                limit=limit,
+                maturity=maturity,
+                strikes=strikes,
+            )
+            discount = math.exp(-params.r * maturity)
+            forward = params.spot0 * math.exp(params.r * maturity)
+            for dt in config.dt_grid:
+                n_paths = config.pricing_paths(dt)
+                simulated = simulate_terminal(
+                    params=params,
+                    measure=Measure.Q_EXACT,
+                    maturity=maturity,
+                    max_dt=dt,
+                    n_paths=n_paths,
+                    seed=seed,
+                )
+                pair_values: list[np.ndarray] = []
+                coefficients: list[float] = []
+                prices = np.empty(strikes.size)
+                price_se = np.empty(strikes.size)
+                for index, strike in enumerate(strikes):
+                    adjusted, coefficient = _controlled_call_pair_values(
+                        terminal_spot=simulated.terminal_spot,
+                        strike=float(strike),
+                        discount=discount,
+                        expected_discounted_spot=params.spot0,
+                    )
+                    pair_values.append(adjusted)
+                    coefficients.append(coefficient)
+                    prices[index], price_se[index] = _mean_and_se(adjusted)
+                mc_ivols, mc_ivol_se = _ivols_and_se(
+                    maturity=maturity,
+                    forward=forward,
+                    discount=discount,
+                    strikes=strikes,
+                    prices=prices,
+                    price_se=price_se,
+                )
+                error_bp = 1.0e4 * (mc_ivols - affine_ivols)
+                records.append(
+                    {
+                        "parameter_set": name,
+                        "maturity": maturity,
+                        "dt": dt,
+                        "n_steps": simulated.n_steps,
+                        "n_paths": n_paths,
+                        "seed": seed,
+                        "strikes": strikes,
+                        "mc_prices": prices,
+                        "mc_price_se": price_se,
+                        "mc_ivols": mc_ivols,
+                        "mc_ivol_se": mc_ivol_se,
+                        "affine_prices": affine_prices,
+                        "affine_ivols": affine_ivols,
+                        "error_bp": error_bp,
+                        "mean_abs_error_bp": float(np.nanmean(np.abs(error_bp))),
+                        "max_abs_error_bp": float(np.nanmax(np.abs(error_bp))),
+                        "mean_ivol_se_bp": float(1.0e4 * np.nanmean(mc_ivol_se)),
+                        "max_ivol_se_bp": float(1.0e4 * np.nanmax(mc_ivol_se)),
+                        "control_coefficients": np.asarray(coefficients),
+                        "floor_hits": simulated.floor_hits,
+                        "kernel_invalid_hits": 0,
+                    }
+                )
+
+    summaries: list[dict[str, Any]] = []
+    finest_table: list[dict[str, Any]] = []
+    for name in params_by_name:
+        for maturity in config.maturities:
+            group = sorted(
+                (
+                    row
+                    for row in records
+                    if row["parameter_set"] == name and row["maturity"] == maturity
+                ),
+                key=lambda row: row["dt"],
+                reverse=True,
+            )
+            within_noise = True
+            for coarse, fine in zip(group[:-1], group[1:]):
+                noise = 2.0 * (coarse["mean_ivol_se_bp"] + fine["mean_ivol_se_bp"])
+                within_noise &= fine["mean_abs_error_bp"] <= coarse["mean_abs_error_bp"] + noise
+            finest = group[-1]
+            band_pass = bool(
+                np.all(
+                    np.abs(finest["error_bp"])
+                    <= 50.0 + 2.0e4 * finest["mc_ivol_se"]
+                )
+            )
+            summaries.append(
+                {
+                    "parameter_set": name,
+                    "maturity": maturity,
+                    "monotone_within_mc_noise": bool(within_noise),
+                    "finest_within_50bp_plus_2strike_se_band": bool(band_pass),
+                    "acceptance_pass": bool(within_noise and band_pass),
+                    "finest_mean_abs_error_bp": finest["mean_abs_error_bp"],
+                    "finest_max_abs_error_bp": finest["max_abs_error_bp"],
+                    "finest_mean_ivol_se_bp": finest["mean_ivol_se_bp"],
+                }
+            )
+            for index, strike in enumerate(finest["strikes"]):
+                finest_table.append(
+                    {
+                        "parameter_set": name,
+                        "maturity": maturity,
+                        "dt": finest["dt"],
+                        "strike": float(strike),
+                        "mc_ivol": float(finest["mc_ivols"][index]),
+                        "mc_ivol_se": float(finest["mc_ivol_se"][index]),
+                        "affine_ivol": float(finest["affine_ivols"][index]),
+                        "error_bp": float(finest["error_bp"][index]),
+                    }
+                )
+    return {
+        "claim": "Q_EXACT option IVs converge to the continuous affine-expansion benchmark",
+        "seed": seed,
+        "records": records,
+        "summaries": summaries,
+        "finest_table": finest_table,
+        "acceptance_pass": bool(all(row["acceptance_pass"] for row in summaries)),
+        "acceptance_criterion": (
+            "Mean absolute errors must decline within Monte Carlo noise, and each "
+            "finest-step strike error must lie within 50 bp plus two of its own MC SE."
+        ),
+    }
+
+
+def _stable_weights(log_weights: np.ndarray) -> tuple[np.ndarray, float, float]:
+    logs = np.asarray(log_weights, dtype=np.float64)
+    if logs.ndim != 1 or not np.all(np.isfinite(logs)):
+        raise ValueError("log_weights must be a finite one-dimensional array")
+    maximum = float(np.max(logs))
+    scaled = np.exp(logs - maximum)
+    scale = math.exp(maximum)
+    weights = scale * scaled
+    mean_weight = float(np.mean(weights))
+    total = float(np.sum(scaled))
+    ess = total * total / float(np.sum(np.square(scaled)))
+    return weights, mean_weight, ess
+
+
+def run_e2(
+    params_by_name: dict[str, TgarchParams],
+    config: StudyConfig,
+) -> dict[str, Any]:
+    """E2: compare direct Q, P-to-Q weighting, and the hatted limit recursion."""
+    maturity = max(config.maturities)
+    seed = BASE_SEED + 2
+    records: list[dict[str, Any]] = []
+    for name, params in params_by_name.items():
+        limit = derived_limit_params(params)
+        strike = params.spot0
+        discount = math.exp(-params.r * maturity)
+        for dt in config.dt_grid:
+            n_paths = config.pricing_paths(dt)
+            exact = simulate_terminal(
+                params=params,
+                measure=Measure.Q_EXACT,
+                maturity=maturity,
+                max_dt=dt,
+                n_paths=n_paths,
+                seed=seed,
+            )
+            physical = simulate_terminal(
+                params=params,
+                measure=Measure.P,
+                maturity=maturity,
+                max_dt=dt,
+                n_paths=n_paths,
+                seed=seed,
+                track_log_weights=True,
+            )
+            limit_sim = simulate_terminal(
+                params=params,
+                measure=Measure.Q_LIMIT,
+                maturity=maturity,
+                max_dt=dt,
+                n_paths=n_paths,
+                seed=seed,
+                limit_params=limit,
+            )
+            weights, mean_weight, ess = _stable_weights(physical.log_weights)
+            exact_pairs, exact_cv = _controlled_call_pair_values(
+                terminal_spot=exact.terminal_spot,
+                strike=strike,
+                discount=discount,
+                expected_discounted_spot=params.spot0,
+            )
+            weighted_pairs, weighted_cv = _controlled_call_pair_values(
+                terminal_spot=physical.terminal_spot,
+                strike=strike,
+                discount=discount,
+                expected_discounted_spot=params.spot0,
+                weights=weights,
+            )
+            limit_pairs, limit_cv = _controlled_call_pair_values(
+                terminal_spot=limit_sim.terminal_spot,
+                strike=strike,
+                discount=discount,
+                expected_discounted_spot=params.spot0,
+            )
+            exact_price, exact_se = _mean_and_se(exact_pairs)
+            weighted_price, weighted_se = _mean_and_se(weighted_pairs)
+            limit_price, limit_se = _mean_and_se(limit_pairs)
+            exact_minus_weighted = exact_pairs - weighted_pairs
+            limit_minus_exact = limit_pairs - exact_pairs
+            difference_ab, difference_ab_se = _mean_and_se(exact_minus_weighted)
+            difference_ca, difference_ca_se = _mean_and_se(limit_minus_exact)
+            records.append(
+                {
+                    "parameter_set": name,
+                    "maturity": maturity,
+                    "strike": strike,
+                    "dt": dt,
+                    "n_paths": n_paths,
+                    "seed": seed,
+                    "exact_price": exact_price,
+                    "exact_se": exact_se,
+                    "weighted_price": weighted_price,
+                    "weighted_se": weighted_se,
+                    "limit_price": limit_price,
+                    "limit_se": limit_se,
+                    "exact_minus_weighted": difference_ab,
+                    "exact_minus_weighted_se": difference_ab_se,
+                    "limit_minus_exact": difference_ca,
+                    "limit_minus_exact_se": difference_ca_se,
+                    "mean_likelihood_weight": mean_weight,
+                    "ess": ess,
+                    "ess_fraction": ess / n_paths,
+                    "ess_warning": ess / n_paths < 0.2,
+                    "ab_within_3se": abs(difference_ab) <= 3.0 * difference_ab_se,
+                    "control_coefficients": {
+                        "exact": exact_cv,
+                        "weighted": weighted_cv,
+                        "limit": limit_cv,
+                    },
+                    "floor_hits": {
+                        "exact": exact.floor_hits,
+                        "physical": physical.floor_hits,
+                        "limit": limit_sim.floor_hits,
+                    },
+                }
+            )
+
+    rates: list[dict[str, Any]] = []
+    for name in params_by_name:
+        group = sorted(
+            (row for row in records if row["parameter_set"] == name),
+            key=lambda row: row["dt"],
+        )
+        x = np.log(np.array([row["dt"] for row in group]))
+        y_raw = np.array([abs(row["limit_minus_exact"]) for row in group])
+        noise = np.array([row["limit_minus_exact_se"] for row in group])
+        usable = y_raw > noise
+        if np.count_nonzero(usable) >= 2:
+            slope, intercept = np.polyfit(x[usable], np.log(y_raw[usable]), 1)
+        else:
+            slope, intercept = np.nan, np.nan
+        rates.append(
+            {
+                "parameter_set": name,
+                "fitted_rate": float(slope),
+                "fitted_intercept": float(intercept),
+                "usable_points": int(np.count_nonzero(usable)),
+                "sqrt_dt_consistent": bool(np.isfinite(slope) and 0.2 <= slope <= 0.8),
+            }
+        )
+    return {
+        "claim": "kernel algebra gives the same Q law and Q_LIMIT closes at sqrt(dt) order",
+        "seed": seed,
+        "maturity": maturity,
+        "records": records,
+        "rates": rates,
+        "acceptance_pass": bool(
+            all(row["ab_within_3se"] for row in records)
+            and all(row["sqrt_dt_consistent"] for row in rates)
+        ),
+    }
+
+
+def _gig_distribution(limit: LimitParams, vartheta2: float) -> Any:
+    lam = 2.0 * limit.d1_hat / vartheta2 - 1.0
+    chi = 4.0 * limit.d0 / vartheta2
+    psi = 4.0 * limit.kappa2_hat / vartheta2
+    if psi <= 0.0:
+        shape = 1.0 - 2.0 * limit.d1_hat / vartheta2
+        scale = 2.0 * limit.d0 / vartheta2
+        return invgamma(a=shape, scale=scale)
+    return geninvgauss(
+        p=lam,
+        b=math.sqrt(chi * psi),
+        scale=math.sqrt(chi / psi),
+    )
+
+
+def _density_diagnostic(
+    samples: np.ndarray,
+    distribution: Any,
+    max_kde_samples: int = 30_000,
+) -> dict[str, Any]:
+    values = np.asarray(samples, dtype=np.float64)
+    values = values[np.isfinite(values) & (values > 0.0)]
+    if values.size < 100:
+        raise ValueError("at least 100 positive stationary samples are required")
+    lower = float(distribution.ppf(0.001))
+    upper = float(distribution.ppf(0.999))
+    grid = np.geomspace(max(lower, 1.0e-8), upper, 350)
+    stride = max(1, values.size // max_kde_samples)
+    kde_values = values[::stride][:max_kde_samples]
+    kde = gaussian_kde(kde_values)
+    estimated_density = kde(grid)
+    theoretical_density = distribution.pdf(grid)
+    sup_error = float(np.max(np.abs(estimated_density - theoretical_density)))
+    max_density = float(np.max(theoretical_density))
+    probabilities = np.linspace(0.01, 0.99, 99)
+    sample_quantiles = np.quantile(values, probabilities)
+    theoretical_quantiles = distribution.ppf(probabilities)
+    qq_relative_rmse = float(
+        np.sqrt(
+            np.mean(
+                np.square(
+                    (sample_quantiles - theoretical_quantiles)
+                    / np.maximum(theoretical_quantiles, 1.0e-12)
+                )
+            )
+        )
+    )
+    return {
+        "n_samples": values.size,
+        "grid": grid,
+        "estimated_density": estimated_density,
+        "theoretical_density": theoretical_density,
+        "sup_density_error": sup_error,
+        "relative_sup_density_error": sup_error / max_density,
+        "probabilities": probabilities,
+        "sample_quantiles": sample_quantiles,
+        "theoretical_quantiles": theoretical_quantiles,
+        "qq_relative_rmse": qq_relative_rmse,
+    }
+
+
+def run_e3(
+    params_by_name: dict[str, TgarchParams],
+    config: StudyConfig,
+) -> dict[str, Any]:
+    """E3: compare the stationary Q_LIMIT recursion with its GIG law."""
+    seed = BASE_SEED + 3
+    records: list[dict[str, Any]] = []
+    comparison_dts = (
+        (1.0 / 252.0, 1.0 / 1008.0)
+        if config.profile is not StudyProfile.SMOKE
+        else (1.0 / 252.0,)
+    )
+    for name, params in params_by_name.items():
+        base = derived_limit_params(params)
+        variants = (
+            ("baseline", base),
+            ("kappa2_5pct", _limit_with_kappa2(base, 0.05 * base.kappa2_hat)),
+        )
+        for variant_name, limit in variants:
+            dts = comparison_dts if variant_name == "baseline" else (1.0 / 252.0,)
+            distribution = _gig_distribution(limit, params.vartheta**2)
+            for dt in dts:
+                simulated = simulate_stationary_sigma(
+                    params=params,
+                    measure=Measure.Q_LIMIT,
+                    dt=dt,
+                    burn_years=config.stationary_burn_years,
+                    sample_years=config.stationary_sample_years,
+                    sample_interval=1.0 / 252.0,
+                    seed=seed,
+                    limit_params=limit,
+                )
+                diagnostic = _density_diagnostic(simulated.samples, distribution)
+                records.append(
+                    {
+                        "parameter_set": name,
+                        "variant": variant_name,
+                        "dt": dt,
+                        "burn_years": config.stationary_burn_years,
+                        "sample_years": config.stationary_sample_years,
+                        "seed": seed,
+                        "kappa2_hat": limit.kappa2_hat,
+                        "theta_hat": limit.theta_hat,
+                        "kappa1_hat": limit.kappa1_hat,
+                        "floor_hits": simulated.floor_hits,
+                        **diagnostic,
+                    }
+                )
+    baseline_records = [row for row in records if row["variant"] == "baseline"]
+    return {
+        "claim": "the Q_LIMIT stationary law converges to the stated GIG density",
+        "seed": seed,
+        "records": records,
+        "acceptance_pass": bool(
+            all(row["relative_sup_density_error"] <= 0.15 for row in baseline_records)
+            and all(row["floor_hits"] == 0 for row in records)
+        ),
+        "small_error_threshold": "relative sup-density error <= 0.15 (study convention)",
+        "acceptance_criterion": (
+            "The 0.15 threshold applies to the baseline daily and 1/1008 runs. The "
+            "kappa2_hat-at-5% rows are a separate inverse-gamma degeneration stress test."
+        ),
+    }
+
+
+def _bootstrap_mean_ci(
+    pair_values: np.ndarray,
+    *,
+    seed: int,
+    replications: int,
+) -> tuple[float, float]:
+    values = np.asarray(pair_values, dtype=np.float64)
+    if values.ndim != 1 or values.size < 2:
+        raise ValueError("bootstrap input must contain at least two pair values")
+    if values.size > 4_096:
+        block_count = 1_024
+        usable = (values.size // block_count) * block_count
+        values = values[:usable].reshape(block_count, -1).mean(axis=1)
+    generator = np.random.Generator(np.random.PCG64(seed))
+    estimates = np.empty(replications)
+    for index in range(replications):
+        selected = generator.integers(0, values.size, size=values.size)
+        estimates[index] = np.mean(values[selected])
+    lower, upper = np.quantile(estimates, (0.025, 0.975))
+    return float(lower), float(upper)
+
+
+def _power_pair_values(log_spot: np.ndarray, power: float) -> tuple[np.ndarray, np.ndarray]:
+    left, right = _pair_arrays(np.asarray(log_spot, dtype=np.float64))
+    with np.errstate(over="ignore", invalid="ignore"):
+        left_values = np.exp(power * left)
+        right_values = np.exp(power * right)
+    return 0.5 * (left_values + right_values), np.concatenate((left_values, right_values))
+
+
+def _top_share(values: np.ndarray, fraction: float = 0.001) -> float:
+    positive = np.asarray(values, dtype=np.float64)
+    if positive.ndim != 1 or positive.size == 0 or not np.all(positive >= 0.0):
+        return float("nan")
+    if not np.all(np.isfinite(positive)):
+        return 1.0
+    count = max(1, int(math.ceil(fraction * positive.size)))
+    total = float(np.sum(positive))
+    if total <= 0.0:
+        return float("nan")
+    selected = np.partition(positive, positive.size - count)[-count:]
+    return float(np.sum(selected) / total)
+
+
+def _spot_moment_sufficient_boundary(params: TgarchParams, power: float) -> float:
+    """Return the exponential-supersolution sufficient curve for E[S_T**p]."""
+    return params.beta * power + params.vartheta * math.sqrt(power * (power - 1.0))
+
+
+def run_e4(
+    params: TgarchParams,
+    config: StudyConfig,
+) -> dict[str, Any]:
+    """E4: probe heavy spot moments near the sufficient continuous-time curve.
+
+    The brief does not specify which recursion to vary.  We use ``Q_LIMIT`` and
+    hold ``d0`` and ``d1_hat`` fixed as ``kappa2_hat`` changes.  This avoids the
+    pathwise ``b_k < 1/2`` failure that a positive affine exact-kernel loading
+    would create when targeting small ``kappa2_hat``.  Consequently this is an
+    Euler proxy for, not a proof of, the open uniform-integrability conjecture.
+    """
+    seed = BASE_SEED + 4
+    maturity = 1.0 / 4.0
+    base = derived_limit_params(params)
+    records: list[dict[str, Any]] = []
+    for dt in config.dt_grid:
+        for kappa2_hat in KAPPA2_MOMENT_GRID:
+            limit = _limit_with_kappa2(base, kappa2_hat)
+            simulated = simulate_terminal(
+                params=params,
+                measure=Measure.Q_LIMIT,
+                maturity=maturity,
+                max_dt=dt,
+                n_paths=config.e4_paths,
+                seed=seed,
+                limit_params=limit,
+            )
+            for power in MOMENT_POWERS:
+                pair_values, path_values = _power_pair_values(simulated.terminal_log_spot, power)
+                if np.all(np.isfinite(pair_values)):
+                    estimate, standard_error = _mean_and_se(pair_values)
+                    ci_lower, ci_upper = _bootstrap_mean_ci(
+                        pair_values,
+                        seed=seed + 100_000 + int(100 * power) + int(1000 * kappa2_hat),
+                        replications=config.bootstrap_replications,
+                    )
+                else:
+                    estimate = standard_error = ci_lower = ci_upper = float("inf")
+                boundary = _spot_moment_sufficient_boundary(params, power)
+                records.append(
+                    {
+                        "parameter_set": "crypto",
+                        "maturity": maturity,
+                        "dt": dt,
+                        "n_paths": config.e4_paths,
+                        "seed": seed,
+                        "kappa2_hat": kappa2_hat,
+                        "power": power,
+                        "moment": estimate,
+                        "standard_error": standard_error,
+                        "bootstrap_ci_lower": ci_lower,
+                        "bootstrap_ci_upper": ci_upper,
+                        "top_0_1pct_share": _top_share(path_values),
+                        "sufficient_boundary": boundary,
+                        "inside_sufficient_region": kappa2_hat >= boundary,
+                        "floor_hits": simulated.floor_hits,
+                    }
+                )
+    verdicts: list[dict[str, Any]] = []
+    for power in MOMENT_POWERS:
+        boundary = _spot_moment_sufficient_boundary(params, power)
+        for kappa2_hat in KAPPA2_MOMENT_GRID:
+            group = sorted(
+                (
+                    row
+                    for row in records
+                    if row["power"] == power and row["kappa2_hat"] == kappa2_hat
+                ),
+                key=lambda row: row["dt"],
+                reverse=True,
+            )
+            coarse, fine = group[0], group[-1]
+            combined_se = math.sqrt(coarse["standard_error"] ** 2 + fine["standard_error"] ** 2)
+            if kappa2_hat >= boundary:
+                empirical_pass = abs(fine["moment"] - coarse["moment"]) <= 3.0 * combined_se
+                expected_pattern = "stability"
+            else:
+                empirical_pass = (
+                    fine["moment"] > coarse["moment"] + combined_se
+                    and fine["top_0_1pct_share"] >= coarse["top_0_1pct_share"]
+                )
+                expected_pattern = "growth and increasing tail concentration (conjectural)"
+            verdicts.append(
+                {
+                    "power": power,
+                    "kappa2_hat": kappa2_hat,
+                    "sufficient_boundary": boundary,
+                    "expected_pattern": expected_pattern,
+                    "empirical_pattern_pass": bool(empirical_pass),
+                }
+            )
+    return {
+        "claim": "spot moments stabilise inside a sufficient supersolution region",
+        "seed": seed,
+        "maturity_assumption": maturity,
+        "measure_choice": "Q_LIMIT with fixed d0 and d1_hat",
+        "boundary_classification": (
+            "sufficient all-horizons exponential-supersolution condition; the paper does not "
+            "prove necessity or divergence outside it"
+        ),
+        "records": records,
+        "verdicts": verdicts,
+        "acceptance_pass": bool(all(row["empirical_pattern_pass"] for row in verdicts)),
+    }
+
+
+def _hill_curve(samples: np.ndarray) -> tuple[np.ndarray, np.ndarray, int, float]:
+    values = np.sort(np.asarray(samples, dtype=np.float64))
+    values = values[np.isfinite(values) & (values > 0.0)]
+    if values.size < 1_000:
+        raise ValueError("Hill estimation requires at least 1,000 positive samples")
+    maximum_k = min(5_000, values.size // 10)
+    k_grid = np.unique(np.geomspace(50, maximum_k, 45).astype(int))
+    tail_indices = np.empty(k_grid.size)
+    for index, k in enumerate(k_grid):
+        threshold = values[-k - 1]
+        log_excess = np.log(values[-k:]) - math.log(threshold)
+        tail_indices[index] = 1.0 / np.mean(log_excess)
+    selected_k = int(round(math.sqrt(values.size)))
+    selected_k = min(max(selected_k, 50), maximum_k)
+    threshold = values[-selected_k - 1]
+    selected_alpha = float(
+        1.0 / np.mean(np.log(values[-selected_k:]) - math.log(threshold))
+    )
+    return k_grid, tail_indices, selected_k, selected_alpha
+
+
+def _kesten_tail_index(params: TgarchParams, dt: float) -> float:
+    """Solve the Kesten equation by adaptive, piecewise Gaussian quadrature.
+
+    The absolute-news term is non-smooth at zero.  Fixed-order Hermite rules
+    leave an error comparable with the order-``dt`` signal as the step shrinks,
+    so the integral is split at zero and evaluated adaptively.
+    """
+    if not math.isfinite(dt) or dt <= 0.0:
+        raise ValueError("dt must be a positive finite number")
+    root_dt = math.sqrt(dt)
+    normalizer = 1.0 / math.sqrt(2.0 * math.pi)
+
+    def moment(power: float) -> float:
+        def integrand(z: float) -> float:
+            w = (abs(z) - M1) / S1
+            innovation = params.beta * z + params.eps * w
+            coefficient = abs(1.0 - params.kappa1 * dt + root_dt * innovation)
+            return coefficient**power * normalizer * math.exp(-0.5 * z * z)
+
+        negative = quad(
+            integrand,
+            -math.inf,
+            0.0,
+            epsabs=2.0e-12,
+            epsrel=2.0e-12,
+            limit=500,
+        )[0]
+        positive = quad(
+            integrand,
+            0.0,
+            math.inf,
+            epsabs=2.0e-12,
+            epsrel=2.0e-12,
+            limit=500,
+        )[0]
+        return float(negative + positive)
+
+    def equation(power: float) -> float:
+        return moment(power) - 1.0
+
+    lower = 1.0e-6
+    if equation(lower) >= 0.0:
+        return float("nan")
+    upper = 2.0
+    while upper <= 100.0 and equation(upper) <= 0.0:
+        upper *= 2.0
+    if upper > 100.0:
+        return float("nan")
+    return float(brentq(equation, lower, upper, xtol=1.0e-11))
+
+
+def run_e5(params: TgarchParams, config: StudyConfig) -> dict[str, Any]:
+    """E5: estimate fixed-step Kesten tails and expose the brief's false limit claim."""
+    seed = BASE_SEED + 5
+    linear_params = replace(params, kappa2=0.0)
+    dts = (1.0 / 52.0, 1.0 / 252.0, 1.0 / 1008.0)
+    if config.profile is StudyProfile.SMOKE:
+        dts = (1.0 / 52.0, 1.0 / 252.0)
+    continuous_alpha = 1.0 + 2.0 * linear_params.kappa1 / linear_params.vartheta**2
+    records: list[dict[str, Any]] = []
+    for dt in dts:
+        simulated = simulate_stationary_sigma(
+            params=linear_params,
+            measure=Measure.P,
+            dt=dt,
+            burn_years=config.stationary_burn_years,
+            sample_years=config.e5_sample_years,
+            sample_interval=max(dt, 1.0 / 252.0),
+            seed=seed,
+        )
+        k_grid, hill_alpha, selected_k, selected_alpha = _hill_curve(simulated.samples)
+        kesten_alpha = _kesten_tail_index(linear_params, dt)
+        records.append(
+            {
+                "parameter_set": "crypto_linear_P",
+                "dt": dt,
+                "burn_years": config.stationary_burn_years,
+                "sample_years": config.e5_sample_years,
+                "seed": seed,
+                "n_samples": simulated.samples.size,
+                "k_grid": k_grid,
+                "hill_alpha": hill_alpha,
+                "selected_k": selected_k,
+                "selected_hill_alpha": selected_alpha,
+                "kesten_alpha": kesten_alpha,
+                "continuous_inverse_gamma_alpha": continuous_alpha,
+                "floor_hits": simulated.floor_hits,
+            }
+        )
+    convergence_error = [abs(row["kesten_alpha"] - continuous_alpha) for row in records]
+    corrected_convergence = all(
+        fine <= coarse + 1.0e-8
+        for coarse, fine in zip(convergence_error[:-1], convergence_error[1:])
+    )
+    return {
+        "claim": "fixed-step Kesten tails converge to the continuous inverse-gamma tail",
+        "seed": seed,
+        "records": records,
+        "continuous_tail_index": continuous_alpha,
+        "brief_acceptance_pass": False,
+        "corrected_acceptance_pass": bool(corrected_convergence),
+        "contradiction": (
+            "The brief says the limit has all moments and the tail index should diverge. "
+            "Remark 19 and the published stationary density instead imply an inverse-gamma "
+            f"survival-tail exponent 1+2*kappa1/vartheta^2={continuous_alpha:.6f}."
+        ),
+    }
+
+
+def _observation_indices(times: np.ndarray, dt_observation: float) -> np.ndarray:
+    final_time = float(times[-1])
+    target = np.arange(int(math.floor(final_time / dt_observation)) + 1) * dt_observation
+    indices = np.rint(target / (times[1] - times[0])).astype(int)
+    indices = np.clip(indices, 0, times.size - 1)
+    return np.unique(indices)
+
+
+def _forgetting_rate(times: np.ndarray, difference: np.ndarray) -> float:
+    mask = (times > 0.0) & (times <= min(5.0, times[-1])) & (difference > 1.0e-8)
+    if np.count_nonzero(mask) < 5:
+        return float("nan")
+    slope, _ = np.polyfit(times[mask], np.log(difference[mask]), 1)
+    return float(-slope)
+
+
+def run_e6(
+    params_by_name: dict[str, TgarchParams],
+    config: StudyConfig,
+) -> dict[str, Any]:
+    """E6: apply the exact discrete filter to paths of the two-shock diffusion limit."""
+    seed = BASE_SEED + 6
+    fine_dt = 1.0 / 16128.0
+    observation_dts = (1.0 / 52.0, 1.0 / 252.0, 1.0 / 1008.0, 1.0 / 4032.0)
+    if config.profile is StudyProfile.SMOKE:
+        observation_dts = (1.0 / 52.0, 1.0 / 1008.0)
+    records: list[dict[str, Any]] = []
+    self_checks: list[dict[str, Any]] = []
+    forgetting_series: list[dict[str, Any]] = []
+    for name, params in params_by_name.items():
+        self_path = simulate_discrete_path(
+            params=params,
+            measure=Measure.P,
+            dt=1.0 / 252.0,
+            years=min(config.e6_years, 2.0),
+            seed=seed,
+        )
+        self_filtered = filter_discrete_returns(
+            log_prices=self_path.log_prices,
+            observation_times=self_path.times,
+            params=params,
+            sigma0=params.sigma0,
+        )
+        self_checks.append(
+            {
+                "parameter_set": name,
+                "max_abs_filter_error_own_model": float(
+                    np.max(np.abs(self_filtered - self_path.sigmas))
+                ),
+                "pass": bool(np.max(np.abs(self_filtered - self_path.sigmas)) <= 1.0e-10),
+            }
+        )
+        source = simulate_two_shock_limit_path(
+            params=params,
+            dt=fine_dt,
+            years=config.e6_years,
+            seed=seed,
+        )
+        for dt_observation in observation_dts:
+            indices = _observation_indices(source.times, dt_observation)
+            times = source.times[indices]
+            log_prices = source.log_prices[indices]
+            true_sigma = source.sigmas[indices]
+            filtered = filter_discrete_returns(
+                log_prices=log_prices,
+                observation_times=times,
+                params=params,
+                sigma0=params.sigma0,
+            )
+            wrong = filter_discrete_returns(
+                log_prices=log_prices,
+                observation_times=times,
+                params=params,
+                sigma0=1.5 * params.sigma0,
+            )
+            burn_mask = times >= min(1.0, 0.1 * times[-1])
+            rmse = float(np.sqrt(np.mean(np.square(filtered[burn_mask] - true_sigma[burn_mask]))))
+            wrong_rmse = float(
+                np.sqrt(np.mean(np.square(wrong[burn_mask] - true_sigma[burn_mask])))
+            )
+            difference = np.abs(wrong - filtered)
+            forgetting_rate = _forgetting_rate(times, difference)
+            linearised_rate = params.kappa1 + params.kappa2 * params.theta
+            forgetting_rate_ratio = forgetting_rate / linearised_rate
+            forgetting_rate_roughly_mean_reversion = bool(
+                math.isfinite(forgetting_rate_ratio)
+                and 0.5 <= forgetting_rate_ratio <= 2.0
+            )
+            effective_dts = np.diff(times)
+            records.append(
+                {
+                    "parameter_set": name,
+                    "source_dt": fine_dt,
+                    "dt_observation_nominal": dt_observation,
+                    "dt_observation_mean": float(np.mean(effective_dts)),
+                    "dt_observation_min": float(np.min(effective_dts)),
+                    "dt_observation_max": float(np.max(effective_dts)),
+                    "years": config.e6_years,
+                    "seed": seed,
+                    "rmse_correct_start": rmse,
+                    "rmse_wrong_start": wrong_rmse,
+                    "forgetting_rate": forgetting_rate,
+                    "linearised_mean_reversion_rate": linearised_rate,
+                    "forgetting_rate_ratio": forgetting_rate_ratio,
+                    "forgetting_rate_roughly_mean_reversion": (
+                        forgetting_rate_roughly_mean_reversion
+                    ),
+                    "source_floor_hits": source.floor_hits,
+                }
+            )
+            stride = max(1, times.size // 600)
+            forgetting_series.append(
+                {
+                    "parameter_set": name,
+                    "dt_observation_nominal": dt_observation,
+                    "times": times[::stride],
+                    "wrong_minus_correct_abs": difference[::stride],
+                }
+            )
+    scale_verdicts: list[dict[str, Any]] = []
+    for name in params_by_name:
+        group = sorted(
+            (row for row in records if row["parameter_set"] == name),
+            key=lambda row: row["dt_observation_nominal"],
+            reverse=True,
+        )
+        decreasing = all(
+            fine["rmse_correct_start"] <= coarse["rmse_correct_start"]
+            for coarse, fine in zip(group[:-1], group[1:])
+        )
+        forgetting_pass = all(
+            row["forgetting_rate_roughly_mean_reversion"] for row in group
+        )
+        scale_verdicts.append(
+            {
+                "parameter_set": name,
+                "rmse_decreases_with_dt": bool(decreasing),
+                "forgetting_rate_roughly_mean_reversion": bool(forgetting_pass),
+                "minimum_forgetting_rate_ratio": min(
+                    row["forgetting_rate_ratio"] for row in group
+                ),
+                "maximum_forgetting_rate_ratio": max(
+                    row["forgetting_rate_ratio"] for row in group
+                ),
+                "coarse_rmse": group[0]["rmse_correct_start"],
+                "fine_rmse": group[-1]["rmse_correct_start"],
+            }
+        )
+    return {
+        "claim": "the exact one-shock filter consistently recovers a two-shock limit path",
+        "seed": seed,
+        "records": records,
+        "self_model_checks": self_checks,
+        "forgetting_series": forgetting_series,
+        "scale_verdicts": scale_verdicts,
+        "acceptance_pass": bool(
+            all(row["pass"] for row in self_checks)
+            and all(row["rmse_decreases_with_dt"] for row in scale_verdicts)
+            and all(
+                row["forgetting_rate_roughly_mean_reversion"]
+                for row in scale_verdicts
+            )
+        ),
+        "acceptance_criterion": (
+            "RMSE must decrease at finer observation steps, and the fitted wrong-start "
+            "decay rate must be within a factor of two of the linearised mean-reversion "
+            "rate (study convention)."
+        ),
+        "interpretation_caveat": (
+            "Exactness holds for the one-shock discrete recursion. A path generated with an "
+            "independent second Brownian shock is deliberately not the filter's own model."
+        ),
+    }
+
+
+@njit(cache=True)
+def _qmle_observations(
+    transformed: np.ndarray,
+    log_returns: np.ndarray,
+    dt: float,
+    r: float,
+) -> np.ndarray:
+    kappa1 = math.exp(transformed[0])
+    kappa2 = math.exp(transformed[1])
+    theta = math.exp(transformed[2])
+    beta = transformed[3]
+    eps = math.exp(transformed[4])
+    gamma1 = transformed[5]
+    sigma = theta
+    root_dt = math.sqrt(dt)
+    observations = np.empty(log_returns.size)
+    constant = math.log(2.0 * math.pi * dt)
+    for index in range(log_returns.size):
+        if sigma <= 1.0e-8 or not math.isfinite(sigma):
+            observations[:] = -1.0e12
+            return observations
+        conditional_mean = (r + gamma1 * sigma * sigma - 0.5 * sigma * sigma) * dt
+        z = (log_returns[index] - conditional_mean) / (sigma * root_dt)
+        observations[index] = -0.5 * (constant + 2.0 * math.log(sigma) + z * z)
+        w = (abs(z) - M1) / S1
+        drift = (kappa1 + kappa2 * sigma) * (theta - sigma)
+        sigma = sigma + drift * dt + sigma * root_dt * (beta * z + eps * w)
+    return observations
+
+
+def _to_transformed(natural: np.ndarray) -> np.ndarray:
+    if natural.shape != (6,):
+        raise ValueError("natural parameter vector must have length six")
+    if np.any(natural[[0, 1, 2, 4]] <= 0.0):
+        raise ValueError("kappa1, kappa2, theta, and eps must be positive")
+    return np.array(
+        (
+            math.log(natural[0]),
+            math.log(natural[1]),
+            math.log(natural[2]),
+            natural[3],
+            math.log(natural[4]),
+            natural[5],
+        ),
+        dtype=np.float64,
+    )
+
+
+def _to_natural(transformed: np.ndarray) -> np.ndarray:
+    return np.array(
+        (
+            math.exp(transformed[0]),
+            math.exp(transformed[1]),
+            math.exp(transformed[2]),
+            transformed[3],
+            math.exp(transformed[4]),
+            transformed[5],
+        ),
+        dtype=np.float64,
+    )
+
+
+def _fit_qmle(
+    log_returns: np.ndarray,
+    *,
+    dt: float,
+    r: float,
+    start_natural: np.ndarray,
+) -> tuple[np.ndarray, float, bool, float]:
+    transformed_start = _to_transformed(start_natural)
+    bounds = (
+        (math.log(0.1), math.log(20.0)),
+        (math.log(0.01), math.log(20.0)),
+        (math.log(0.03), math.log(2.5)),
+        (-3.0, 3.0),
+        (math.log(0.05), math.log(4.0)),
+        (-2.0, 2.0),
+    )
+
+    def objective(vector: np.ndarray) -> float:
+        values = _qmle_observations(vector, log_returns, dt, r)
+        result = -float(np.mean(values))
+        return result if np.isfinite(result) else 1.0e12
+
+    fitted = minimize(
+        objective,
+        transformed_start,
+        method="L-BFGS-B",
+        bounds=bounds,
+        options={"maxiter": 350, "ftol": 1.0e-10, "gtol": 1.0e-6},
+    )
+    vector = np.asarray(fitted.x, dtype=np.float64)
+    observations = _qmle_observations(vector, log_returns, dt, r)
+    scores = np.empty((log_returns.size, vector.size))
+    for column in range(vector.size):
+        step = 1.0e-4 * (1.0 + abs(vector[column]))
+        plus = vector.copy()
+        minus = vector.copy()
+        plus[column] += step
+        minus[column] -= step
+        scores[:, column] = (
+            _qmle_observations(plus, log_returns, dt, r)
+            - _qmle_observations(minus, log_returns, dt, r)
+        ) / (2.0 * step)
+    information = scores.T @ scores
+    covariance = np.linalg.pinv(information, rcond=1.0e-10)
+    gamma1_se = float(math.sqrt(max(covariance[5, 5], 0.0)))
+    return _to_natural(vector), gamma1_se, bool(fitted.success), float(np.sum(observations))
+
+
+def run_e7(
+    params_by_name: dict[str, TgarchParams],
+    config: StudyConfig,
+) -> dict[str, Any]:
+    """E7: run the exact prediction-error QMLE identification experiment."""
+    seed = BASE_SEED + 7
+    dt = 1.0 / 252.0
+    sample_years = (5, 10, 20, 40)
+    if config.profile is StudyProfile.SMOKE:
+        sample_years = (5, 10)
+    parameter_names = ("kappa1", "kappa2", "theta", "beta", "eps", "gamma1")
+    estimates: list[dict[str, Any]] = []
+    for name in config.e7_parameter_sets:
+        params = params_by_name[name]
+        truth = np.array(
+            (params.kappa1, params.kappa2, params.theta, params.beta, params.eps, params.gamma1)
+        )
+        start = truth * np.array((0.85, 1.15, 1.05, 0.8, 1.1, 0.5))
+        if abs(start[3]) < 0.05:
+            start[3] = -0.1
+        for replication in range(config.e7_replications):
+            replication_seed = seed + replication
+            path = simulate_discrete_path(
+                params=params,
+                measure=Measure.P,
+                dt=dt,
+                years=float(max(sample_years)),
+                seed=replication_seed,
+            )
+            all_returns = np.diff(path.log_prices)
+            for years in sample_years:
+                count = int(round(years / dt))
+                fitted, gamma1_se, converged, log_likelihood = _fit_qmle(
+                    all_returns[:count],
+                    dt=dt,
+                    r=params.r,
+                    start_natural=start,
+                )
+                estimates.append(
+                    {
+                        "parameter_set": name,
+                        "years": years,
+                        "replication": replication,
+                        "seed": replication_seed,
+                        "estimate": fitted,
+                        "gamma1_se": gamma1_se,
+                        "gamma1_tstat": (
+                            fitted[5] / gamma1_se if gamma1_se > 0.0 else float("nan")
+                        ),
+                        "converged": converged,
+                        "log_likelihood": log_likelihood,
+                        "floor_hits": path.floor_hits,
+                    }
+                )
+    summaries: list[dict[str, Any]] = []
+    identification: list[dict[str, Any]] = []
+    for name in config.e7_parameter_sets:
+        params = params_by_name[name]
+        truth = np.array(
+            (params.kappa1, params.kappa2, params.theta, params.beta, params.eps, params.gamma1)
+        )
+        for years in sample_years:
+            group = [
+                row
+                for row in estimates
+                if row["parameter_set"] == name and row["years"] == years
+            ]
+            matrix = np.vstack([row["estimate"] for row in group])
+            for index, parameter in enumerate(parameter_names):
+                errors = matrix[:, index] - truth[index]
+                summaries.append(
+                    {
+                        "parameter_set": name,
+                        "years": years,
+                        "parameter": parameter,
+                        "truth": float(truth[index]),
+                        "mean_estimate": float(np.mean(matrix[:, index])),
+                        "bias": float(np.mean(errors)),
+                        "rmse": float(np.sqrt(np.mean(np.square(errors)))),
+                    }
+                )
+            tstats = np.array([abs(row["gamma1_tstat"]) for row in group])
+            kappa2_lower_hits = int(np.count_nonzero(np.isclose(matrix[:, 1], 0.01)))
+            kappa2_upper_hits = int(np.count_nonzero(np.isclose(matrix[:, 1], 20.0)))
+            identification.append(
+                {
+                    "parameter_set": name,
+                    "years": years,
+                    "median_abs_gamma1_tstat": float(np.nanmedian(tstats)),
+                    "gamma1_identified_at_2": bool(np.nanmedian(tstats) >= 2.0),
+                    "kappa1_kappa2_estimate_correlation": float(
+                        np.corrcoef(matrix[:, 0], matrix[:, 1])[0, 1]
+                        if matrix.shape[0] >= 3
+                        else np.nan
+                    ),
+                    "convergence_fraction": float(np.mean([row["converged"] for row in group])),
+                    "kappa2_lower_bound_hits": kappa2_lower_hits,
+                    "kappa2_upper_bound_hits": kappa2_upper_hits,
+                    "kappa2_any_bound_fraction": float(
+                        (kappa2_lower_hits + kappa2_upper_hits) / matrix.shape[0]
+                    ),
+                }
+            )
+    threshold_years: dict[str, int | None] = {}
+    for name in config.e7_parameter_sets:
+        candidates = [
+            row["years"]
+            for row in identification
+            if row["parameter_set"] == name and row["gamma1_identified_at_2"]
+        ]
+        threshold_years[name] = min(candidates) if candidates else None
+    unreached = [name for name, years in threshold_years.items() if years is None]
+    correlation_values = [
+        row["kappa1_kappa2_estimate_correlation"] for row in identification
+    ]
+    five_year_rows = [row for row in identification if row["years"] == 5]
+    findings = [
+        (
+            "Median absolute gamma1 t-statistic did not reach 2 through 40 years for "
+            + ", ".join(unreached)
+            + "."
+            if unreached
+            else "Median absolute gamma1 t-statistic reached 2 within the simulated horizon."
+        ),
+        (
+            "kappa1/kappa2 estimates remain poorly separated: correlations range from "
+            f"{min(correlation_values):.3f} to {max(correlation_values):.3f}; five-year "
+            "kappa2 bound-hit fractions are "
+            + ", ".join(
+                f"{row['parameter_set']}={row['kappa2_any_bound_fraction']:.1%}"
+                for row in five_year_rows
+            )
+            + "."
+        ),
+    ]
+    return {
+        "claim": "QMLE sample-size experiment measures structural identification",
+        "seed_rule": f"{seed} + replication index",
+        "dt": dt,
+        "replications": config.e7_replications,
+        "estimates": estimates,
+        "summaries": summaries,
+        "identification": identification,
+        "gamma1_median_abs_tstat_2_years": threshold_years,
+        "acceptance_criterion": "none: negative identification results are findings",
+        "findings": findings,
+    }
+
+
+def _parameter_header(params: TgarchParams) -> dict[str, Any]:
+    limit = derived_limit_params(params)
+    return {
+        "physical": asdict(params),
+        "derived": asdict(limit),
+        "lambda0_bar": params.gamma1,
+        "lambda1_bar": -(M1 / S1) * params.eta1,
+        "vartheta": params.vartheta,
+    }
+
+
+def run_all_experiments(
+    output_dir: Path,
+    profile: StudyProfile = StudyProfile.FULL,
+) -> StudyResults:
+    """Run mandatory checks followed by E1--E7 in the brief's priority order."""
+    output = Path(output_dir)
+    if not output.exists() or not output.is_dir():
+        raise ValueError("output_dir must be an existing directory")
+    config = make_study_config(profile)
+    params_by_name = parameter_sets()
+    print(f"[TGARCH] profile={profile.value}: mandatory simulator checks", flush=True)
+    checks = run_unit_checks(
+        parameter_sets=params_by_name,
+        dt_grid=config.dt_grid,
+        maturity=max(config.maturities),
+        seed=BASE_SEED,
+        n_paths=config.unit_paths,
+        moment_draws=config.moment_check_draws,
+    )
+    if not checks.get("all_passed", False):
+        raise RuntimeError(
+            "mandatory simulator checks failed; experiments were not started: "
+            + json.dumps(_as_jsonable(checks), indent=2)[:4_000]
+        )
+
+    def timed_run(identifier: str, function: Callable[[], dict[str, Any]]) -> dict[str, Any]:
+        print(f"[TGARCH] {identifier}: start", flush=True)
+        started = time.perf_counter()
+        result = function()
+        result["runtime_seconds"] = time.perf_counter() - started
+        print(
+            f"[TGARCH] {identifier}: done in {result['runtime_seconds']:.2f}s",
+            flush=True,
+        )
+        return result
+
+    experiments: dict[str, Any] = {}
+    experiments["E1"] = timed_run("E1", lambda: run_e1(params_by_name, config))
+    experiments["E2"] = timed_run("E2", lambda: run_e2(params_by_name, config))
+    experiments["E3"] = timed_run("E3", lambda: run_e3(params_by_name, config))
+    experiments["E4"] = timed_run("E4", lambda: run_e4(params_by_name["crypto"], config))
+    experiments["E5"] = timed_run("E5", lambda: run_e5(params_by_name["crypto"], config))
+    experiments["E6"] = timed_run("E6", lambda: run_e6(params_by_name, config))
+    experiments["E7"] = timed_run("E7", lambda: run_e7(params_by_name, config))
+    warnings: list[str] = []
+    for row in experiments["E2"]["records"]:
+        if row["ess_warning"]:
+            warnings.append(
+                f"E2 ESS/n below 0.2 for {row['parameter_set']} at dt={row['dt']:.8g}"
+            )
+    if any(
+        row.get("floor_hits", 0) != 0
+        for experiment in experiments.values()
+        for row in experiment.get("records", [])
+        if isinstance(row.get("floor_hits", 0), (int, np.integer))
+    ):
+        warnings.append("At least one reported simulation recorded volatility-floor hits.")
+    warnings.extend(
+        (
+            "Q_EXACT antithetic base normals do not produce equal |z| within a pair when the "
+            "conditional Gaussian has a nonzero, state-dependent mean.",
+            "E4 uses Q_LIMIT because the brief does not define how to vary kappa2_hat in the "
+            "exact kernel without violating b_k < 1/2 on unbounded volatility states.",
+            "E5's stated all-moments-finite limit is contradicted by the inverse-gamma law.",
+            "E6 weekly observation times require alternating fine-grid spacings because "
+            "16128/52 is not an integer.",
+        )
+    )
+    return StudyResults(
+        profile=profile.value,
+        config=_as_jsonable(config),
+        parameters={name: _parameter_header(params) for name, params in params_by_name.items()},
+        checks=_as_jsonable(checks),
+        experiments=experiments,
+        provenance=collect_provenance(output, profile),
+        warnings=warnings,
+    )
+
+
+__all__ = [
+    "StudyConfig",
+    "StudyProfile",
+    "StudyResults",
+    "collect_provenance",
+    "make_study_config",
+    "parameter_sets",
+    "run_all_experiments",
+]

--- a/volatility_book/ch_discrete_vol/experiments.py
+++ b/volatility_book/ch_discrete_vol/experiments.py
@@ -215,6 +215,14 @@ def _sha256(path: Path) -> str | None:
     return digest.hexdigest()
 
 
+def _sha256_normalized_text(path: Path) -> str | None:
+    """Hash text using the repository's LF-normalized Git-content convention."""
+    if not path.exists():
+        return None
+    content = path.read_bytes().replace(b"\r\n", b"\n")
+    return hashlib.sha256(content).hexdigest()
+
+
 def _git_output(repository: Path, *arguments: str) -> str:
     try:
         completed = subprocess.run(
@@ -232,6 +240,7 @@ def collect_provenance(output_dir: Path, profile: StudyProfile) -> dict[str, Any
     """Collect source hashes, versions, seeds, and the enclosing repository revision."""
     repo = Path(__file__).resolve().parents[2]
     code_dir = Path(__file__).resolve().parent
+    notes_dir = code_dir / "notes"
     source_files = ("sim.py", "experiments.py", "reporting.py", "run_study.py")
     packages = ("numpy", "scipy", "matplotlib", "numba", "pandas", "stochvolmodels")
     versions: dict[str, str] = {}
@@ -252,10 +261,10 @@ def collect_provenance(output_dir: Path, profile: StudyProfile) -> dict[str, Any
         "study_folder_git_tag": "N/A: the Volatility Book folder is not a Git repository",
         "code_sha256": {name: _sha256(code_dir / name) for name in source_files},
         "input_sha256": {
-            "brief": _sha256(
-                output_dir / "2026-08-23_SOL_BRIEF_discrete_vs_continuous_tgarch_study.md"
+            "brief": _sha256_normalized_text(
+                notes_dir / "SOL_BRIEF_discrete_vs_continuous_tgarch_study.md"
             ),
-            "note": _sha256(output_dir / "tgarch_quadratic_drift_note.tex"),
+            "note": _sha256_normalized_text(notes_dir / "tgarch_quadratic_drift_note.tex"),
         },
         "seeds": {f"E{index}": BASE_SEED + index for index in range(1, 8)},
     }

--- a/volatility_book/ch_discrete_vol/notes/SOL_BRIEF_discrete_vs_continuous_tgarch_study.md
+++ b/volatility_book/ch_discrete_vol/notes/SOL_BRIEF_discrete_vs_continuous_tgarch_study.md
@@ -1,0 +1,141 @@
+# Brief for Sol: discrete versus continuous log-normal beta SV study, round 2
+
+Date: 2026-08-23, revision 2. This file replaces the round-1 brief. It
+records the round-1 status, corrects two errors that were in the round-1
+text, and defines the round-2 scope. The working note and the published
+paper remain the technical references. Round-1 results are the archive
+delivered 2026-08-23 (results.md, results.json, figures.pdf, with the
+recorded SHA-256 hashes).
+
+## Round-1 status, as reviewed
+
+- Unit gate: PASS.
+- E1 (prices versus affine expansion): PASS. The residual plateau is a
+  measurement of the expansion itself: 4-5 bp mean (equity-like), 23-26 bp
+  mean and 58 bp max in the 1M wing (crypto-like, vartheta = 1.80). Keep
+  these numbers, they go into the paper's verification section.
+- E2 (kernel consistency): PASS. Exact-Q equals reweighted-P within 3 SE
+  everywhere, ESS >= 0.96, limit-gap rates 0.480 and 0.486 against the
+  predicted sqrt(dt).
+- E3 (GIG stationary law): PASS. The degraded kappa2-at-5% stress is
+  understood: theta_hat rises to 1.23 and the near-inverse-gamma tail index
+  falls toward 1.9, so the KDE tail is noise-dominated. No re-run needed.
+- E4 (moments near the boundary): formal FAIL, reinterpreted. On
+  dt <= 1/252 the log-moment slopes against log(1/dt) are 0.035, 0.017,
+  0.007, 0.001, -0.001 for kappa2_hat = 0, 0.5, 1, 2, 4.25 at p = 1.5,
+  with the same ordering at p = 1.25. Growth is visible for
+  kappa2_hat <= 1 and absent for kappa2_hat >= 2, so the empirical
+  explosion threshold sits near 1-2 against the sufficient boundary
+  beta*p + vartheta*sqrt(p*(p-1)) of 2.26 and 3.06. The weekly point is a
+  coarse-step artifact and broke the round-1 pattern test.
+- E5 (tails): the round-1 brief was wrong and your correction stands, see
+  below. Corrected claim: PASS, Kesten index 2.680, 2.764, 2.802 rising
+  toward 2.846.
+- E6 (filtering): formal FAIL caused by a wrong benchmark in the round-1
+  brief, see below. The data in fact match two closed forms with no fitted
+  constants to within a few percent at fine steps.
+- E7 (QMLE): measurement delivered. gamma1 never reaches median |t| = 2
+  through 40 years (crypto 1.95, equity 0.76), kappa2 bias 0.3-4.1 with
+  kappa1/kappa2 estimate correlation to -0.80. This is the identification
+  case for joint estimation with the d0 restriction.
+
+## Corrections to the standing text (round-1 brief errors)
+
+1. E5 claim. With kappa2 = 0 the limit stationary law is inverse gamma
+   with survival-tail index `1 + 2*kappa1/vartheta^2` (2.846 at the crypto
+   set), not a law with all moments finite. The correct statement is that
+   the fixed-step Kesten index sits below this value and converges up to
+   it as dt shrinks. Do not test for a diverging tail index.
+2. E6 acceptance. The wrong-start forgetting benchmark is not the
+   mean-reversion rate. The filter gain is data-driven and the correct
+   benchmarks, derived from the |z| channel, are
+   - forgetting rate approx `kappa_lin + (eps*m1/s1)/sqrt(dt)`,
+   - steady-state `RMSE approx sigma_bar * sqrt(eps*s1/m1) * dt^0.25`,
+   with `sigma_bar` the time average of the true volatility over the
+   sample (report the theta-based value alongside). Round-1 fitted rates
+   match the first formula within about 4 percent at dt <= 1/1008.
+3. E4 pattern test. Exclude the weekly point. Test growth by the slope of
+   log-moment against log(1/dt) on dt <= 1/252 with a bootstrap confidence
+   interval, growth meaning the interval lies above zero.
+
+Also blessed as the standing convention: E4 varies `kappa2_hat` under
+`Q_LIMIT` holding `d0` and `d1_hat` fixed, exactly as you implemented it.
+The antithetic caveat under `Q_EXACT` (pairs do not share |z| when the
+conditional mean is nonzero) is noted and needs no change.
+
+## Round-2 scope
+
+### R1. Provenance, blocking, do this first
+
+Put the study folder under git, commit, tag. Commit or stash the
+`stochvolmodels` working tree so the run is from a clean tagged state.
+Re-run the light profile and produce a one-table stability report against
+round 1: E1 finest-step errors, E2 fitted rates, E3 baseline sup-density
+errors, E4 moments at kappa2_hat in {0, 4.25}. Agreement within Monte
+Carlo noise closes the item. No manuscript number will be taken from the
+round-1 dirty-tree run.
+
+### R2. E4a: martingale defect at p = 1
+
+Under `Q_LIMIT`, crypto set, estimate `E[S_T * exp(-r*T)] - 1` against dt
+for kappa2_hat in {0, 0.5, 1, 2, 4.25}, maturities T in {0.25, 1.0}, at
+least 2^20 paths with antithetics and bootstrap intervals, common random
+numbers across kappa2_hat. Expected pattern: a defect that converges to a
+strictly negative plateau at kappa2_hat = 0 (the strict-local-martingale
+limit) and to zero for large kappa2_hat. `Q_EXACT` is an exact martingale
+by construction and serves as the zero-defect control at each dt.
+
+### R3. E4b: empirical critical curve, the round-2 headline
+
+Trace the empirical moment-explosion boundary in the (p, kappa2_hat)
+plane and overlay the sufficient curve
+`kappa2_hat = beta*p + vartheta*sqrt(p*(p-1))`.
+Grid: kappa2_hat in {0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5}, dt in
+{1/252, 1/1008, 1/4032, 1/16128}, and powers p in {1.1, 1.2, ..., 1.9}
+evaluated on the same simulated paths, since powers are free given the
+terminal spots. Classify each (p, kappa2_hat) cell by the corrected slope
+test and report the crossing p*(kappa2_hat). Deliver one heatmap figure
+with both curves and a table of crossings with intervals.
+Where the top-0.1 percent tail share exceeds 0.2, either raise paths or
+apply a simple importance-sampling tilt of the volatility innovations;
+timebox the tilt to one day and document a skip if it resists.
+
+### R4. E6a: test the two filter formulas as the acceptance criteria
+
+Rerun the E6 harness unchanged and add two fits per parameter set:
+- regress log RMSE on log dt, report the exponent with an interval,
+  expected 0.25, and compare the level against
+  `sigma_bar * sqrt(eps*s1/m1)`;
+- regress the fitted forgetting rate on 1/sqrt(dt), compare the slope
+  against `eps*m1/s1` and the intercept against the linearized
+  mean-reversion rate.
+Acceptance: both comparisons within 15 percent on dt <= 1/252. Include
+the predicted-versus-observed table in the memo. A finer observation
+scale would need a 1/64512 source grid, run it only if it is cheap.
+
+### R5. E7a: derived-quantity identification, reuse round-1 replications
+
+From the stored per-replication estimates (store them in this round if
+round 1 kept only summaries, same seeds), report bias and RMSE for the
+derived quantities `d0 = kappa1*theta`, `d1 = kappa2*theta - kappa1`,
+`kappa1 + kappa2*theta`, and `vartheta`, plus the eigen-decomposition of
+the (kappa1, kappa2) estimate covariance. Hypothesis to test: the
+well-identified combination is the linearized reversion speed
+`kappa1 + kappa2*theta`, and the ridge is its orthogonal complement.
+Add one profiled variant: re-estimate with kappa2 fixed at truth and
+report the RMSE improvement for kappa1 and theta. This quantifies what an
+option-implied kappa2_hat plus the d0 restriction buys the time series.
+
+### R6. Reporting
+
+Same memo format and conventions as round 1, contradictions first. New
+figures appended to the figures PDF. Every number with script, seed,
+versions, and the new tag. The interpretation caveats of round 1
+(sqrt(dt) scaling relativity, no inference transfer) stand verbatim.
+
+## Order and effort
+
+R1 first and blocking, roughly half a day. Then R3 (the headline), R4,
+R2, R5. Ask before spending more than a day on any single numerical
+difficulty, in particular the importance-sampling tilt in R3. No re-runs
+of E1, E2, E3, E5 beyond the R1 stability check.

--- a/volatility_book/ch_discrete_vol/notes/SOL_BRIEF_discrete_vs_continuous_tgarch_study_1.md
+++ b/volatility_book/ch_discrete_vol/notes/SOL_BRIEF_discrete_vs_continuous_tgarch_study_1.md
@@ -1,0 +1,115 @@
+# Brief for Sol: discrete versus continuous log-normal beta SV study, round 3
+
+Date: 2026-08-23, revision 3. This file replaces the round-2 brief. Round 3
+is a closing round: one blocking traceability item, three small additions,
+and one gated item awaiting a decision. The working note is now at revision
+3 and cites study numbers directly, so number stability is a standing
+obligation from here on.
+
+## Round-2 status, as reviewed
+
+- R1 stability gate: PASS on all comparisons (max z = 2.43). Residual gap:
+  the full-budget E1 and E3 numbers still trace to the round-1 dirty-tree
+  archive, and the clean-tag repeat ran at light budget with ~70 bp wing
+  standard errors. Closed by R6 below.
+- R2: accepted as the round's best result under your reframing, which was
+  correct: both kernels are exact discrete martingales at every step, and
+  the negative estimates are fixed-budget estimator shortfall, the
+  empirical face of the uniform-integrability failure. The note now cites
+  the table in exactly this language.
+- R3: honest downgrade accepted. No cell confirms growth under the
+  bootstrap slope test, the low-kappa2_hat region is tail-unresolved, and
+  the round-1 "threshold near 1-2" reading is retracted. The slope test is
+  the wrong instrument there without importance sampling. Gated item R10.
+- R4: closed. Your Jensen-corrected log-decay intercept
+  `kappa_lin + 0.5*(eps*m1/s1)^2` is adopted, and both filter formulas are
+  now displayed equations in the note with the measured constants.
+- R5: closed. The ridge hypothesis is confirmed (speed-direction cosines
+  0.971-0.9996), and your objection to the oracle framing is accepted: the
+  fixed-kappa2 profile is an oracle ridge-removal proxy, not the
+  option-plus-d0 gain. R8 below builds the honest oracle version of that
+  claim.
+- All three of your mathematical corrections to the round-2 brief stand.
+
+## Numbers now cited in the note (stability obligation)
+
+The note (revision 3) cites: E1 finest-step accuracy (4-5 bp equity mean,
+23-26 bp crypto mean, 58 bp wing max), E2 fitted rates 0.48, E3 relative
+sup-density errors 3-9 percent at daily steps, E5 Kesten indices 2.68,
+2.76, 2.80 against 2.85, R2 shortfalls 0.22 and 0.08 at T = 1 with zero
+for kappa2_hat >= 2, R4 exponents 0.249 and 0.234 with the slope and
+intercept matches, and R5 identification figures (gamma1 unidentified at
+40 years, kappa2 RMSE 56-100 percent, vartheta about 4 percent, kappa_lin
+about 13 percent, cosines above 0.97, d0 at 19-25 percent). Any future run
+that moves one of these outside Monte Carlo noise is a finding to report,
+not a number to overwrite.
+
+## Round-3 scope
+
+### R6. Close traceability, blocking
+
+Rerun E1 at the full round-1 budget under the current clean tag, and store
+the E3 stationary samples in the archive so future stability checks can
+diff samples instead of using repeat-run tolerances. Acceptance: the
+full-budget clean-tag E1 numbers agree with the round-1 archived values
+within combined Monte Carlo error. On acceptance these become the
+manuscript numbers, and the note's sentence about the pending rerun comes
+out. If any strike moves outside noise, report it as a finding and do not
+average the runs.
+
+### R7. Budget dimension of the shortfall
+
+The note claims the R2 shortfall mass "sits in paths that no fixed budget
+samples". Give that claim its budget axis: at T = 1, finest two step
+sizes, kappa2_hat in {0, 0.5, 2}, estimate the discounted-spot shortfall
+at path counts 2^16, 2^18, 2^20, 2^22 with bootstrap intervals, common
+seeds nested so smaller budgets are prefixes of larger ones. Expected
+pattern: slow shrinkage of the shortfall in the budget at kappa2_hat in
+{0, 0.5} and noise around zero at 2. One figure, shortfall against
+log2 paths, one row per kappa2_hat. This is cheap and directly supports a
+sentence already in the note.
+
+### R8. Honest oracle for the option-plus-d0 claim
+
+Extend the R5 profile ladder by one rung. Estimate under three regimes on
+the stored replication samples: (a) unrestricted (done), (b) kappa2 fixed
+at truth (done), (c) kappa2 fixed at truth and d0 fixed at truth, so the
+free drift parameters reduce by one through kappa1 = d0/theta. Report the
+RMSE ladder for kappa1 and theta across sample lengths and both parameter
+sets. Frame the result exactly as: an oracle upper bound on what an
+option-implied kappa2_hat plus the cross-measure d0 restriction can add to
+the time series. Do not frame it as achieved identification from options.
+The real-data joint-estimation experiment stays out of this study's scope.
+
+### R9. Cited-numbers manifest
+
+Generate a machine-readable manifest `cited_numbers.json` mapping every
+note-cited value in the list above to its JSON pointer in the study
+archive and the producing tag. Future runs diff against the manifest
+automatically and report any excursion. This turns the stability
+obligation into a script instead of a reading exercise.
+
+### R10. Gated: importance-sampled boundary figure
+
+Only on explicit go-ahead. A designed importance-sampling scheme
+(exponential tilt of the volatility innovations, tilt chosen per
+kappa2_hat cell, likelihood-ratio weights with ESS control) to resolve the
+tail-unresolved cells of R3 and produce the p*(kappa2_hat) heatmap against
+the sufficient curve. Budget two to three days. The current
+recommendation on record is to drop it, because R2 already carries the
+headline and the boundary figure is decorative unless the paper argues
+sharpness of the sufficient condition. Do not start without the word.
+
+## Reporting
+
+Same memo format, contradictions first, one figures PDF, provenance lines
+per section as in round 2. The standing caveats carry verbatim: all
+convergence statements are relative to the square-root step scaling of
+the kernel loadings, and nothing transfers statistical inference between
+the discrete and continuous models.
+
+## Order and effort
+
+R6 first and blocking, well under a day. Then R7 and R9, each small, then
+R8. R10 only if released. Ask before spending more than a day on any
+single numerical difficulty.

--- a/volatility_book/ch_discrete_vol/notes/tgarch_quadratic_drift_note.tex
+++ b/volatility_book/ch_discrete_vol/notes/tgarch_quadratic_drift_note.tex
@@ -1,0 +1,990 @@
+% ============================================================================
+% AI-DRAFTED BLOCK (Claude), revision 3, 2026-08-23. Entire file is one
+% generated block, delimited per the project seam protocol. Author passages
+% pending:
+%   (1) the economic-mechanism paragraph in Section 1 is marked for redraft
+%       by the author per the project drafting protocol;
+%   (2) bibliography entries marked % TODO carry unverified volume/page data.
+% Revision 3 changes vs revision 2: simulation-backed upgrades from the
+% companion study (through tag tgarch-study-round3-v1). Remark on filtering
+% now carries the two closed-form error laws with measured constants; the
+% tails remark states the verified Kesten-to-inverse-gamma index
+% convergence instead of the former non-commuting-limits claim; Section 5
+% reports the completed verification numbers, the identification results,
+% and the fixed-budget shortfall illustration of the open uniform
+% integrability problem. The full-budget clean-tag pricing rerun and the
+% nested path-budget diagnostic are complete.
+% Revision 2 changes vs revision 1: notation aligned with the published
+% log-normal beta SV paper (signed volatility beta, residual vol-of-vol,
+% hatted Q-parameters); Student-t section removed; one-step kernels presented
+% as a product measure change; exact-filtration proposition added; remarks
+% added on the minimal kernel, on the Girsanov (not Ito) origin of the
+% quadratic term, and on the correspondence with the paper's parameter
+% transformation.
+% ============================================================================
+\documentclass[11pt]{article}
+\usepackage[margin=1.1in]{geometry}
+\usepackage{amsmath,amssymb,amsthm}
+\usepackage{booktabs}
+
+\newtheorem{theorem}{Theorem}
+\newtheorem{proposition}[theorem]{Proposition}
+\newtheorem{lemma}[theorem]{Lemma}
+\newtheorem{corollary}[theorem]{Corollary}
+\newtheorem{assumption}[theorem]{Assumption}
+\theoremstyle{remark}
+\newtheorem{remark}[theorem]{Remark}
+
+\newcommand{\E}{\mathbb{E}}
+\newcommand{\Pm}{\mathbb{P}}
+\newcommand{\Qm}{\mathbb{Q}}
+\newcommand{\R}{\mathbb{R}}
+\newcommand{\Dt}{\Delta}
+
+\title{A Discrete-Time Origin of the Log-Normal Beta Stochastic Volatility
+Model with Quadratic Drift}
+\author{Working note (draft)\thanks{AI-assisted draft, revision 3, prepared
+2026-08-23. All numbered claims carry proofs in the text. Bibliography
+entries marked in the source require verification before any submission
+use.}}
+\date{August 23, 2026}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+The log-normal beta stochastic volatility model with quadratic drift of Sepp
+and Rakhmonov (2023) connects its statistical and risk-neutral dynamics
+through a Girsanov change with two risk prices proportional to volatility,
+whose constants $\bar\lambda_0$ and $\bar\lambda_1$ are free parameters.
+A discrete-time model generating these dynamics, and an economic
+identification of the two constants, have been missing.
+We apply one-period exponential-quadratic pricing kernels with
+volatility-dependent loadings to a threshold recursion on the volatility
+level driven by the single return innovation.
+The risk-neutral drift reproduces the parameter transformation of the
+continuous model with $\bar\lambda_0=\gamma_1$, the slope of the Sharpe
+ratio in volatility, and $\bar\lambda_1=-(m_1/s_1)\,\eta_1$, the slope of
+the kernel variance preference.
+The drift intercept $\kappa_1\theta$ is invariant under every admissible
+kernel, and the recursion converges weakly to the continuous model under
+both measures.
+The recursion supplies an exact volatility filter from returns at every
+step and a cross-measure restriction for joint estimation from returns and
+options.
+\end{abstract}
+
+\section{Introduction and results}\label{sec:intro}
+
+The log-normal beta stochastic volatility (SV) model with quadratic drift
+specifies the volatility dynamics
+$d\sigma_t=(\kappa_1+\kappa_2\sigma_t)(\theta-\sigma_t)\,dt
++\beta\sigma_t\,dW^{(0)}_t+\varepsilon\sigma_t\,dW^{(1)}_t$, with the
+volatility beta $\beta\in\R$ measuring the response of volatility to
+returns and with $\varepsilon>0$ the residual volatility of volatility
+\cite{SeppRakhmonov2023}.
+The published paper connects the statistical and the risk-neutral dynamics
+through a Girsanov change with risk prices
+$\lambda_0(t)=\bar\lambda_0\sigma_t$ and
+$\lambda_1(t)=\bar\lambda_1\sigma_t$, which shifts the quadratic
+mean-reversion rate to
+$\hat\kappa_2=\kappa_2+\beta\bar\lambda_0+\varepsilon\bar\lambda_1$ and
+leaves the products $\kappa_1\theta=\hat\kappa_1\hat\theta$ matched.
+Carr and Willems (2019) study a close relative with the same drift
+structure.
+The discrete-time side of this model family has remained open.
+Nelson (1990) showed that the standard GARCH(1,1) recursion converges to a
+variance diffusion with linear mean reversion, not to the Heston model.
+Duan (1997) extended the convergence theory to an augmented family that
+nests recursions on the volatility level, whose limits carry linear
+drift.
+The affine recursion of Heston and Nandi (2000) converges to the Heston
+model with perfectly correlated shocks.
+No discrete-time model has been shown to generate the quadratic drift, and
+the continuous-time constants $\bar\lambda_0$ and $\bar\lambda_1$ have had
+no primitive interpretation.
+
+We establish three results.
+First, we derive the transformation of the volatility drift under
+one-period exponential-quadratic pricing kernels with volatility-dependent
+loadings (Theorem~\ref{thm:main}).
+The physical drift polynomial $d_0+d_1\sigma+d_2\sigma^2$ maps to
+$d_0+(d_1+\Lambda_0)\sigma+(d_2+\Lambda_1)\sigma^2$, where $\Lambda_0$ and
+$\Lambda_1$ collect the intercepts and the slopes of the Sharpe ratio
+$\gamma(\sigma)=\gamma_0+\gamma_1\sigma$ and of the kernel variance
+preference $\eta(\sigma)=\eta_0+\eta_1\sigma$.
+The map reproduces the parameter transformation of the continuous model
+exactly, with the induced risk prices $\lambda_0(\sigma)=\gamma(\sigma)$
+and $\lambda_1(\sigma)=-(m_1/s_1)\,\eta(\sigma)$.
+The free constants of the published paper acquire discrete primitives:
+$\bar\lambda_0$ is the Sharpe-ratio slope and $\bar\lambda_1$ is the slope
+of the variance preference scaled by the news-impact constant $m_1/s_1$
+(Corollary~\ref{cor:theta} and Remark~\ref{rem:match}).
+Second, we show that the drift intercept $d_0=\kappa_1\theta$ is invariant
+under every admissible pricing kernel, at every step size and in the limit
+(Proposition~\ref{prop:invariance}).
+The invariance turns the matching convention
+$\kappa_1\theta=\hat\kappa_1\hat\theta$ of the published paper into a
+structural restriction available for joint estimation.
+Third, we prove weak convergence of the recursion to the continuous model
+under both measures (Theorem~\ref{thm:limit}), and we show that the
+recursion admits an exact volatility filter from returns at every step
+(Proposition~\ref{prop:filter}), a property the two-Brownian limit does not
+share.
+
+% [AUTHOR: mechanism paragraph below is a placeholder draft. Per project
+% protocol the economic-mechanism passage is author-written. Redraft.]
+Under the risk-neutral measure the volatility drift acquires the covariance
+between the pricing kernel and the volatility innovation.
+The kernel prices two features of the single return innovation: its level,
+at the market Sharpe ratio, and its size, at the variance preference.
+When the Sharpe ratio rises with volatility, the compensation for the level
+shock scales with $\sigma$, and its transmission into the volatility
+recursion scales with $\beta\sigma$, which contributes
+$\beta\gamma_1\sigma^2$ to the drift.
+The variance-preference slope acts in the same way through the size channel
+carried by $\varepsilon$.
+The quadratic drift is the continuous-time image of level-dependent risk
+prices, and the sign of $\beta$ decides which channel can fund it.
+
+The construction subsumes the linear-drift case: setting
+$\kappa_2=\gamma_1=\eta_1=0$ recovers a linear drift under both measures,
+and the physical recursion is exactly the threshold model of Zakoian (1994)
+written on the volatility level.
+As a discrete-to-continuous bridge, the construction substitutes for Heston
+and Nandi (2000) on assets with log-normal volatility and a signed
+volatility beta.
+The cost of switching is the loss of an exact discrete moment-generating
+function recursion, and the retained benefit is a single-shock recursion
+whose volatility is an exact function of observed returns.
+
+One problem stays open, and we state it rather than hide it.
+Weak convergence delivers option prices only for bounded payoffs, and call
+prices require uniform integrability of the discrete price family, which
+fails for $\hat\kappa_2=0$ with $\beta>0$ because the discounted limiting
+stock-price process is a strict local martingale.
+Section~\ref{sec:open} formulates the required uniform moment bound, which
+we regard as the central technical claim of any full paper built on this
+note.
+Section~\ref{sec:model} defines the discrete model.
+Section~\ref{sec:kernel} derives the risk-neutral recursion.
+Section~\ref{sec:limit} states the diffusion limits, and
+Section~\ref{sec:open} collects verification steps, constraints, and the
+open problem.
+
+\section{The discrete model under the physical measure}\label{sec:model}
+
+We fix a horizon $T$, a step $\Dt>0$, and the grid $t_k=k\Dt$.
+Innovations $z_{k}$ are independent standard Gaussian variables on a
+filtered space with filtration $\mathcal{F}_k$ generated by the
+innovations.
+We write $m_1=\E|z|=\sqrt{2/\pi}$ and
+$s_1^2=\operatorname{Var}(|z|)=1-2/\pi$, and we define the standardized
+size innovation
+\begin{equation}\label{eq:w}
+w \;=\; \frac{|z|-m_1}{s_1},
+\end{equation}
+which satisfies $\E[w]=0$, $\E[w^2]=1$ and $\E[z\,w]=0$ by symmetry of $z$.
+The physical model for the log price $X=\ln S$ and the volatility $\sigma$
+is
+\begin{align}
+X_{k+1}&=X_k+\Big(r+\gamma(\sigma_k)\,\sigma_k
+-\tfrac{1}{2}\sigma_k^2\Big)\Dt+\sigma_k\sqrt{\Dt}\,z_{k+1},
+\label{eq:Xdyn}\\
+\sigma_{k+1}&=\sigma_k+b(\sigma_k)\,\Dt
++\sigma_k\sqrt{\Dt}\,\big(\beta\,z_{k+1}+\varepsilon\,w_{k+1}\big),
+\label{eq:sigdyn}
+\end{align}
+with the quadratic drift and the Sharpe ratio
+\begin{equation}\label{eq:drift}
+b(\sigma)=(\kappa_1+\kappa_2\sigma)(\theta-\sigma)
+=d_0+d_1\sigma+d_2\sigma^2,
+\qquad
+\gamma(\sigma)=\gamma_0+\gamma_1\sigma ,
+\end{equation}
+so that $d_0=\kappa_1\theta>0$, $d_1=\kappa_2\theta-\kappa_1$ and
+$d_2=-\kappa_2\le0$, with $\kappa_1,\theta>0$ and $\kappa_2\ge0$ as in the
+continuous model.
+The volatility beta $\beta\in\R$ is signed, the residual volatility of
+volatility satisfies $\varepsilon>0$, and the total variance of the
+volatility innovation is $\vartheta^2=\beta^2+\varepsilon^2$, matching the
+continuous convention.
+The excess return in \eqref{eq:Xdyn} equals $\gamma(\sigma)\sigma$, so
+$\gamma(\sigma)$ is the conditional Sharpe ratio of the asset.
+We believe the affine Sharpe specification is the right trade-off because
+it is the minimal specification that can move the quadratic drift
+coefficient and it nests the proportional risk price
+$\lambda_0=\bar\lambda_0\sigma$ of the continuous model at $\gamma_0=0$
+with $\bar\lambda_0=\gamma_1$.
+
+\begin{lemma}\label{lem:innov}
+The volatility innovation admits the threshold form
+$\beta z+\varepsilon w
+=(\beta+\varepsilon/s_1)\,z^{+}-(\beta-\varepsilon/s_1)\,z^{-}
+-\varepsilon m_1/s_1$
+with $z^{+}=\max(z,0)$ and $z^{-}=\max(-z,0)$, and its variance equals
+$\vartheta^2$.
+\end{lemma}
+
+\begin{proof}
+Substitute $z=z^{+}-z^{-}$ and $|z|=z^{+}+z^{-}$ into
+$\beta z+\varepsilon w$.
+The variance follows from $\E[zw]=0$.
+\end{proof}
+
+The threshold form identifies \eqref{eq:sigdyn} as a Zakoian (1994) model
+on the volatility level with an intercept, so the physical dynamics require
+no new econometrics, and for $\beta<0$ the down-move slope
+$\varepsilon/s_1-\beta$ exceeds the up-move slope, which is the leverage
+asymmetry.
+Both equations are driven by functions of the single innovation $z$, and
+the next proposition records the consequence that the volatility path is an
+exact function of the return path.
+
+\begin{proposition}\label{prop:filter}
+Fix the model parameters and $\sigma_0>0$, and suppose the recursion is
+modified by the localization device of Remark~\ref{rem:trunc} so that
+$\sigma_k>0$ for all $k$.
+Then for every $k$ the volatility $\sigma_k$ is measurable with respect to
+$\sigma(X_1,\dots,X_k;\sigma_0)$: the innovation is recovered from the
+observed return by
+\begin{equation}\label{eq:filter}
+z_{k+1}
+=\frac{X_{k+1}-X_k-\big(r+\gamma(\sigma_k)\sigma_k
+-\tfrac{1}{2}\sigma_k^2\big)\Dt}{\sigma_k\sqrt{\Dt}},
+\end{equation}
+and \eqref{eq:sigdyn} then determines $\sigma_{k+1}$.
+The same statement holds under the risk-neutral measure with the
+risk-neutral drifts.
+\end{proposition}
+
+\begin{proof}
+Induction over $k$: given $\sigma_k>0$, equation \eqref{eq:filter} inverts
+\eqref{eq:Xdyn} for $z_{k+1}$, the size innovation $w_{k+1}$ is the
+deterministic transform \eqref{eq:w} of $z_{k+1}$, and \eqref{eq:sigdyn}
+delivers $\sigma_{k+1}$.
+\end{proof}
+
+\begin{remark}[Estimation]\label{rem:qmle}
+Proposition~\ref{prop:filter} makes estimation identical to threshold GARCH
+inference.
+The volatility $\sigma_k$ is predictable, so the return over
+$(t_k,t_{k+1}]$ is conditionally Gaussian with mean
+$(r+\gamma(\sigma_k)\sigma_k-\tfrac{1}{2}\sigma_k^2)\Dt$ and variance
+$\sigma_k^2\Dt$, and the sample likelihood is the prediction-error
+decomposition
+\begin{equation}\label{eq:qmle}
+\ell=-\frac{1}{2}\sum_{k=0}^{n-1}
+\Big(\ln\big(2\pi\sigma_k^2\Dt\big)+z_{k+1}^2\Big),
+\end{equation}
+with $z_{k+1}$ recovered by \eqref{eq:filter} and $\sigma_{k+1}$ updated by
+\eqref{eq:sigdyn} inside the same loop.
+The Sharpe function sits in the conditional mean, so $\gamma_1$ is
+estimated as an in-mean coefficient from returns alone, and it is the same
+constant that the kernel maps to the risk price $\bar\lambda_0$ in
+Section~\ref{sec:kernel}.
+The initial value $\sigma_0$ is a parameter or is set to $\theta$, with an
+influence that decays at the mean-reversion rate.
+Under Gaussian innovations \eqref{eq:qmle} is the exact likelihood, and
+otherwise it is a quasi-likelihood in the usual sense.
+\end{remark}
+
+\begin{remark}\label{rem:filtergap}
+The limit model does not share this property, because the size innovations
+$w_k$ aggregate into a Brownian motion $W^{(1)}$ independent of the return
+Brownian $W^{(0)}$, and the limit volatility is not spanned by returns.
+Exact filterability at every $\Dt$ and unspanned volatility in the limit
+are reconciled by the asymptotic filtering theory of Nelson and Foster
+(1994), and the reconciliation is quantitative.
+Applied to a path of the two-shock limit model, the filter of
+Proposition~\ref{prop:filter} corrects its own error at the data-driven
+rate
+\begin{equation}\label{eq:filterrate}
+g_\Dt=\kappa_{\mathrm{lin}}
++\frac{\varepsilon\,m_1}{s_1}\,\frac{1}{\sqrt{\Dt}},
+\qquad
+\kappa_{\mathrm{lin}}=\kappa_1+\kappa_2\theta,
+\end{equation}
+because an overestimated volatility shrinks the recovered residuals and
+the size channel pushes the estimate back down.
+Balancing this gain against the unspanned noise gives the steady-state
+error
+\begin{equation}\label{eq:filterrmse}
+\mathrm{RMSE}\;\approx\;\bar\sigma\,
+\sqrt{\varepsilon\, s_1/m_1}\;\Dt^{1/4},
+\end{equation}
+with $\bar\sigma$ the average volatility level, which is the
+Nelson--Foster rate with explicit constants.
+The companion simulation study confirms both
+formulas.\footnote{All simulation numbers quoted in this note are from the
+companion study (module \texttt{volatility\_book.ch\_discrete\_vol}). The
+full-budget clean rerun and closing diagnostics use tag
+\texttt{tgarch-study-round3-v1}; earlier inputs retain their producing tags.
+The file \texttt{cited\_numbers.json} maps every quoted value to its JSON
+pointer and producing tag, with seeds, package versions and hashes retained
+in the study archive.}
+Fitted error exponents are $0.249$ and $0.234$ at the two parameter sets
+against the predicted $1/4$, the gain slope matches
+$\varepsilon m_1/s_1$ within a tenth of a percent, and the level matches
+\eqref{eq:filterrmse} within ten percent using the realized average
+volatility.
+A pathwise log-decay regression measures the intercept as the
+Jensen-corrected value
+$\kappa_{\mathrm{lin}}+\tfrac{1}{2}(\varepsilon m_1/s_1)^2$, within about nine
+percent, because the multiplicative noise of the error accelerates the
+decay of its logarithm.
+\end{remark}
+
+\begin{table}[h]
+\centering
+\caption{Notation. Quantities carry units of inverse time where the
+continuous model requires it ($r$, $\kappa_1$, $\kappa_2\theta$, $d_i$),
+and $\Dt$ carries units of time.}
+\begin{tabular}{ll}
+\toprule
+$z,\,w$ & return innovation, size innovation \eqref{eq:w}\\
+$m_1,\,s_1$ & mean and standard deviation of $|z|$\\
+$\beta,\,\varepsilon,\,\vartheta$ & volatility beta ($\beta\in\R$),
+residual vol-of-vol, $\vartheta^2=\beta^2+\varepsilon^2$\\
+$b,\,\hat b$ & drift polynomials of $\sigma$ under $\Pm$ and $\Qm$\\
+$d_0,d_1,d_2$ and $\hat d_0,\hat d_1,\hat d_2$ & coefficients of the drift
+polynomials\\
+$\gamma(\sigma)=\gamma_0+\gamma_1\sigma$ & conditional Sharpe ratio\\
+$\eta(\sigma)=\eta_0+\eta_1\sigma$ & variance-preference loading\\
+$\Lambda(\sigma)=\Lambda_0+\Lambda_1\sigma$ & volatility risk adjustment
+(Proposition~\ref{prop:qmoments})\\
+$\kappa_1,\kappa_2,\theta$ and $\hat\kappa_1,\hat\kappa_2,\hat\theta$ &
+drift parameters under $\Pm$ and $\Qm$\\
+$\kappa_{\mathrm{lin}}=\kappa_1+\kappa_2\theta$ & linearized reversion
+speed \eqref{eq:filterrate}\\
+$\lambda_0(\sigma),\,\lambda_1(\sigma)$ & induced risk prices of the return
+and size channels\\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\section{Pricing kernels and the risk-neutral recursion}\label{sec:kernel}
+
+This section performs the change of measure and computes the risk-neutral
+drift of the volatility recursion.
+The measure change is specified through one-period kernels, and we first
+make precise in what sense this is a single change of measure rather than a
+new one at every step.
+Let $M_{k+1}$ be a positive $\mathcal{F}_{k+1}$-measurable variable with
+$\E_k[M_{k+1}]=1$, and define
+\begin{equation}\label{eq:product}
+\zeta_n=\prod_{k=0}^{n-1}M_{k+1},
+\qquad
+\frac{d\Qm}{d\Pm}\Big|_{\mathcal{F}_n}=\zeta_n .
+\end{equation}
+The process $\zeta$ is a positive $\Pm$-martingale by construction, the
+one-period kernels are its multiplicative increments, and \eqref{eq:product}
+is the discrete counterpart of the It\^{o} exponential that defines the
+measure change of the continuous model.
+The factorization into one-period kernels is not an extra assumption,
+because every positive martingale density factorizes this way.
+The one-period form is what makes the discounted price a $\Qm$-martingale
+over each step rather than only at the horizon, which is the discrete
+statement of dynamic no-arbitrage.
+The kernel class is exponential-quadratic in the return innovation, in the
+spirit of the variance-dependent kernel of Christoffersen, Heston and
+Jacobs (2013).
+Its loadings are affine in the volatility level,
+\begin{equation}\label{eq:kernel}
+M_{k+1}
+\;\propto\;
+\exp\!\big(a_k z_{k+1}+b_k z_{k+1}^2\big),
+\qquad
+b_k=\sqrt{\Dt}\,\eta(\sigma_k),\quad
+\eta(\sigma)=\eta_0+\eta_1\sigma ,
+\end{equation}
+normalized to unit conditional expectation, with $a_k$ determined below by
+the martingale condition and with $b_k<1/2$, which holds for all small
+$\Dt$ on compact volatility sets.
+The $\sqrt{\Dt}$ scaling of the loadings is a choice, and any convergence
+statement below is a statement about this scaling scheme, in line with the
+non-uniqueness results of Corradi (2000).
+We adopt it because it is the unique power scaling under which the risk
+adjustment neither vanishes nor explodes in the limit.
+
+\begin{lemma}\label{lem:qlaw}
+Under $\Qm$ the innovation $z_{k+1}$ given $\mathcal{F}_k$ is Gaussian with
+mean $\lambda_k=a_k\varsigma_k^2$ and variance
+$\varsigma_k^{2}=(1-2b_k)^{-1}$.
+\end{lemma}
+
+\begin{proof}
+The conditional $\Qm$-density is proportional to
+$\varphi(z)\exp(a_k z+b_k z^2)
+\propto\exp\{-\tfrac{1}{2}(1-2b_k)z^2+a_k z\}$, and completing the square
+gives the stated Gaussian law.
+\end{proof}
+
+\begin{proposition}\label{prop:pinned}
+For each $b_k<1/2$ there exists a unique $a_k$ such that the discounted
+price $e^{-r t_k+X_k}$ is a $\Qm$-martingale, and it satisfies
+\begin{equation}\label{eq:lambda}
+\lambda_k=-\sqrt{\Dt}\,\gamma(\sigma_k)
+-\tfrac{1}{2}\,\sigma_k\sqrt{\Dt}\,\big(\varsigma_k^{2}-1\big)
+=-\sqrt{\Dt}\,\gamma(\sigma_k)+O(\Dt),
+\end{equation}
+locally uniformly in $\sigma_k$.
+\end{proposition}
+
+\begin{proof}
+By Lemma~\ref{lem:qlaw} the martingale condition
+$\E^{\Qm}_k[e^{X_{k+1}-X_k}]=e^{r\Dt}$ reads
+$\gamma(\sigma)\sigma\Dt+\sigma\sqrt{\Dt}\,\lambda_k
++\tfrac{1}{2}\sigma^2\Dt(\varsigma_k^2-1)=0$, which solves to
+\eqref{eq:lambda}.
+The map $a\mapsto\lambda=a\varsigma_k^2$ is a strictly increasing bijection
+of $\R$ for fixed $b_k<1/2$, so $a_k$ exists and is unique.
+The remainder in \eqref{eq:lambda} is $O(\Dt)$ because
+$\varsigma_k^2-1=2b_k/(1-2b_k)=2\sqrt{\Dt}\,\eta(\sigma)+O(\Dt)$, with
+constants uniform on compact volatility sets since $\gamma$ and $\eta$ are
+affine.
+\end{proof}
+
+The martingale condition therefore pins the level loading to the Sharpe
+ratio, and the only free input of the kernel is the variance preference
+$\eta$.
+The proof also records a cancellation worth naming.
+The It\^{o} compensator $-\sigma^2/2$ of the log return cancels against the
+quadratic term of the risk-neutral moment generating function up to order
+$\Dt^{3/2}$, so the convexity of log returns leaves no trace in
+\eqref{eq:lambda} at the relevant order.
+The next step is the one place in the derivation where something can go
+wrong, so we spell out why it does not.
+The volatility innovation contains $|z|$, and a location shift of size
+$\sqrt{\Dt}$ in $z$ could in principle feed the Sharpe ratio into the size
+channel at order $\sqrt{\Dt}$, which would entangle the two risk prices in
+the drift.
+It cannot, because the first derivative of the absolute moment with respect
+to a location shift vanishes at zero for every symmetric law: with
+$h(x)=\E|z+x|$ one has $h'(0)=\E[\operatorname{sgn}(z)]=0$.
+Symmetry of the innovation law is load-bearing here, and the channels
+decouple at leading order precisely because of it.
+Under skewed innovations the decomposition below acquires a cross term
+proportional to $h'(0)$, which we leave to a skewed extension.
+
+\begin{proposition}\label{prop:qmoments}
+Let $h(x)=2\varphi(x)+x\,(2\Phi(x)-1)$ denote the absolute moment of a unit
+Gaussian shifted by $x$, with $\varphi$ and $\Phi$ the standard normal
+density and distribution function.
+Under the kernel \eqref{eq:kernel} with $a_k$ from
+Proposition~\ref{prop:pinned},
+\begin{equation}\label{eq:Lambda}
+\E^{\Qm}_k\big[\beta z_{k+1}+\varepsilon w_{k+1}\big]
+=\sqrt{\Dt}\,\Lambda(\sigma_k)+O(\Dt),
+\qquad
+\Lambda(\sigma)
+=-\beta\,\gamma(\sigma)+\varepsilon\,\frac{m_1}{s_1}\,\eta(\sigma),
+\end{equation}
+together with
+$\operatorname{Var}^{\Qm}_k(\beta z+\varepsilon w)
+=\vartheta^2+O(\sqrt{\Dt})$ and
+$\operatorname{Cov}^{\Qm}_k(z,\beta z+\varepsilon w)
+=\beta+O(\sqrt{\Dt})$,
+all locally uniformly in $\sigma_k$.
+\end{proposition}
+
+\begin{proof}
+By Lemma~\ref{lem:qlaw},
+$\E^{\Qm}_k|z|=\varsigma_k\,h(\lambda_k/\varsigma_k)$.
+Direct differentiation gives $h'(x)=2\Phi(x)-1$ and $h''(x)=2\varphi(x)$,
+so $h(x)=m_1+\varphi(0)x^2+O(x^4)$ and
+$\E^{\Qm}_k|z|=\varsigma_k m_1+O(\lambda_k^2)
+= m_1+\sqrt{\Dt}\,\eta(\sigma_k)\,m_1+O(\Dt)$.
+Combining with $\E^{\Qm}_k[z]=\lambda_k$ from \eqref{eq:lambda} inside
+\eqref{eq:w} yields \eqref{eq:Lambda}.
+The variance and covariance are smooth functions of
+$(\lambda_k,\varsigma_k)$ that equal $(\vartheta^2,\beta)$ at $(0,1)$, and
+$(\lambda_k,\varsigma_k)=(0,1)+O(\sqrt{\Dt})$, which gives the stated
+perturbations.
+Uniformity holds on compact volatility sets because the loadings are
+affine.
+\end{proof}
+
+\begin{theorem}\label{thm:main}
+Under the kernel \eqref{eq:kernel} the volatility recursion under $\Qm$
+takes the form
+\begin{equation}\label{eq:qrec}
+\sigma_{k+1}=\sigma_k+\hat b_{\Dt}(\sigma_k)\,\Dt
++\sigma_k\sqrt{\Dt}\,\bar{u}_{k+1},
+\qquad
+\bar{u}_{k+1}=\beta z_{k+1}+\varepsilon w_{k+1}
+-\E^{\Qm}_k\big[\beta z_{k+1}+\varepsilon w_{k+1}\big],
+\end{equation}
+where $\bar u$ has conditional mean zero, conditional variance
+$\vartheta^2+O(\sqrt{\Dt})$, conditional covariance $\beta+O(\sqrt{\Dt})$
+with the return innovation, and
+\begin{equation}\label{eq:driftmap}
+\hat b_{\Dt}(\sigma)\;\longrightarrow\;
+\hat b(\sigma)= d_0+\big(d_1+\Lambda_0\big)\sigma
++\big(d_2+\Lambda_1\big)\sigma^{2},
+\qquad
+\begin{aligned}
+\Lambda_0&=-\beta\gamma_0+\varepsilon\, m_1\eta_0/s_1,\\
+\Lambda_1&=-\beta\gamma_1+\varepsilon\, m_1\eta_1/s_1,
+\end{aligned}
+\end{equation}
+locally uniformly as $\Dt\to0$.
+In particular, the risk-neutral quadratic mean-reversion rate is
+\begin{equation}\label{eq:kappa2}
+\hat\kappa_2 \;=\; -\hat d_2
+\;=\; \kappa_2+\beta\,\gamma_1-\varepsilon\,\frac{m_1}{s_1}\,\eta_1 .
+\end{equation}
+\end{theorem}
+
+\begin{proof}
+Adding and subtracting the conditional mean in \eqref{eq:sigdyn} gives
+\eqref{eq:qrec} with the exact identity
+$\hat b_{\Dt}(\sigma)=b(\sigma)
++\sigma\,\E^{\Qm}_k[\beta z+\varepsilon w]/\sqrt{\Dt}$, and
+Proposition~\ref{prop:qmoments} gives
+$\E^{\Qm}_k[\beta z+\varepsilon w]
+=\sqrt{\Dt}\Lambda(\sigma)+O(\Dt)$ locally uniformly.
+Collecting powers of $\sigma$ in $b(\sigma)+\sigma\Lambda(\sigma)$ yields
+\eqref{eq:driftmap}, and \eqref{eq:kappa2} follows from $d_2=-\kappa_2$.
+\end{proof}
+
+\begin{remark}\label{rem:match}
+Theorem~\ref{thm:main} lands exactly on the continuous transformation of
+Sepp and Rakhmonov (2023, Section 2).
+Their Girsanov change with risk prices $\lambda_0(\sigma)$ and
+$\lambda_1(\sigma)$ shifts the volatility drift by
+$-\sigma\,(\beta\lambda_0(\sigma)+\varepsilon\lambda_1(\sigma))$, and
+comparison with \eqref{eq:Lambda} identifies the induced prices
+\begin{equation}\label{eq:prices}
+\lambda_0(\sigma)=\gamma(\sigma),
+\qquad
+\lambda_1(\sigma)=-\frac{m_1}{s_1}\,\eta(\sigma).
+\end{equation}
+Their proportional specification
+$\lambda_0=\bar\lambda_0\sigma$, $\lambda_1=\bar\lambda_1\sigma$
+corresponds to $\gamma_0=\eta_0=0$ with $\bar\lambda_0=\gamma_1$ and
+$\bar\lambda_1=-(m_1/s_1)\,\eta_1$, and then \eqref{eq:kappa2} reads
+$\hat\kappa_2=\kappa_2+\beta\bar\lambda_0+\varepsilon\bar\lambda_1$, which
+is their transformation verbatim.
+The constants gain discrete primitives: the equity risk price is the
+Sharpe-ratio slope, the volatility risk price is the variance-preference
+slope, and the conversion factor $m_1/s_1=\sqrt{2/\pi}/\sqrt{1-2/\pi}$ is a
+property of the absolute-value news-impact function.
+The intercepts $\gamma_0$ and $\eta_0$ move only the linear coefficient
+$\hat d_1$, which explains why the proportional specification of the
+published paper leaves $\kappa_1-\kappa_2\theta$ unchanged.
+\end{remark}
+
+\begin{remark}\label{rem:esscher}
+The variance loading is optional.
+With $\eta\equiv0$ the kernel is linear in the innovation, the minimal
+one-period martingale change, and the limit exists unchanged with
+$\bar\lambda_1=0$ and $\hat\kappa_2=\kappa_2+\beta\gamma_1$.
+The quadratic loading exists for one purpose only, which is to generate a
+nonzero price of the size channel, and it is not needed for the log-return
+limit.
+\end{remark}
+
+\begin{remark}\label{rem:ito}
+The quadratic term in \eqref{eq:kappa2} is a Girsanov product, not an
+It\^{o} correction.
+Setting $\gamma_1=\eta_1=0$ gives $\hat\kappa_2=\kappa_2$ exactly, although
+every convexity term of the model, including the log-return compensator
+$-\sigma^2/2$, remains in place, and the proof of
+Proposition~\ref{prop:pinned} shows that this compensator cancels at the
+relevant order.
+The shift $\hat\kappa_2-\kappa_2$ is the product of the level-proportional
+dispersion $\beta\sigma$ with the level-proportional risk price
+$\gamma_1\sigma$, plus the analogous product in the size channel, which is
+the same structure as the continuous Girsanov computation of the published
+paper.
+\end{remark}
+
+Two structural readings of \eqref{eq:driftmap} deserve emphasis.
+The intercepts $\gamma_0$ and $\eta_0$ move only the linear coefficient, so
+the quadratic coefficient is funded exclusively by the slopes of the two
+risk prices.
+The intercept $d_0$ does not move at all, and the next proposition shows
+that this invariance is a property of the recursion class rather than of
+the exponential-quadratic family.
+
+\begin{proposition}\label{prop:invariance}
+Let the pricing kernel be any positive $\mathcal{F}_{k+1}$-measurable
+random variable $M_{k+1}$ with $\E_k[M_{k+1}]=1$ and
+$\E_k[M_{k+1}(|z_{k+1}|+|w_{k+1}|)]<\infty$, and suppose the rescaled
+adjustment
+$\E_k[M_{k+1}(\beta z_{k+1}+\varepsilon w_{k+1})]/\sqrt{\Dt}$ converges
+locally uniformly to some function $\Lambda(\sigma)$.
+Then the risk-neutral drift satisfies
+$\hat b(\sigma)=b(\sigma)+\sigma\Lambda(\sigma)$, and in particular
+$\hat b(0)=b(0)=d_0$, equivalently
+$\hat\kappa_1\hat\theta=\kappa_1\theta$.
+\end{proposition}
+
+\begin{proof}
+The change of measure alters the drift of \eqref{eq:sigdyn} by
+$\sigma_k\sqrt{\Dt}\,\E_k[M_{k+1}(\beta z_{k+1}+\varepsilon w_{k+1})]$,
+which is proportional to $\sigma_k$ for every admissible kernel because the
+innovation enters the recursion only through the dispersion term.
+Kernels that load on shocks independent of $z$ multiply the adjustment by a
+factor with unit expectation and leave the conclusion unchanged.
+\end{proof}
+
+\begin{remark}
+Proposition~\ref{prop:invariance} is the discrete image of the Girsanov
+theorem for the limit diffusion: the drift adjustment is proportional to
+the dispersion, which vanishes linearly at zero volatility.
+In the published paper the equality $\kappa_1\theta=\hat\kappa_1\hat\theta$
+enters as the first of the parameter-matching equations, and the
+proposition shows that it is not a convention: no admissible kernel can
+break it, at any step size.
+\end{remark}
+
+\begin{corollary}\label{cor:theta}
+Write the risk-neutral drift as
+$\hat b(\sigma)=(\hat\kappa_1+\hat\kappa_2\sigma)(\hat\theta-\sigma)$ with
+$\hat\kappa_2>0$.
+Then the parameters are determined by the polynomial coefficients through
+\begin{equation}\label{eq:thetaQ}
+\hat\kappa_2=-\hat d_2,\qquad
+\hat\theta
+=\frac{\hat d_1+\sqrt{\hat d_1^{\,2}+4\,\hat\kappa_2\,d_0}}
+{2\,\hat\kappa_2},
+\qquad
+\hat\kappa_1=\frac{d_0}{\hat\theta},
+\end{equation}
+and with $\hat d_1=-(\kappa_1-\kappa_2\theta)$ these are the
+risk-transformed parameters of Sepp and Rakhmonov (2023, Section 2).
+The level $\hat\theta$ equals the physical level $\theta$ only on the
+one-parameter kernel set with $\Lambda_0=(\hat\kappa_2-\kappa_2)\theta$.
+\end{corollary}
+
+\begin{proof}
+Expanding the factorized form gives $d_0=\hat\kappa_1\hat\theta$,
+$\hat d_1=\hat\kappa_2\hat\theta-\hat\kappa_1$ and
+$\hat d_2=-\hat\kappa_2$.
+Eliminating $\hat\kappa_1$ yields
+$\hat\kappa_2\hat\theta^2-\hat d_1\hat\theta-d_0=0$, whose unique positive
+root is \eqref{eq:thetaQ} because $\hat\kappa_2>0$ and $d_0>0$.
+Setting $\hat\theta=\theta$ in the quadratic and using
+$\hat d_1=d_1+\Lambda_0$ with $d_0=\kappa_1\theta$ gives the stated
+restriction on $\Lambda_0$.
+\end{proof}
+
+Corollary~\ref{cor:theta} settles the parametrization question that
+motivated this note.
+The triple $(\hat\kappa_1,\hat\kappa_2,\hat\theta)$ obscures the measure
+change because all three parameters move together, while the polynomial
+coefficients separate cleanly: $\hat d_2$ carries the risk-price slopes,
+$\hat d_1$ carries the risk-price levels, and $d_0$ carries nothing.
+We therefore parametrize the discrete model, and its reference
+implementation, by $(d_0,d_1,d_2)$ with the cross-measure restriction
+$d_0^{\Pm}=d_0^{\Qm}$ imposed in any joint estimation from returns and
+options.\footnote{Reference implementation planned in the open-source
+\texttt{stochvolmodels} package,
+\texttt{github.com/ArturSepp/StochVolModels}.}
+
+The transformation formula has one falsifiable consequence worth stating.
+On the minimal kernel set of Remark~\ref{rem:esscher}, equation
+\eqref{eq:kappa2} reduces to $\hat\kappa_2=\kappa_2+\beta\gamma_1$.
+For assets with $\beta>0$, option surfaces must display
+$\hat\kappa_2>\kappa_2$ whenever the time-series Sharpe ratio increases in
+volatility, before any volatility risk premium is invoked.
+For assets with $\beta<0$ the level channel contributes
+$-|\beta|\gamma_1$, so an increase of the quadratic rate requires the size
+channel with $\eta_1<0$, equivalently $\bar\lambda_1>0$, or a Sharpe ratio
+that falls with volatility.
+Which channel funds the quadratic drift is an empirical question whose
+answer the model links, through \eqref{eq:kappa2}, to the sign of the
+volatility beta.
+
+\section{Diffusion limits}\label{sec:limit}
+
+We now state the convergence of the recursion to the continuous model, and
+we state it under both measures, because nothing in the argument prefers
+one of them.
+The physical recursion satisfies the convergence conditions directly, and
+the risk-neutral recursion satisfies them after the drift map of
+Theorem~\ref{thm:main}.
+The conditions are those of Nelson (1990), which descend from the
+Markov-chain convergence theory of Stroock and Varadhan, and the
+verification is a bookkeeping exercise given the moment expansions above.
+
+\begin{assumption}\label{ass:limit}
+The parameters satisfy $\kappa_1,\theta>0$, $\kappa_2\ge0$ and
+$\hat\kappa_2\ge0$, the initial values converge, and the recursion is
+modified by the localization device of Remark~\ref{rem:trunc}.
+\end{assumption}
+
+\begin{theorem}\label{thm:limit}
+Under Assumption~\ref{ass:limit} the interpolated processes
+$(X^{\Dt},\sigma^{\Dt})$ converge weakly, as $\Dt\to0$, to the unique
+solution of the log-normal beta SV model.
+Under $\Pm$ the limit is
+\begin{equation}\label{eq:limitP}
+dX_t=\Big(r+\gamma(\sigma_t)\sigma_t-\tfrac{1}{2}\sigma_t^2\Big)dt
++\sigma_t\,dW^{(0)}_t,
+\quad
+d\sigma_t=b(\sigma_t)\,dt
++\beta\sigma_t\,dW^{(0)}_t+\varepsilon\sigma_t\,dW^{(1)}_t,
+\end{equation}
+and under $\Qm$ the limit is the same system with drift
+$r-\sigma_t^2/2$ for the log price and
+$\hat b(\sigma_t)=(\hat\kappa_1+\hat\kappa_2\sigma_t)
+(\hat\theta-\sigma_t)$ for the volatility, with
+$W^{(0)}$ and $W^{(1)}$ independent Brownian motions under the respective
+measure and parameters given by Corollary~\ref{cor:theta}.
+\end{theorem}
+
+\begin{proof}
+Under $\Pm$ the per-unit-time conditional means of the increments equal the
+drifts of \eqref{eq:limitP} exactly, and under $\Qm$ they converge to the
+risk-neutral drifts locally uniformly by Proposition~\ref{prop:qmoments}
+and Theorem~\ref{thm:main}.
+The conditional covariance matrix of the pair converges to
+$\sigma^2\begin{pmatrix}1&\beta\\ \beta&\vartheta^2\end{pmatrix}$ under
+both measures, which is the covariance of
+$(\sigma dW^{(0)},\,\sigma(\beta dW^{(0)}+\varepsilon dW^{(1)}))$, because
+the vector $(z,w)$ is uncorrelated with unit variances and its partial
+sums aggregate into two independent Brownian motions.
+Fourth conditional moments of the increments are of order $\Dt^2$ times
+fourth innovation moments, which are finite for Gaussian innovations, so
+they vanish at the required rate on compact sets.
+The limit martingale problem is well posed: the volatility equation has a
+unique strong solution with values in $(0,\infty)$ despite the
+non-Lipschitz drift \cite{SeppRakhmonov2023}, and appending the log-price
+equation preserves uniqueness because its coefficients are Lipschitz given
+the volatility path.
+Convergence then follows from Theorem 2.1 of Nelson (1990).
+\end{proof}
+
+\begin{remark}\label{rem:trunc}
+Two localization devices make the recursion well defined for all states and
+change nothing in the limit.
+We truncate the innovation at $\pm\varepsilon_0/\sqrt{\Dt}$ for a small
+fixed $\varepsilon_0$, which alters each conditional moment by $o(\Dt)$
+under Gaussian tails, and we evaluate the quadratic drift term at
+$\sigma\wedge\Dt^{-1/2}$, which is invisible on compact sets.
+Weak convergence to a well-posed limit depends on the generator only
+through its values on compacts, so both devices are limit-invariant.
+The truncation also keeps the volatility strictly positive for small
+$\varepsilon_0$, because the drift at zero equals $d_0>0$ while the
+dispersion vanishes.
+\end{remark}
+
+\begin{remark}\label{rem:equiv}
+At every fixed $\Dt$ the one-period kernels define an equivalent measure
+change without further conditions.
+The equivalence condition of the continuous model, which requires
+$\hat\kappa_2\ge0$ in the notation of the published paper, reappears only
+through the well-posedness of the limit, so the discrete family
+regularizes the measure-equivalence boundary and the constraint binds in
+the limit alone.
+\end{remark}
+
+\begin{remark}\label{rem:gig}
+The stationary density of the limit volatility follows from the scale and
+speed measures,
+\begin{equation}\label{eq:gig}
+p(\sigma)\;\propto\;
+\sigma^{\,2\hat d_1/\vartheta^2-2}\,
+\exp\!\Big(-\frac{2d_0}{\vartheta^2\,\sigma}
+-\frac{2\hat\kappa_2}{\vartheta^2}\,\sigma\Big),
+\qquad \sigma>0,
+\end{equation}
+a generalized inverse Gaussian law, which degenerates to an inverse gamma
+law as $\hat\kappa_2\to0$.
+This matches the steady state derived by Carr and Willems (2019) for their
+quadratic-drift specification and provides a free numerical checkpoint: the
+ergodic distribution of the simulated recursion must converge to
+\eqref{eq:gig}.
+In the linear-drift case $\kappa_2=0$ the tails admit a sharper statement.
+At fixed $\Dt$ the recursion is a stochastic recurrence equation, and
+Kesten-type results give its stationary law a power tail with index
+$\chi_\Dt$ solving
+$\E\,|1+d_1\Dt+\sqrt{\Dt}\,(\beta z+\varepsilon w)|^{\chi}=1$.
+The limit law is itself power-tailed, an inverse gamma with survival index
+$1+2\kappa_1/\vartheta^2$, and $\chi_\Dt$ sits below this value and rises
+toward it as the step shrinks.
+The companion study confirms the gap and its closure, with
+$\chi_\Dt=2.68$, $2.76$ and $2.80$ at weekly, daily and finer steps
+against the limit index $2.85$.
+The discrete tails are therefore heavier than the limit tails at any
+fixed step, by a computable margin rather than by a change of tail class.
+\end{remark}
+
+\section{Verification, constraints, and the open problem}\label{sec:open}
+
+Three verification steps preceded this revision, and all three are now on
+record in the companion simulation study.
+The simulated risk-neutral recursion reproduces the affine-expansion
+prices of the continuous model, and the residual at the finest step
+measures the expansion itself.
+Mean absolute implied-volatility errors are 4 to 5 basis points at the
+equity-like parameter set.
+At the crypto-like set with $\vartheta=1.80$ they are 23 to 26 basis
+points, with a maximum of 58 basis points in the one-month wing.
+The full-budget clean-tag rerun reproduces every finest-step strike from the
+archived run exactly under the retained common seeds, so the quoted values
+are now the clean-tag manuscript numbers.
+The kernel algebra is validated end to end.
+Prices from the exact risk-neutral law and from likelihood-ratio
+reweighting of physical paths agree within Monte Carlo error at every
+step size, and the gap of the limit recursion closes at fitted rates of
+$0.48$ against the predicted $\sqrt{\Dt}$.
+The ergodic density of the simulated volatility matches \eqref{eq:gig}
+with relative sup-density errors of $5.63$ and $8.69$ percent at daily
+steps, falling to $2.95$ and $6.42$ percent at $\Dt=1/1008$.
+The remaining verification item is the cross-measure restriction
+$d_0^{\Pm}=d_0^{\Qm}$ on joint return and option data, where it supplies
+one overidentifying restriction and one stability diagnostic.
+
+The estimation experiment of Remark~\ref{rem:qmle} quantifies what the
+time series alone can deliver, and the answer motivates the
+parametrization adopted after Corollary~\ref{cor:theta}.
+Across 200 replications at daily steps, the Sharpe slope $\gamma_1$ does
+not reach a median absolute $t$-statistic of two even at forty years.
+At forty years, $\kappa_2$ carries relative root-mean-square errors of 56
+to 100 percent, while the relative errors of the total volatility of
+volatility $\vartheta$ and the linearized reversion speed
+$\kappa_{\mathrm{lin}}$ are about 4 and 13 percent.
+The speed direction aligns with the low-variance eigendirection of the
+$(\kappa_1,\kappa_2)$ estimates with cosines above $0.97$; this is a
+conditional local ridge diagnostic evaluated at the true $\theta$.
+The intercept $d_0$ has a forty-year relative error of 19 to 25 percent,
+and the split of the curvature between $\kappa_1$ and $\kappa_2$ is the
+ridge.
+An oracle ladder quantifies what two restrictions can add.
+At forty years, fixing physical $\kappa_2$ and $d_0$ at truth reduces the
+$\kappa_1$ RMSE by 79 to 80 percent relative to the unrestricted fit and
+by 67 to 69 percent relative to fixing $\kappa_2$ alone; the corresponding
+$\theta$ reductions are 10 to 14 percent and 6 to 7 percent.
+This is an oracle upper bound on what an option-implied
+$\hat\kappa_2$ plus the cross-measure $d_0$ restriction can add to the time
+series, not achieved identification from options.
+
+Two constraints bound what any convergence claim may assert.
+The $\sqrt{\Dt}$ scaling of the kernel loadings is a modeling choice, and
+alternative scalings produce different limits, so every statement above is
+relative to the stated scheme \cite{Corradi2000}.
+Statistical experiments generated by the recursion and by the diffusion are
+not equivalent \cite{Wang2002}, so no claim about transferring inference
+between the discrete and the continuous model is made here.
+
+The open problem is the convergence of call prices, and we state it as the
+central technical claim of the intended paper.
+Weak convergence yields prices of bounded continuous payoffs only.
+For $\hat\kappa_2=0$ and $\beta>0$ the discounted limiting stock-price
+process is a strict local martingale \cite{Sin1998,LionsMusiela2007}, and
+each discrete model prices calls perfectly well at fixed $\Dt$, so the
+price family cannot converge to the continuous prices, and the failure
+appears only in the limit.
+The companion study makes this failure quantitative at a fixed
+computational budget.
+Every recursion in the family has discounted-spot expectation exactly one
+at every step size.
+A Monte Carlo estimate with $2^{20}$ paths at one-year maturity
+nevertheless falls short of one by about $0.22$ at $\hat\kappa_2=0$ and by
+about $0.08$ at $\hat\kappa_2=1/2$, with weak dependence over the finest
+two step sizes.
+At $\Dt\le1/1008$, estimates for $\hat\kappa_2\ge2$ are statistically
+indistinguishable from zero.
+The shortfall is not a defect of any fixed-step model but the
+finite-budget face of the missing uniform integrability.
+Nested budgets from $2^{16}$ to $2^{22}$ paths leave the
+$\hat\kappa_2=0$ shortfall near $0.22$ and the largest-budget
+$\hat\kappa_2=1/2$ shortfall near $0.09$ at both finest steps.
+The latter curve is nonmonotone at the finest step because a rare-path
+overshoot at the smallest budget temporarily pushes the empirical mean
+above one, while every $\hat\kappa_2=2$ interval contains zero.
+This behavior is consistent with a compensating mean contribution lying
+in paths missed or irregularly represented at the chosen budget, but an
+ordinary bootstrap conditional on observed paths cannot measure unseen
+mass.
+The conjecture is that a uniform moment bound restores convergence: for
+every $\hat\kappa_2\ge\underline{\kappa}>0$ there exists $\varepsilon_1>0$
+with
+$\sup_{\Dt}\E^{\Qm}\big[(S_T^{\Dt})^{1+\varepsilon_1}\big]<\infty$, which
+implies uniform integrability and convergence of call prices.
+The corresponding continuous-time result is the true-martingale property
+established for the quadratic-drift model.
+The discrete conjecture is stronger because it requires a superlinear
+moment uniformly in $\Dt$.
+In this reading the quadratic rate is the price of admitting a continuum
+limit with positive volatility beta: the discrete family with
+$\hat\kappa_2=0$ hides the pathology at every fixed step and reveals it
+only in the limit.
+A second, smaller open item is a discrete moment-generating-function
+recursion closed under a quadratic-affine ansatz to the same order as the
+affine expansion of the continuous model, which would complete the analogy
+with Heston and Nandi (2000).
+
+\begin{thebibliography}{99}
+
+\bibitem[Carr and Willems(2019)]{CarrWillems2019}
+Carr, P. and S. Willems (2019).
+A lognormal type stochastic volatility model with quadratic drift.
+arXiv:1908.07417.
+
+\bibitem[Christoffersen et al.(2013)]{CHJ2013}
+Christoffersen, P., S. Heston and K. Jacobs (2013).
+Capturing option anomalies with a variance-dependent pricing kernel.
+\textit{Review of Financial Studies} 26, 1963--2006.
+
+\bibitem[Corradi(2000)]{Corradi2000}
+Corradi, V. (2000).
+Reconsidering the continuous time limit of the GARCH(1,1) process.
+\textit{Journal of Econometrics} 96, 145--153.
+% TODO: verify pages.
+
+\bibitem[Duan(1997)]{Duan1997}
+Duan, J.-C. (1997).
+Augmented GARCH(p,q) process and its diffusion limit.
+\textit{Journal of Econometrics} 79, 97--127.
+
+\bibitem[Heston and Nandi(2000)]{HestonNandi2000}
+Heston, S. and S. Nandi (2000).
+A closed-form GARCH option valuation model.
+\textit{Review of Financial Studies} 13, 585--625.
+
+\bibitem[Lions and Musiela(2007)]{LionsMusiela2007}
+Lions, P.-L. and M. Musiela (2007).
+Correlations and bounds for stochastic volatility models.
+\textit{Annales de l'Institut Henri Poincar\'e (C) Analyse Non Lin\'eaire}
+24, 1--16.
+
+\bibitem[Nelson(1990)]{Nelson1990}
+Nelson, D. B. (1990).
+ARCH models as diffusion approximations.
+\textit{Journal of Econometrics} 45, 7--38.
+
+\bibitem[Nelson and Foster(1994)]{NelsonFoster1994}
+Nelson, D. B. and D. P. Foster (1994).
+Asymptotic filtering theory for univariate ARCH models.
+\textit{Econometrica} 62, 1--41.
+
+\bibitem[Sepp and Rakhmonov(2023)]{SeppRakhmonov2023}
+Sepp, A. and P. Rakhmonov (2023).
+Log-normal stochastic volatility model with quadratic drift.
+\textit{International Journal of Theoretical and Applied Finance} 26(8),
+2450003.
+
+\bibitem[Sin(1998)]{Sin1998}
+Sin, C. A. (1998).
+Complications with stochastic volatility models.
+\textit{Advances in Applied Probability} 30, 256--268.
+
+\bibitem[Wang(2002)]{Wang2002}
+Wang, Y. (2002).
+Asymptotic nonequivalence of GARCH models and diffusions.
+\textit{Annals of Statistics} 30, 754--783.
+% TODO: verify pages.
+
+\bibitem[Zakoian(1994)]{Zakoian1994}
+Zakoian, J.-M. (1994).
+Threshold heteroskedastic models.
+\textit{Journal of Economic Dynamics and Control} 18, 931--955.
+
+\end{thebibliography}
+
+\end{document}

--- a/volatility_book/ch_discrete_vol/reporting.py
+++ b/volatility_book/ch_discrete_vol/reporting.py
@@ -1,0 +1,1603 @@
+"""Reporting utilities for the discrete-versus-continuous TGARCH study.
+
+The study uses annualized volatilities and rates, time measured in years, and
+log returns.  This module deliberately contains no model or estimation logic:
+it turns experiment records into a Markdown memo, a JSON audit record, and one
+Matplotlib-only PDF.  Experiment records may be dataclasses or mappings; see
+the public writer docstrings for the small structural protocol they accept.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import math
+import textwrap
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.figure import Figure
+from matplotlib.ticker import NullFormatter, ScalarFormatter
+
+
+@dataclasses.dataclass(frozen=True)
+class FigureRecord:
+    """One PDF figure and the standalone caption that accompanies it.
+
+    Parameters
+    ----------
+    title
+        Short figure title used in the PDF bookmark note and caption prefix.
+    caption
+        Standalone caption.  It should state the parameter set, time-step
+        grid, path count, and seed whenever those concepts apply.
+    figure
+        A Matplotlib figure, or a zero-argument factory returning one.  A
+        factory avoids retaining all study figures in memory at once.
+    """
+
+    title: str
+    caption: str
+    figure: Figure | Callable[[], Figure]
+
+
+_MISSING = object()
+
+_EXPERIMENT_TITLES = {
+    "E1": "Option prices versus the continuous affine pricer",
+    "E2": "Exact-Q, reweighted-P, and limit-Q kernel consistency",
+    "E3": "Stationary recursion versus the GIG law",
+    "E4": "Spot moments near the sufficient martingale boundary",
+    "E5": "Fixed-step Kesten tails versus the inverse-gamma limit",
+    "E6": "Filtering across observation scales",
+    "E7": "QMLE recovery and identification",
+}
+
+_TABLE_FIELDS: dict[str, tuple[tuple[str, str], ...]] = {
+    "E1": (
+        ("Acceptance summary", "summaries"),
+        ("Finest-step implied volatilities", "finest_table"),
+    ),
+    "E2": (
+        ("Price comparisons and Monte Carlo standard errors", "records"),
+        ("Fitted limit-versus-exact convergence rates", "rates"),
+    ),
+    "E3": (("Density and quantile diagnostics", "records"),),
+    "E4": (
+        ("Empirical pattern verdicts", "verdicts"),
+        ("Moment and tail-contribution estimates", "records"),
+    ),
+    "E5": (("Hill and Kesten tail-index diagnostics", "records"),),
+    "E6": (
+        ("Exact-filter checks in its own discrete model", "self_model_checks"),
+        ("Across-scale verdicts", "scale_verdicts"),
+        ("Limit-path filter diagnostics", "records"),
+    ),
+    "E7": (
+        ("QMLE bias and RMSE", "summaries"),
+        ("Identification diagnostics", "identification"),
+    ),
+}
+
+_OMITTED_TABLE_COLUMNS = {
+    "strikes",
+    "mc_prices",
+    "mc_price_se",
+    "mc_ivols",
+    "mc_ivol_se",
+    "affine_prices",
+    "affine_ivols",
+    "error_bp",
+    "control_coefficients",
+    "grid",
+    "estimated_density",
+    "theoretical_density",
+    "probabilities",
+    "sample_quantiles",
+    "theoretical_quantiles",
+    "k_grid",
+    "hill_alpha",
+    "times",
+    "wrong_minus_correct_abs",
+    "estimate",
+}
+
+
+def _field(record: object, *names: str, default: Any = None) -> Any:
+    """Return the first present field from a mapping or attribute record."""
+    if isinstance(record, Mapping):
+        for name in names:
+            if name in record:
+                return record[name]
+        return default
+    for name in names:
+        value = getattr(record, name, _MISSING)
+        if value is not _MISSING:
+            return value
+    return default
+
+
+def _is_scalar(value: object) -> bool:
+    return value is None or isinstance(value, (str, bytes, int, float, bool, Enum, Path))
+
+
+def _sequence(value: object) -> list[Any]:
+    """Normalize an optional record collection without iterating strings."""
+    if value is None:
+        return []
+    if isinstance(value, Mapping):
+        return list(value.values())
+    if isinstance(value, np.ndarray):
+        return list(value)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return list(value)
+    return [value]
+
+
+def _experiments(results: object) -> list[Any]:
+    experiments = _field(results, "experiments", "experiment_results", default=None)
+    return _sequence(experiments)
+
+
+def _experiment_items(results: object) -> list[tuple[str, Any]]:
+    experiments = _field(results, "experiments", "experiment_results", default=None)
+    if isinstance(experiments, Mapping):
+        return [(str(identifier), value) for identifier, value in experiments.items()]
+    return [(f"E{index}", value) for index, value in enumerate(_sequence(experiments), start=1)]
+
+
+def _compact_table(value: object) -> object:
+    """Remove plot arrays and nested diagnostic objects from a memo table."""
+    rows = _mapping_rows(value)
+    compact: list[dict[str, Any]] = []
+    for row in rows:
+        compact.append(
+            {
+                key: item
+                for key, item in row.items()
+                if not (
+                    key in _OMITTED_TABLE_COLUMNS
+                    and not (_is_scalar(item) or isinstance(item, np.generic))
+                )
+            }
+        )
+    return compact
+
+
+def _parameter_rows(results: object) -> list[dict[str, Any]]:
+    parameters = _field(results, "parameters", default=None)
+    if not isinstance(parameters, Mapping):
+        return []
+    rows: list[dict[str, Any]] = []
+    for name, header in parameters.items():
+        physical = _field(header, "physical", default={})
+        derived = _field(header, "derived", default={})
+        row = {
+            "set": name,
+            "theta": _field(physical, "theta"),
+            "kappa1": _field(physical, "kappa1"),
+            "kappa2": _field(physical, "kappa2"),
+            "beta": _field(physical, "beta"),
+            "eps": _field(physical, "eps"),
+            "sigma0": _field(physical, "sigma0"),
+            "gamma1": _field(physical, "gamma1"),
+            "eta1": _field(physical, "eta1"),
+            "lambda0_bar": _field(header, "lambda0_bar"),
+            "lambda1_bar": _field(header, "lambda1_bar"),
+            "kappa2_hat": _field(derived, "kappa2_hat"),
+            "theta_hat": _field(derived, "theta_hat"),
+            "kappa1_hat": _field(derived, "kappa1_hat"),
+            "vartheta": _field(header, "vartheta"),
+        }
+        rows.append(row)
+    return rows
+
+
+def _check_summary_rows(checks: object) -> list[dict[str, Any]]:
+    if not isinstance(checks, Mapping):
+        return _mapping_rows(checks)
+    rows: list[dict[str, Any]] = []
+    moment_checks = _field(checks, "one_step_moments", default={})
+    if isinstance(moment_checks, Mapping):
+        for case, measures in moment_checks.items():
+            if not isinstance(measures, Mapping):
+                continue
+            for measure, diagnostic in measures.items():
+                z_scores = _field(diagnostic, "absolute_z_scores", default={})
+                maximum_z_score = (
+                    max(float(value) for value in z_scores.values())
+                    if isinstance(z_scores, Mapping) and z_scores
+                    else float("nan")
+                )
+                rows.append(
+                    {
+                        "check": "one-step moments",
+                        "case": case,
+                        "measure": measure,
+                        "passed": _field(diagnostic, "passed"),
+                        "max_abs_z_score": maximum_z_score,
+                        "n_paths": _field(diagnostic, "n_paths"),
+                        "seed": _field(diagnostic, "seed"),
+                    }
+                )
+    martingale_checks = _field(checks, "martingale", default={})
+    if isinstance(martingale_checks, Mapping):
+        for case, diagnostic in martingale_checks.items():
+            rows.append(
+                {
+                    "check": "discounted-spot martingale",
+                    "case": case,
+                    "measure": "Q_EXACT",
+                    "passed": _field(diagnostic, "passed"),
+                    "estimate": _field(diagnostic, "estimate"),
+                    "standard_error": _field(diagnostic, "standard_error"),
+                    "absolute_z_score": _field(diagnostic, "absolute_z_score"),
+                    "n_paths": _field(diagnostic, "n_paths"),
+                    "seed": _field(diagnostic, "seed"),
+                }
+            )
+    zero_checks = _field(checks, "zero_kernel_law", default={})
+    if isinstance(zero_checks, Mapping):
+        for case, diagnostic in zero_checks.items():
+            differences = _field(diagnostic, "differences", default={})
+            maximum_difference = 0.0
+            if isinstance(differences, Mapping):
+                maximum_difference = max(
+                    (
+                        max(
+                            float(_field(values, "max_abs_log_spot_difference", default=0.0)),
+                            float(_field(values, "max_abs_sigma_difference", default=0.0)),
+                        )
+                        for values in differences.values()
+                    ),
+                    default=0.0,
+                )
+            rows.append(
+                {
+                    "check": "zero-kernel common law",
+                    "case": case,
+                    "measure": "P/Q_EXACT/Q_LIMIT",
+                    "passed": _field(diagnostic, "passed"),
+                    "max_pathwise_difference": maximum_difference,
+                    "n_paths": _field(diagnostic, "n_paths"),
+                    "seed": _field(diagnostic, "seed"),
+                }
+            )
+    return rows
+
+
+def _experiment_verdict(identifier: str, experiment: object) -> str:
+    if identifier == "E5":
+        corrected = bool(_field(experiment, "corrected_acceptance_pass", default=False))
+        corrected_text = "PASS" if corrected else "FAIL"
+        return f"BRIEF CLAIM CONTRADICTED; corrected inverse-gamma convergence: {corrected_text}"
+    if identifier == "E7":
+        return "MEASUREMENT ONLY - no pass/fail acceptance criterion"
+    if identifier == "E4" and not bool(
+        _field(experiment, "acceptance_pass", default=False)
+    ):
+        verdicts = _sequence(_field(experiment, "verdicts", default=None))
+        inside = [
+            row for row in verdicts
+            if float(row["kappa2_hat"]) >= float(row["sufficient_boundary"])
+        ]
+        outside = [row for row in verdicts if row not in inside]
+        if inside and all(row["empirical_pattern_pass"] for row in inside) and outside:
+            return "FAIL - inside-region stability PASS; outside-boundary growth NOT OBSERVED"
+    accepted = _field(experiment, "acceptance_pass", default=_MISSING)
+    if accepted is not _MISSING:
+        return "PASS" if bool(accepted) else "FAIL"
+    return str(_field(experiment, "verdict", "status", default="Not evaluated"))
+
+
+def _experiment_key_numbers(identifier: str, experiment: object) -> dict[str, Any]:
+    numbers: dict[str, Any] = {}
+    for name in (
+        "seed",
+        "seed_rule",
+        "maturity",
+        "maturity_assumption",
+        "measure_choice",
+        "small_error_threshold",
+        "continuous_tail_index",
+        "dt",
+        "replications",
+    ):
+        value = _field(experiment, name, default=_MISSING)
+        if value is not _MISSING:
+            numbers[name] = value
+
+    records = _sequence(_field(experiment, "records", default=None))
+    if identifier == "E1" and records:
+        numbers["finest_dt"] = min(float(row["dt"]) for row in records)
+        numbers["largest_mean_across_strikes_iv_se_bp"] = max(
+            float(row["mean_ivol_se_bp"]) for row in records
+        )
+        numbers["largest_per_strike_iv_se_bp"] = max(
+            float(
+                row.get(
+                    "max_ivol_se_bp",
+                    1.0e4 * np.nanmax(np.asarray(row["mc_ivol_se"], dtype=float)),
+                )
+            )
+            for row in records
+        )
+    elif identifier == "E2" and records:
+        numbers["minimum_ess_fraction"] = min(float(row["ess_fraction"]) for row in records)
+        numbers["all_exact_vs_weighted_within_3se"] = all(
+            bool(row["ab_within_3se"]) for row in records
+        )
+    elif identifier == "E3" and records:
+        baseline = [row for row in records if row.get("variant") == "baseline"]
+        stress = [row for row in records if row.get("variant") != "baseline"]
+        numbers["maximum_baseline_relative_sup_density_error"] = max(
+            float(row["relative_sup_density_error"]) for row in baseline
+        )
+        if stress:
+            numbers["maximum_stress_relative_sup_density_error"] = max(
+                float(row["relative_sup_density_error"]) for row in stress
+            )
+    elif identifier == "E4" and records:
+        numbers["maximum_top_0_1pct_share"] = max(
+            float(row["top_0_1pct_share"]) for row in records
+        )
+    elif identifier == "E5":
+        numbers["brief_acceptance_pass"] = _field(
+            experiment,
+            "brief_acceptance_pass",
+        )
+        numbers["corrected_acceptance_pass"] = _field(
+            experiment,
+            "corrected_acceptance_pass",
+        )
+    elif identifier == "E6" and records:
+        numbers["maximum_source_floor_hits"] = max(
+            int(row["source_floor_hits"]) for row in records
+        )
+    elif identifier == "E7":
+        threshold_years = _field(
+            experiment,
+            "gamma1_median_abs_tstat_2_years",
+            default={},
+        )
+        if isinstance(threshold_years, Mapping):
+            for parameter_set, years in threshold_years.items():
+                numbers[f"first_years_median_abs_gamma1_tstat_ge_2_{parameter_set}"] = (
+                    years if years is not None else "not reached through 40 years"
+                )
+    return numbers
+
+
+def _experiment_provenance(
+    experiment: object,
+    global_provenance: object,
+) -> str:
+    script = _field(global_provenance, "script", default="not supplied")
+    packages = _field(global_provenance, "package_versions", default={})
+    tag = _field(
+        global_provenance,
+        "repository_describe",
+        "study_folder_git_tag",
+        default="not supplied",
+    )
+    seed = _field(experiment, "seed", "seed_rule", default="see study seed map")
+    return (
+        f"script={script}; seed={_format_value(seed)}; versions={_provenance_text(packages)}; "
+        f"tag={tag}"
+    )
+
+
+def _escape_markdown(value: object) -> str:
+    return str(value).replace("|", "\\|").replace("\n", "<br>")
+
+
+def _format_number(value: object) -> str:
+    if isinstance(value, np.generic):
+        value = value.item()
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, int):
+        return f"{value:,}"
+    if isinstance(value, float):
+        if math.isnan(value):
+            return "NaN"
+        if math.isinf(value):
+            return "+infinity" if value > 0.0 else "-infinity"
+        return f"{value:.8g}"
+    if isinstance(value, Enum):
+        return str(value.value)
+    if isinstance(value, Path):
+        return str(value)
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _format_value(value: object) -> str:
+    """Format a scalar or an estimate/standard-error pair for Markdown."""
+    if isinstance(value, Mapping):
+        estimate = _field(value, "estimate", "value", "mean", default=_MISSING)
+        standard_error = _field(value, "standard_error", "se", "stderr", default=_MISSING)
+        if estimate is not _MISSING and standard_error is not _MISSING:
+            return f"{_format_number(estimate)} (SE {_format_number(standard_error)})"
+        return "; ".join(
+            f"{key}={_format_number(item)}" for key, item in value.items() if _is_scalar(item)
+        )
+    if isinstance(value, np.ndarray) and value.ndim == 0:
+        return _format_number(value.item())
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return ", ".join(_format_number(item) for item in value)
+    return _format_number(value)
+
+
+def _mapping_rows(value: object) -> list[dict[str, Any]]:
+    """Convert common table containers to a list of row mappings."""
+    if value is None:
+        return []
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        try:
+            records = to_dict(orient="records")
+        except TypeError:
+            records = None
+        if isinstance(records, list) and all(isinstance(row, Mapping) for row in records):
+            return [dict(row) for row in records]
+    if isinstance(value, Mapping):
+        if all(_is_scalar(item) or isinstance(item, np.generic) for item in value.values()):
+            return [{"metric": key, "value": item} for key, item in value.items()]
+        rows: list[dict[str, Any]] = []
+        for key, item in value.items():
+            if isinstance(item, Mapping):
+                rows.append({"row": key, **item})
+            else:
+                rows.append({"row": key, "value": item})
+        return rows
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return [dataclasses.asdict(value)]
+    if isinstance(value, np.ndarray):
+        array = np.asarray(value)
+        if array.ndim == 1:
+            return [{"value": item} for item in array]
+        if array.ndim == 2:
+            return [
+                {f"column_{index + 1}": item for index, item in enumerate(row)}
+                for row in array
+            ]
+        return []
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        rows = []
+        for item in value:
+            if isinstance(item, Mapping):
+                rows.append(dict(item))
+            elif dataclasses.is_dataclass(item) and not isinstance(item, type):
+                rows.append(dataclasses.asdict(item))
+            else:
+                rows.append({"value": item})
+        return rows
+    return [{"value": value}]
+
+
+def _markdown_table(value: object) -> str:
+    rows = _mapping_rows(value)
+    if not rows:
+        return "_No rows._"
+    columns: list[str] = []
+    for row in rows:
+        for column in row:
+            if column not in columns:
+                columns.append(str(column))
+    header = "| " + " | ".join(_escape_markdown(column) for column in columns) + " |"
+    separator = "| " + " | ".join("---" for _ in columns) + " |"
+    body = []
+    for row in rows:
+        body.append(
+            "| "
+            + " | ".join(
+                _escape_markdown(_format_value(row.get(column))) for column in columns
+            )
+            + " |"
+        )
+    return "\n".join([header, separator, *body])
+
+
+def _provenance_text(provenance: object) -> str:
+    if provenance is None:
+        return "Not supplied."
+    if isinstance(provenance, str):
+        return provenance
+    if dataclasses.is_dataclass(provenance) and not isinstance(provenance, type):
+        provenance = dataclasses.asdict(provenance)
+    if isinstance(provenance, Mapping):
+        return "; ".join(
+            f"{key}={_format_value(value).replace(chr(13), '').replace(chr(10), ' | ')}"
+            for key, value in provenance.items()
+        )
+    return _format_value(provenance)
+
+
+def _markdown_experiment(
+    experiment: object,
+    identifier: str,
+    global_provenance: object,
+) -> str:
+    title = _field(
+        experiment,
+        "title",
+        "name",
+        default=_EXPERIMENT_TITLES.get(identifier, "Experiment"),
+    )
+    claim = _field(experiment, "claim", "tested_claim", default=None)
+    verdict = _experiment_verdict(identifier, experiment)
+    lines = [f"## {_format_value(identifier)}. {_format_value(title)}", ""]
+    if claim:
+        lines.extend([f"**Claim tested:** {_format_value(claim)}", ""])
+    lines.extend([f"**Acceptance verdict:** {_format_value(verdict)}", ""])
+
+    key_numbers = _field(experiment, "key_numbers", "metrics", "summary_metrics", default=None)
+    if key_numbers is None:
+        key_numbers = _experiment_key_numbers(identifier, experiment)
+    if key_numbers:
+        lines.extend(["### Key numbers", "", _markdown_table(key_numbers), ""])
+
+    tables = _field(experiment, "tables", "table", default=None)
+    if isinstance(tables, Mapping):
+        for table_name, table in tables.items():
+            lines.extend([f"### {_format_value(table_name)}", "", _markdown_table(table), ""])
+    elif tables is not None:
+        for table_index, table in enumerate(_sequence(tables), start=1):
+            table_name = _field(table, "title", "name", default=f"Table {table_index}")
+            table_data = _field(table, "data", "rows", default=table)
+            lines.extend([f"### {_format_value(table_name)}", "", _markdown_table(table_data), ""])
+    else:
+        for table_name, field_name in _TABLE_FIELDS.get(identifier, ()):
+            table_data = _field(experiment, field_name, default=None)
+            if table_data is not None:
+                lines.extend(
+                    [
+                        f"### {table_name}",
+                        "",
+                        _markdown_table(_compact_table(table_data)),
+                        "",
+                    ]
+                )
+
+    notes = _field(experiment, "notes", "findings", "comments", default=None)
+    study_notes = []
+    for field_name in (
+        "contradiction",
+        "interpretation_caveat",
+        "boundary_classification",
+        "acceptance_criterion",
+    ):
+        value = _field(experiment, field_name, default=None)
+        if value:
+            study_notes.append(value)
+    notes = [*_sequence(notes), *study_notes]
+    if notes:
+        lines.extend(["### Findings and limitations", ""])
+        for note in notes:
+            lines.append(f"- {_format_value(note)}")
+        lines.append("")
+
+    lines.extend(
+        [
+            f"**Provenance:** {_experiment_provenance(experiment, global_provenance)}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_results_markdown(results: object, path: Path) -> None:
+    """Write the human-readable study memo.
+
+    ``results`` may be a dataclass or mapping.  The writer recognizes the
+    optional top-level fields ``title``, ``summary``, ``profile``,
+    ``unit_checks``, ``experiments``, ``notes``, and ``provenance``.  Each
+    experiment may expose ``id``, ``title``, ``claim``, ``verdict``,
+    ``key_numbers``, ``tables``, ``notes``, and ``provenance``.  This small
+    structural protocol keeps the reporting layer independent of simulation.
+    """
+    output_path = Path(path)
+    if output_path.suffix.lower() != ".md":
+        raise ValueError("Markdown output path must end in '.md'")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    title = _field(
+        results,
+        "title",
+        default="Discrete versus continuous TGARCH study",
+    )
+    summary = _field(results, "summary", "executive_summary", default=None)
+    profile = _field(results, "profile", "study_profile", default=None)
+    provenance = _field(results, "provenance", default=None)
+
+    lines = [f"# {_format_value(title)}", ""]
+    if summary:
+        lines.extend([_format_value(summary), ""])
+    if profile is not None:
+        lines.extend([f"**Study profile:** {_format_value(profile)}", ""])
+
+    config = _field(results, "config", default=None)
+    if config is not None:
+        lines.extend(["## Run configuration", "", _markdown_table(config), ""])
+
+    parameter_rows = _parameter_rows(results)
+    if parameter_rows:
+        lines.extend(
+            [
+                "## Parameter and drift-map header",
+                "",
+                (
+                    "All volatilities and rates are annualized; time and dt are in years. "
+                    "Returns are log returns."
+                ),
+                "",
+                _markdown_table(parameter_rows),
+                "",
+            ]
+        )
+
+    unit_checks = _field(results, "unit_checks", "checks", default=None)
+    if unit_checks is not None:
+        all_passed = _field(unit_checks, "all_passed", "all_pass", default=None)
+        lines.extend(
+            [
+                "## Simulator checks",
+                "",
+                f"**Mandatory gate:** {'PASS' if all_passed else 'FAIL'}",
+                "",
+                _markdown_table(_check_summary_rows(unit_checks)),
+                "",
+            ]
+        )
+
+    experiment_items = _experiment_items(results)
+    if experiment_items:
+        for identifier, experiment in experiment_items:
+            lines.append(_markdown_experiment(experiment, identifier, provenance))
+    else:
+        lines.extend(
+            [
+                "## Experiments",
+                "",
+                "_No experiment records were supplied._",
+                "",
+            ]
+        )
+
+    notes = _field(results, "notes", "limitations", "warnings", default=None)
+    if notes:
+        lines.extend(["## Cross-experiment findings and limitations", ""])
+        for note in _sequence(notes):
+            lines.append(f"- {_format_value(note)}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Interpretation caveats",
+            "",
+            (
+                "All convergence statements in this memo are relative to the square-root "
+                "time-step kernel scaling. The experiments do not establish transfer of "
+                "statistical inference between the discrete and continuous models."
+            ),
+            "",
+            f"**Study provenance:** {_provenance_text(provenance)}",
+            "",
+        ]
+    )
+    output_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _json_ready(value: object) -> Any:
+    """Return a deterministic, strict-JSON representation of study data."""
+    if isinstance(value, FigureRecord):
+        return {"title": value.title, "caption": value.caption, "figure": "matplotlib"}
+    if isinstance(value, Figure):
+        return {"figure": "matplotlib", "title": _figure_title(value)}
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {
+            field.name: _json_ready(getattr(value, field.name))
+            for field in dataclasses.fields(value)
+        }
+    if isinstance(value, Mapping):
+        return {str(key): _json_ready(item) for key, item in value.items()}
+    if isinstance(value, np.ndarray):
+        return [_json_ready(item) for item in value.tolist()]
+    if isinstance(value, np.generic):
+        return _json_ready(value.item())
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, Enum):
+        return _json_ready(value.value)
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if callable(value):
+        return getattr(value, "__qualname__", repr(value))
+    return value
+
+
+def write_results_json(results: object, path: Path) -> None:
+    """Write a strict JSON audit record for a dataclass or mapping result."""
+    output_path = Path(path)
+    if output_path.suffix.lower() != ".json":
+        raise ValueError("JSON output path must end in '.json'")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(
+            _json_ready(results),
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _figure_title(figure: Figure) -> str:
+    if figure._suptitle is not None:  # Matplotlib exposes no public suptitle getter.
+        title = figure._suptitle.get_text()
+        if title:
+            return title
+    for axis in figure.axes:
+        title = axis.get_title()
+        if title:
+            return title
+    return "Study figure"
+
+
+def _coerce_figure_record(
+    value: object,
+    *,
+    default_title: str,
+    default_caption: str,
+) -> FigureRecord:
+    if isinstance(value, FigureRecord):
+        return value
+    if isinstance(value, Figure):
+        return FigureRecord(
+            title=_figure_title(value),
+            caption=default_caption,
+            figure=value,
+        )
+    if isinstance(value, Mapping) or dataclasses.is_dataclass(value):
+        figure = _field(value, "figure", "make_figure", "factory", default=None)
+        if figure is None:
+            raise ValueError("Figure record is missing a 'figure' or 'make_figure' field")
+        return FigureRecord(
+            title=str(_field(value, "title", "name", default=default_title)),
+            caption=str(_field(value, "caption", default=default_caption)),
+            figure=figure,
+        )
+    if isinstance(value, tuple) and len(value) == 2:
+        figure, caption = value
+        if not isinstance(figure, Figure) and not callable(figure):
+            raise ValueError("First item of a figure tuple must be a Figure or factory")
+        return FigureRecord(
+            title=default_title,
+            caption=str(caption),
+            figure=figure,
+        )
+    raise ValueError(f"Unsupported figure record type: {type(value).__name__}")
+
+
+def _figure_records(results: object) -> list[FigureRecord]:
+    records: list[FigureRecord] = []
+    global_provenance = _provenance_text(_field(results, "provenance", default=None))
+    top_level_figures = _field(results, "figures", "figure_records", default=None)
+    for index, value in enumerate(_sequence(top_level_figures), start=1):
+        records.append(
+            _coerce_figure_record(
+                value,
+                default_title=f"Figure {index}",
+                default_caption=f"Study figure. Provenance: {global_provenance}",
+            )
+        )
+
+    for experiment_index, experiment in enumerate(_experiments(results), start=1):
+        identifier = _field(
+            experiment,
+            "experiment_id",
+            "identifier",
+            "id",
+            default=f"E{experiment_index}",
+        )
+        title = _field(experiment, "title", "name", default="Experiment")
+        provenance = _provenance_text(
+            _field(experiment, "provenance", default=_field(results, "provenance", default=None))
+        )
+        default_caption = f"{identifier}: {title}. Provenance: {provenance}"
+        figures = _field(experiment, "figures", "figure_records", default=None)
+        for figure_index, value in enumerate(_sequence(figures), start=1):
+            records.append(
+                _coerce_figure_record(
+                    value,
+                    default_title=f"{identifier}, figure {figure_index}",
+                    default_caption=default_caption,
+                )
+            )
+    if not records:
+        records.extend(_study_figure_records(results))
+    return records
+
+
+def _sorted_unique(rows: Sequence[Mapping[str, Any]], field: str) -> list[Any]:
+    return sorted({row[field] for row in rows if field in row})
+
+
+def _dt_label(value: float) -> str:
+    reciprocal = 1.0 / value
+    rounded = round(reciprocal)
+    if math.isclose(reciprocal, rounded, rel_tol=0.0, abs_tol=1.0e-8):
+        return f"1/{rounded}"
+    return f"{value:.5g}"
+
+
+def _parameter_caption(results: object, experiment: object) -> str:
+    rows: list[Any] = []
+    for field_name in ("records", "summaries", "identification"):
+        rows.extend(_sequence(_field(experiment, field_name, default=None)))
+    names = {
+        str(row["parameter_set"]).split("_")[0]
+        for row in rows
+        if isinstance(row, Mapping) and "parameter_set" in row
+    }
+    parameters = _field(results, "parameters", default={})
+    if not names and isinstance(parameters, Mapping):
+        names = set(parameters)
+    summaries: list[str] = []
+    for name in sorted(names):
+        header = _field(parameters, name, default=None)
+        if header is None:
+            summaries.append(name)
+            continue
+        physical = _field(header, "physical", default={})
+        derived = _field(header, "derived", default={})
+        summaries.append(
+            (
+                f"{name}(theta={_format_number(_field(physical, 'theta'))}, "
+                f"kappa1={_format_number(_field(physical, 'kappa1'))}, "
+                f"kappa2={_format_number(_field(physical, 'kappa2'))}, "
+                f"beta={_format_number(_field(physical, 'beta'))}, "
+                f"eps={_format_number(_field(physical, 'eps'))}, "
+                f"sigma0={_format_number(_field(physical, 'sigma0'))}; "
+                f"gamma1={_format_number(_field(physical, 'gamma1'))}, "
+                f"eta1={_format_number(_field(physical, 'eta1'))}, "
+                f"kappa1_hat={_format_number(_field(derived, 'kappa1_hat'))}, "
+                f"kappa2_hat={_format_number(_field(derived, 'kappa2_hat'))}, "
+                f"theta_hat={_format_number(_field(derived, 'theta_hat'))}, "
+                f"lambda0_bar={_format_number(_field(header, 'lambda0_bar'))}, "
+                f"lambda1_bar={_format_number(_field(header, 'lambda1_bar'))}, "
+                f"vartheta={_format_number(_field(header, 'vartheta'))})"
+            )
+        )
+    return "; ".join(summaries) if summaries else "parameter set recorded in results.md"
+
+
+def _study_caption(
+    results: object,
+    identifier: str,
+    experiment: object,
+    description: str,
+) -> str:
+    rows = [
+        row
+        for row in _sequence(_field(experiment, "records", default=None))
+        if isinstance(row, Mapping)
+    ]
+    dt_values: list[float] = []
+    for field_name in ("dt", "dt_observation_nominal", "source_dt"):
+        dt_values.extend(float(row[field_name]) for row in rows if field_name in row)
+    dt_text = ", ".join(_dt_label(value) for value in sorted(set(dt_values), reverse=True))
+    if not dt_text:
+        dt_value = _field(experiment, "dt", default=None)
+        dt_text = _dt_label(float(dt_value)) if dt_value is not None else "not applicable"
+    horizons: list[str] = []
+    for field_name in ("maturity", "years", "burn_years", "sample_years"):
+        values = sorted({float(row[field_name]) for row in rows if field_name in row})
+        if values:
+            horizons.append(
+                f"{field_name}={','.join(_format_number(value) for value in values)} years"
+            )
+    if identifier == "E7":
+        summary_rows = _sequence(_field(experiment, "summaries", default=None))
+        sample_years = sorted(
+            {
+                int(row["years"])
+                for row in summary_rows
+                if isinstance(row, Mapping) and "years" in row
+            }
+        )
+        if sample_years:
+            horizons.append(f"sample_years={','.join(str(value) for value in sample_years)}")
+    horizon_text = "; ".join(horizons) if horizons else "horizon not applicable"
+    counts: list[str] = []
+    for field_name in ("n_paths", "n_samples"):
+        values = sorted({int(row[field_name]) for row in rows if field_name in row})
+        if values:
+            counts.append(f"{field_name}={','.join(str(value) for value in values)}")
+    replications = _field(experiment, "replications", default=None)
+    if replications is not None:
+        counts.append(f"replications={replications}")
+    count_text = "; ".join(counts) if counts else "path count not applicable"
+    seed = _field(experiment, "seed", "seed_rule", default="see provenance")
+    provenance = _field(results, "provenance", default={})
+    script = _field(provenance, "script", default="run_study.py")
+    tag = _field(provenance, "repository_describe", default="unavailable")
+    return (
+        f"{description} Parameters: {_parameter_caption(results, experiment)}. "
+        f"Step grid: {dt_text}; {horizon_text}; {count_text}; seed={seed}. "
+        f"Annualized volatility/rates, time in years, log returns. Script: {script}; tag={tag}."
+    )
+
+
+def _finish_figure(
+    figure: Figure,
+    title: str,
+    *,
+    bottom: float = 0.24,
+) -> Figure:
+    figure.suptitle(title, fontsize=14, weight="bold", y=0.98)
+    figure.subplots_adjust(
+        left=0.08,
+        right=0.98,
+        bottom=bottom,
+        top=0.88,
+        hspace=0.38,
+        wspace=0.28,
+    )
+    for axis in figure.axes:
+        axis.grid(True, alpha=0.25, linewidth=0.7)
+        axis.tick_params(labelsize=8)
+        axis.xaxis.label.set_size(9)
+        axis.yaxis.label.set_size(9)
+        axis.title.set_size(10)
+    return figure
+
+
+def _plot_e1(experiment: object) -> Figure:
+    rows = _sequence(_field(experiment, "records", default=None))
+    parameter_sets = _sorted_unique(rows, "parameter_set")
+    figure, axes = plt.subplots(
+        1,
+        len(parameter_sets),
+        figsize=(11.0, 6.8),
+        squeeze=False,
+    )
+    for axis, parameter_set in zip(axes[0], parameter_sets):
+        subset = [row for row in rows if row["parameter_set"] == parameter_set]
+        maturities = _sorted_unique(subset, "maturity")
+        colors = plt.get_cmap("tab10").colors
+        for index, maturity in enumerate(maturities):
+            group = sorted(
+                (row for row in subset if row["maturity"] == maturity),
+                key=lambda row: row["dt"],
+            )
+            dt = np.asarray([row["dt"] for row in group], dtype=float)
+            mean_error = np.asarray([row["mean_abs_error_bp"] for row in group], dtype=float)
+            max_error = np.asarray([row["max_abs_error_bp"] for row in group], dtype=float)
+            noise = 2.0 * np.asarray([row["mean_ivol_se_bp"] for row in group], dtype=float)
+            color = colors[index % len(colors)]
+            axis.plot(
+                dt,
+                mean_error,
+                marker="o",
+                color=color,
+                label=f"T={maturity:.4g}, mean abs.",
+            )
+            axis.plot(
+                dt,
+                max_error,
+                marker="s",
+                linestyle="--",
+                color=color,
+                label=f"T={maturity:.4g}, max abs.",
+            )
+            axis.fill_between(
+                dt,
+                np.maximum(mean_error - noise, 0.0),
+                mean_error + noise,
+                color=color,
+                alpha=0.12,
+                label=f"T={maturity:.4g}, +/-2 mean IV SE",
+            )
+        axis.set(
+            title=str(parameter_set),
+            xlabel="Maximum step dt (years)",
+            ylabel="Absolute implied-volatility error (bp)",
+            xscale="log",
+        )
+        axis.set_yscale("symlog", linthresh=5.0)
+        axis.set_ylim(bottom=0.0)
+        axis.legend(fontsize=7)
+    return _finish_figure(figure, "E1 - discrete option IV convergence")
+
+
+def _plot_e2(experiment: object) -> Figure:
+    rows = _sequence(_field(experiment, "records", default=None))
+    rates = {
+        row["parameter_set"]: row
+        for row in _sequence(_field(experiment, "rates", default=None))
+    }
+    parameter_sets = _sorted_unique(rows, "parameter_set")
+    figure, axes = plt.subplots(
+        len(parameter_sets),
+        2,
+        figsize=(11.0, 4.2 + 2.8 * len(parameter_sets)),
+        squeeze=False,
+    )
+    for row_index, parameter_set in enumerate(parameter_sets):
+        group = sorted(
+            (row for row in rows if row["parameter_set"] == parameter_set),
+            key=lambda row: row["dt"],
+        )
+        dt = np.asarray([row["dt"] for row in group], dtype=float)
+        direct_difference = np.asarray(
+            [row["exact_minus_weighted"] for row in group],
+            dtype=float,
+        )
+        direct_se = np.asarray(
+            [row["exact_minus_weighted_se"] for row in group],
+            dtype=float,
+        )
+        limit_difference = np.asarray(
+            [row["limit_minus_exact"] for row in group],
+            dtype=float,
+        )
+        limit_se = np.asarray(
+            [row["limit_minus_exact_se"] for row in group],
+            dtype=float,
+        )
+        left = axes[row_index, 0]
+        left.errorbar(
+            dt,
+            direct_difference,
+            yerr=3.0 * direct_se,
+            marker="o",
+            capsize=3,
+            color="tab:blue",
+            label="Q_EXACT - reweighted P (+/-3 SE)",
+        )
+        left.axhline(0.0, color="black", linewidth=0.8)
+        left.set(
+            title=f"{parameter_set}: same-Q algorithm check",
+            xlabel="Maximum step dt (years)",
+            ylabel="Call-price difference",
+            xscale="log",
+        )
+        left.legend(fontsize=7)
+
+        right = axes[row_index, 1]
+        right.errorbar(
+            dt,
+            limit_difference,
+            yerr=2.0 * limit_se,
+            marker="o",
+            capsize=3,
+            color="tab:red",
+            label="Q_LIMIT - Q_EXACT (+/-2 paired SE)",
+        )
+        right.axhline(0.0, color="black", linewidth=0.8)
+        rate = rates.get(parameter_set, {})
+        fitted_rate = _field(rate, "fitted_rate", default=float("nan"))
+        nonzero = np.abs(limit_difference) > 0.0
+        if np.isfinite(fitted_rate) and np.any(nonzero):
+            anchor_index = int(np.flatnonzero(nonzero)[0])
+            reference = (
+                limit_difference[anchor_index]
+                * (dt / dt[anchor_index]) ** fitted_rate
+            )
+            right.plot(
+                dt,
+                reference,
+                linestyle=":",
+                color="black",
+                label=f"fitted dt^{fitted_rate:.2f}",
+            )
+        right.set(
+            title=f"{parameter_set}: limit closure",
+            xlabel="Maximum step dt (years)",
+            ylabel="Call-price difference",
+            xscale="log",
+        )
+        linear_threshold = max(float(np.nanmedian(limit_se)), 1.0e-10)
+        right.set_yscale("symlog", linthresh=linear_threshold)
+        right.legend(fontsize=7)
+    return _finish_figure(figure, "E2 - kernel consistency and limit rate", bottom=0.20)
+
+
+def _plot_e3(experiment: object) -> Figure:
+    rows = _sequence(_field(experiment, "records", default=None))
+    parameter_sets = _sorted_unique(rows, "parameter_set")
+    figure, axes = plt.subplots(
+        len(parameter_sets),
+        2,
+        figsize=(11.0, 4.2 + 3.0 * len(parameter_sets)),
+        squeeze=False,
+    )
+    for row_index, parameter_set in enumerate(parameter_sets):
+        group = [row for row in rows if row["parameter_set"] == parameter_set]
+        density_axis = axes[row_index, 0]
+        qq_axis = axes[row_index, 1]
+        colors = plt.get_cmap("tab10").colors
+        qq_min = float("inf")
+        qq_max = 0.0
+        for index, row in enumerate(group):
+            color = colors[index % len(colors)]
+            label = f"{row['variant']}, dt={_dt_label(float(row['dt']))}"
+            grid = np.asarray(row["grid"], dtype=float)
+            density_axis.plot(
+                grid,
+                np.asarray(row["estimated_density"], dtype=float),
+                color=color,
+                label=f"empirical {label}",
+            )
+            density_axis.plot(
+                grid,
+                np.asarray(row["theoretical_density"], dtype=float),
+                color=color,
+                linestyle="--",
+                label=f"GIG {label}",
+            )
+            theoretical = np.asarray(row["theoretical_quantiles"], dtype=float)
+            sample = np.asarray(row["sample_quantiles"], dtype=float)
+            qq_axis.plot(
+                theoretical,
+                sample,
+                marker=".",
+                markersize=3,
+                linewidth=1.0,
+                color=color,
+                label=label,
+            )
+            qq_min = min(qq_min, float(np.nanmin(theoretical)), float(np.nanmin(sample)))
+            qq_max = max(qq_max, float(np.nanmax(theoretical)), float(np.nanmax(sample)))
+        density_axis.set(
+            title=f"{parameter_set}: stationary density",
+            xlabel="Annualized volatility sigma",
+            ylabel="Density",
+            xscale="log",
+        )
+        density_axis.legend(fontsize=6.5)
+        qq_axis.plot([qq_min, qq_max], [qq_min, qq_max], color="black", linestyle=":")
+        qq_axis.set(
+            title=f"{parameter_set}: GIG quantile comparison",
+            xlabel="Theoretical quantile",
+            ylabel="Sample quantile",
+        )
+        qq_axis.legend(fontsize=6.5)
+    return _finish_figure(figure, "E3 - stationary GIG density and QQ diagnostics", bottom=0.20)
+
+
+def _plot_e4(experiment: object) -> Figure:
+    rows = _sequence(_field(experiment, "records", default=None))
+    powers = _sorted_unique(rows, "power")
+    figure, axes = plt.subplots(
+        2,
+        len(powers),
+        figsize=(11.0, 8.2),
+        squeeze=False,
+    )
+    colors = plt.get_cmap("viridis")(
+        np.linspace(0.05, 0.9, len(_sorted_unique(rows, "kappa2_hat")))
+    )
+    for column, power in enumerate(powers):
+        subset = [row for row in rows if row["power"] == power]
+        kappa_values = _sorted_unique(subset, "kappa2_hat")
+        boundary = float(subset[0]["sufficient_boundary"])
+        for color, kappa2_hat in zip(colors, kappa_values):
+            group = sorted(
+                (row for row in subset if row["kappa2_hat"] == kappa2_hat),
+                key=lambda row: row["dt"],
+            )
+            dt = np.asarray([row["dt"] for row in group], dtype=float)
+            moment = np.asarray([row["moment"] for row in group], dtype=float)
+            lower = np.asarray([row["bootstrap_ci_lower"] for row in group], dtype=float)
+            upper = np.asarray([row["bootstrap_ci_upper"] for row in group], dtype=float)
+            finite = np.isfinite(moment) & np.isfinite(lower) & np.isfinite(upper)
+            region = "inside" if kappa2_hat >= boundary else "outside"
+            label = f"kappa2_hat={kappa2_hat:g} ({region})"
+            if np.any(finite):
+                axes[0, column].errorbar(
+                    dt[finite],
+                    moment[finite],
+                    yerr=np.vstack(
+                        (
+                            np.maximum(moment[finite] - lower[finite], 0.0),
+                            np.maximum(upper[finite] - moment[finite], 0.0),
+                        )
+                    ),
+                    marker="o",
+                    capsize=2,
+                    color=color,
+                    label=label,
+                )
+            share = np.asarray([row["top_0_1pct_share"] for row in group], dtype=float)
+            axes[1, column].plot(
+                dt,
+                share,
+                marker="o",
+                color=color,
+                label=label,
+            )
+        axes[0, column].set(
+            title=f"p={power:g}; sufficient boundary={boundary:.3f}",
+            xlabel="Maximum step dt (years)",
+            ylabel=f"E[S_T^{power:g}]",
+            xscale="log",
+            yscale="log",
+        )
+        axes[1, column].set(
+            title=f"p={power:g}; tail concentration",
+            xlabel="Maximum step dt (years)",
+            ylabel="Top 0.1% share of moment estimate",
+            xscale="log",
+            ylim=(0.0, 1.02),
+        )
+        axes[0, column].legend(fontsize=6.5)
+        axes[1, column].legend(fontsize=6.5)
+    return _finish_figure(figure, "E4 - moment stability and tail concentration", bottom=0.22)
+
+
+def _plot_e5(experiment: object) -> Figure:
+    rows = sorted(
+        _sequence(_field(experiment, "records", default=None)),
+        key=lambda row: row["dt"],
+        reverse=True,
+    )
+    figure, axes = plt.subplots(1, 2, figsize=(11.0, 6.8), squeeze=False)
+    hill_axis, index_axis = axes[0]
+    colors = plt.get_cmap("tab10").colors
+    for index, row in enumerate(rows):
+        color = colors[index % len(colors)]
+        label = f"dt={_dt_label(float(row['dt']))}"
+        k_grid = np.asarray(row["k_grid"], dtype=float)
+        hill_alpha = np.asarray(row["hill_alpha"], dtype=float)
+        hill_axis.plot(k_grid, hill_alpha, color=color, label=label)
+        hill_axis.scatter(
+            [row["selected_k"]],
+            [row["selected_hill_alpha"]],
+            marker="o",
+            color=color,
+            s=28,
+        )
+        hill_axis.axhline(
+            row["kesten_alpha"],
+            color=color,
+            linestyle="--",
+            linewidth=0.9,
+        )
+    hill_axis.set(
+        title="Hill curves (dot: selected k; dashed: Kesten root)",
+        xlabel="Upper order statistics k",
+        ylabel="Survival-tail exponent",
+        xscale="log",
+    )
+    all_k = np.concatenate([np.asarray(row["k_grid"], dtype=float) for row in rows])
+    hill_axis.set_xticks(np.geomspace(float(np.min(all_k)), float(np.max(all_k)), 5))
+    hill_axis.xaxis.set_major_formatter(ScalarFormatter())
+    hill_axis.xaxis.set_minor_formatter(NullFormatter())
+    hill_axis.legend(fontsize=7)
+
+    dt = np.asarray([row["dt"] for row in rows], dtype=float)
+    index_axis.plot(
+        dt,
+        [row["selected_hill_alpha"] for row in rows],
+        marker="o",
+        label="selected Hill estimate",
+    )
+    index_axis.plot(
+        dt,
+        [row["kesten_alpha"] for row in rows],
+        marker="s",
+        label="fixed-step Kesten root",
+    )
+    continuous = float(_field(experiment, "continuous_tail_index"))
+    index_axis.axhline(
+        continuous,
+        color="black",
+        linestyle=":",
+        label=f"inverse-gamma limit={continuous:.3f}",
+    )
+    index_axis.set(
+        title="Tail index approaches a finite inverse-gamma limit",
+        xlabel="Step dt (years)",
+        ylabel="Survival-tail exponent",
+        xscale="log",
+    )
+    index_axis.legend(fontsize=7)
+    return _finish_figure(figure, "E5 - non-commuting fixed-step and tail limits")
+
+
+def _plot_e6(experiment: object) -> Figure:
+    rows = _sequence(_field(experiment, "records", default=None))
+    series = _sequence(_field(experiment, "forgetting_series", default=None))
+    parameter_sets = _sorted_unique(rows, "parameter_set")
+    figure, axes = plt.subplots(1, 2, figsize=(11.0, 6.8), squeeze=False)
+    rmse_axis, forgetting_axis = axes[0]
+    colors = plt.get_cmap("tab10").colors
+    for index, parameter_set in enumerate(parameter_sets):
+        color = colors[index % len(colors)]
+        group = sorted(
+            (row for row in rows if row["parameter_set"] == parameter_set),
+            key=lambda row: row["dt_observation_nominal"],
+        )
+        dt = [row["dt_observation_nominal"] for row in group]
+        rmse_axis.plot(
+            dt,
+            [row["rmse_correct_start"] for row in group],
+            marker="o",
+            color=color,
+            label=f"{parameter_set}, correct start",
+        )
+        rmse_axis.plot(
+            dt,
+            [row["rmse_wrong_start"] for row in group],
+            marker="s",
+            linestyle="--",
+            color=color,
+            label=f"{parameter_set}, 50% high start",
+        )
+    rmse_axis.set(
+        title="Filter RMSE across observation scales",
+        xlabel="Observation step dt (years)",
+        ylabel="Volatility RMSE",
+        xscale="log",
+        yscale="log",
+    )
+    rmse_axis.legend(fontsize=7)
+
+    for index, row in enumerate(series):
+        times = np.asarray(row["times"], dtype=float)
+        difference = np.asarray(row["wrong_minus_correct_abs"], dtype=float)
+        positive = difference > 0.0
+        if np.any(positive):
+            forgetting_axis.plot(
+                times[positive],
+                difference[positive],
+                linewidth=1.0,
+                color=colors[index % len(colors)],
+                label=(
+                    f"{row['parameter_set']}, "
+                    f"dt={_dt_label(float(row['dt_observation_nominal']))}"
+                ),
+            )
+    forgetting_axis.set(
+        title="Forgetting a volatility start set 50% too high",
+        xlabel="Time (years)",
+        ylabel="|wrong-start filter - correct-start filter|",
+        yscale="log",
+    )
+    forgetting_axis.legend(fontsize=6.5)
+    return _finish_figure(figure, "E6 - exact discrete filtering across scales")
+
+
+def _plot_e7(experiment: object) -> Figure:
+    summaries = _sequence(_field(experiment, "summaries", default=None))
+    identification = _sequence(_field(experiment, "identification", default=None))
+    parameter_sets = _sorted_unique(summaries, "parameter_set")
+    figure, axes = plt.subplots(1, 2, figsize=(11.0, 6.8), squeeze=False)
+    recovery_axis, identification_axis = axes[0]
+    colors = plt.get_cmap("tab10").colors
+    color_index = 0
+    for parameter_set in parameter_sets:
+        parameters = _sorted_unique(
+            [row for row in summaries if row["parameter_set"] == parameter_set],
+            "parameter",
+        )
+        for parameter in parameters:
+            group = sorted(
+                (
+                    row
+                    for row in summaries
+                    if row["parameter_set"] == parameter_set
+                    and row["parameter"] == parameter
+                ),
+                key=lambda row: row["years"],
+            )
+            truth = abs(float(group[0]["truth"]))
+            scale = truth if truth > 1.0e-10 else 1.0
+            recovery_axis.plot(
+                [row["years"] for row in group],
+                [row["rmse"] / scale for row in group],
+                marker="o",
+                color=colors[color_index % len(colors)],
+                label=f"{parameter_set}: {parameter}",
+            )
+            color_index += 1
+    recovery_axis.set(
+        title="QMLE relative RMSE",
+        xlabel="Sample length (years)",
+        ylabel="RMSE / |true parameter|",
+        yscale="log",
+    )
+    recovery_axis.legend(fontsize=6.5, ncols=2)
+
+    for index, parameter_set in enumerate(parameter_sets):
+        group = sorted(
+            (row for row in identification if row["parameter_set"] == parameter_set),
+            key=lambda row: row["years"],
+        )
+        identification_axis.plot(
+            [row["years"] for row in group],
+            [row["median_abs_gamma1_tstat"] for row in group],
+            marker="o",
+            color=colors[index % len(colors)],
+            label=f"{parameter_set}: median |gamma1 t-stat|",
+        )
+    identification_axis.axhline(2.0, color="black", linestyle=":", label="|t|=2")
+    identification_axis.set(
+        title="Risk-premium identification",
+        xlabel="Sample length (years)",
+        ylabel="Median absolute gamma1 t-statistic",
+    )
+    identification_axis.legend(fontsize=7)
+    return _finish_figure(figure, "E7 - QMLE recovery and identification")
+
+
+def _study_figure_records(results: object) -> list[FigureRecord]:
+    builders: dict[str, Callable[[object], Figure]] = {
+        "E1": _plot_e1,
+        "E2": _plot_e2,
+        "E3": _plot_e3,
+        "E4": _plot_e4,
+        "E5": _plot_e5,
+        "E6": _plot_e6,
+        "E7": _plot_e7,
+    }
+    descriptions = {
+        "E1": (
+            "Mean and maximum absolute IV errors; shading is twice the mean MC IV SE, "
+            "with lower limits clipped at zero on a symlog axis."
+        ),
+        "E2": "Paired price differences with MC uncertainty and the fitted closure rate.",
+        "E3": (
+            "KDE/GIG density and QQ comparisons for baseline hatted parameters and a "
+            "kappa2_hat value scaled to 5%."
+        ),
+        "E4": (
+            "Q_LIMIT bootstrap moments and top-0.1% contributions while kappa2_hat varies "
+            "with d0 and d1_hat fixed."
+        ),
+        "E5": (
+            "Physical crypto parameters with kappa2 reset to zero: Hill curves, Kesten "
+            "roots, and the finite inverse-gamma limit."
+        ),
+        "E6": "Volatility-filter RMSE and decay of the deliberately wrong initial state.",
+        "E7": "QMLE relative RMSE and gamma1 identification; no pass criterion applies.",
+    }
+    records: list[FigureRecord] = []
+    for identifier, experiment in _experiment_items(results):
+        builder = builders.get(identifier)
+        if builder is None:
+            continue
+        records.append(
+            FigureRecord(
+                title=f"{identifier} - {_EXPERIMENT_TITLES[identifier]}",
+                caption=_study_caption(
+                    results,
+                    identifier,
+                    experiment,
+                    descriptions[identifier],
+                ),
+                figure=lambda experiment=experiment, builder=builder: builder(experiment),
+            )
+        )
+    return records
+
+
+def _add_caption(figure: Figure, record: FigureRecord) -> Any:
+    caption = record.caption.strip()
+    if not caption:
+        raise ValueError(f"Figure '{record.title}' has an empty standalone caption")
+    wrapped_caption = textwrap.fill(f"{record.title}. {caption}", width=145)
+    return figure.text(
+        0.01,
+        0.008,
+        wrapped_caption,
+        ha="left",
+        va="bottom",
+        fontsize=7.5,
+        wrap=True,
+    )
+
+
+def _write_cover_page(results: object, pdf: PdfPages) -> None:
+    title = _field(results, "title", default="Discrete versus continuous TGARCH study")
+    profile = _field(results, "profile", "study_profile", default="unspecified")
+    provenance = _field(results, "provenance", default={})
+    provenance_text = (
+        f"script={_field(provenance, 'script', default='not supplied')}; "
+        f"versions={_provenance_text(_field(provenance, 'package_versions', default={}))}; "
+        f"tag={_field(provenance, 'repository_describe', default='not supplied')}; "
+        f"seeds={_provenance_text(_field(provenance, 'seeds', default={}))}"
+    )
+    figure = plt.figure(figsize=(8.27, 11.69))
+    figure.text(0.08, 0.90, str(title), fontsize=20, weight="bold", va="top")
+    figure.text(0.08, 0.84, f"Profile: {_format_value(profile)}", fontsize=11, va="top")
+    figure.text(
+        0.08,
+        0.78,
+        textwrap.fill(f"Provenance: {provenance_text}", width=95),
+        fontsize=9,
+        va="top",
+    )
+    figure.text(
+        0.08,
+        0.68,
+        (
+            "Conventions: annualized volatility and rates; time and time steps in years; "
+            "log returns. Convergence statements are relative to square-root time-step "
+            "kernel scaling."
+        ),
+        fontsize=10,
+        va="top",
+        wrap=True,
+    )
+    pdf.savefig(figure)
+    plt.close(figure)
+
+
+def write_figures_pdf(results: object, path: Path) -> None:
+    """Assemble result figures into one captioned Matplotlib PDF.
+
+    Figures are read from top-level or per-experiment ``figures`` fields.  An
+    item may be a :class:`FigureRecord`, a Matplotlib figure, a
+    ``(figure, caption)`` tuple, or a mapping/dataclass with ``figure`` (or
+    ``make_figure``), ``title``, and ``caption`` fields.  Every page receives
+    a visible caption and a PDF note; callers should provide parameter set,
+    step grid, path count, and seed in the caption where applicable.
+    """
+    output_path = Path(path)
+    if output_path.suffix.lower() != ".pdf":
+        raise ValueError("Figure output path must end in '.pdf'")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    records = _figure_records(results)
+
+    with PdfPages(output_path) as pdf:
+        metadata = pdf.infodict()
+        metadata["Title"] = str(
+            _field(results, "title", default="Discrete versus continuous TGARCH study")
+        )
+        metadata["Subject"] = "Discrete TGARCH recursion versus continuous log-normal beta SV"
+        _write_cover_page(results, pdf)
+        if not records:
+            figure = plt.figure(figsize=(8.27, 11.69))
+            figure.text(
+                0.08,
+                0.90,
+                "No experiment figure records were supplied.",
+                fontsize=14,
+                va="top",
+            )
+            pdf.savefig(figure)
+            plt.close(figure)
+            return
+
+        for record in records:
+            figure = record.figure() if callable(record.figure) else record.figure
+            if not isinstance(figure, Figure):
+                raise ValueError(
+                    f"Figure factory for '{record.title}' returned {type(figure).__name__}, "
+                    "not matplotlib.figure.Figure"
+                )
+            caption_artist = _add_caption(figure, record)
+            pdf.attach_note(record.caption)
+            pdf.savefig(figure, bbox_inches="tight")
+            caption_artist.remove()
+            plt.close(figure)

--- a/volatility_book/ch_discrete_vol/round2.py
+++ b/volatility_book/ch_discrete_vol/round2.py
@@ -1,0 +1,533 @@
+"""Round-2 runner for the discrete-versus-continuous TGARCH study.
+
+This repository-only module executes R1--R6 of the revised 2026-08-23
+brief.  It deliberately leaves the public :mod:`stochvolmodels` package
+untouched.  Volatility and rates are annualized, time is in years, and
+returns are log returns throughout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import math
+import platform
+import subprocess
+import sys
+import time
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+import numpy as np
+
+from volatility_book.ch_discrete_vol.experiments import StudyProfile, parameter_sets
+from volatility_book.ch_discrete_vol.round2_e4 import run_round2_r2, run_round2_r3
+from volatility_book.ch_discrete_vol.round2_e6 import run_round2_e6
+from volatility_book.ch_discrete_vol.round2_e7 import run_round2_e7
+from volatility_book.ch_discrete_vol.round2_reporting import (
+    write_round2_figures_pdf,
+    write_round2_markdown,
+    write_round2_results_json,
+)
+
+BASE_DIR = Path(__file__).resolve().parent
+DEFAULT_NOTES_DIR = BASE_DIR / "notes"
+DEFAULT_BACKGROUND_NOTE = Path(
+    r"C:\Users\artur\OneDrive\My Papers\Volatility Book 2026\My Reference Papers"
+    r"\Chapter on Discrete Volatility Estimation. Zurich. Aug 2026"
+    r"\tgarch_quadratic_drift_note.tex"
+)
+ROUND1_ARCHIVE_HASHES = {
+    "results.md": "3d368fe8f93b9ecaf55bd156325187a8ea53b465397148b168eadd14f8070f5c",
+    "results.json": "f4c08fe9a5df7b1967a57155d93762ff78d87463f3d774223427a21705629196",
+    "figures.pdf": "0262aad5c07b6a612300a1435891a8c021926f1c22334976628b205f37d5d336",
+}
+
+
+class LocalTests(str, Enum):
+    """Runnable round-2 workload profiles."""
+
+    SMOKE = "smoke"
+    REFERENCE = "reference"
+    FULL = "full"
+
+
+def _json(path: Path) -> dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as stream:
+        value = json.load(stream)
+    if not isinstance(value, dict):
+        raise ValueError(f"Expected a JSON object in {path}")
+    return value
+
+
+def _sha256(path: Path) -> str | None:
+    path = Path(path)
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _git(repo: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ["git", "-c", "safe.directory=*", "-C", str(repo), *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _require_clean_exact_tag() -> dict[str, str]:
+    repo = _repo_root()
+    status = _git(repo, "status", "--short")
+    if status:
+        raise RuntimeError("Round 2 must run from a clean tree; git status is:\n" + status)
+    try:
+        tag = _git(repo, "describe", "--tags", "--exact-match", "HEAD")
+    except subprocess.CalledProcessError as error:
+        raise RuntimeError("Round 2 must run from an exactly tagged commit") from error
+    executed_inputs = sorted(BASE_DIR.glob("*.py")) + [
+        DEFAULT_NOTES_DIR / "SOL_BRIEF_discrete_vs_continuous_tgarch_study.md"
+    ]
+    for path in executed_inputs:
+        relative = path.resolve().relative_to(repo.resolve()).as_posix()
+        try:
+            _git(repo, "ls-files", "--error-unmatch", relative)
+            head_blob = _git(repo, "rev-parse", f"HEAD:{relative}")
+            working_blob = _git(repo, "hash-object", str(path))
+        except subprocess.CalledProcessError as error:
+            raise RuntimeError(
+                f"Executed study input is not tracked at HEAD: {relative}"
+            ) from error
+        if head_blob != working_blob:
+            raise RuntimeError(f"Executed study input differs from tagged HEAD: {relative}")
+    return {
+        "repository_head": _git(repo, "rev-parse", "HEAD"),
+        "repository_tag": tag,
+        "repository_status": status,
+    }
+
+
+def _keyed(
+    rows: list[dict[str, Any]], fields: tuple[str, ...]
+) -> dict[tuple[Any, ...], dict[str, Any]]:
+    return {tuple(row[field] for field in fields): row for row in rows}
+
+
+def _e1_stability(round1: dict[str, Any], repeat: dict[str, Any]) -> list[dict[str, Any]]:
+    def finest(data: dict[str, Any]) -> dict[tuple[Any, ...], dict[str, Any]]:
+        rows = data["experiments"]["E1"]["records"]
+        groups: dict[tuple[Any, ...], list[dict[str, Any]]] = {}
+        for row in rows:
+            groups.setdefault((row["parameter_set"], row["maturity"]), []).append(row)
+        return {key: min(group, key=lambda row: row["dt"]) for key, group in groups.items()}
+
+    old = finest(round1)
+    new = finest(repeat)
+    output: list[dict[str, Any]] = []
+    for key in sorted(old):
+        first = old[key]
+        second = new[key]
+        error_first = np.asarray(first["mc_ivols"]) - np.asarray(first["affine_ivols"])
+        error_second = np.asarray(second["mc_ivols"]) - np.asarray(second["affine_ivols"])
+        combined_se = np.hypot(first["mc_ivol_se"], second["mc_ivol_se"])
+        z_score = np.divide(
+            error_second - error_first,
+            combined_se,
+            out=np.zeros_like(error_first, dtype=float),
+            where=np.asarray(combined_se) > 0.0,
+        )
+        maximum_z = float(np.max(np.abs(z_score)))
+        output.append(
+            {
+                "item": "E1 finest IV errors",
+                "parameter_set": key[0],
+                "case": f"T={key[1]:.8g}",
+                "round1_value": float(np.mean(np.abs(error_first)) * 1.0e4),
+                "repeat_value": float(np.mean(np.abs(error_second)) * 1.0e4),
+                "round1_max_value": float(np.max(np.abs(error_first)) * 1.0e4),
+                "repeat_max_value": float(np.max(np.abs(error_second)) * 1.0e4),
+                "units": "mean absolute bp",
+                "noise_statistic": maximum_z,
+                "criterion": "max strike-level |difference| / combined MC SE <= 3",
+                "passed": maximum_z <= 3.0,
+            }
+        )
+    return output
+
+
+def _rate_se(data: dict[str, Any], parameter_set: str) -> float:
+    rows = [
+        row for row in data["experiments"]["E2"]["records"] if row["parameter_set"] == parameter_set
+    ]
+    x = np.log(np.asarray([row["dt"] for row in rows], dtype=float))
+    gap = np.abs(np.asarray([row["limit_minus_exact"] for row in rows], dtype=float))
+    gap_se = np.asarray([row["limit_minus_exact_se"] for row in rows], dtype=float)
+    slope_weights = (x - np.mean(x)) / np.sum(np.square(x - np.mean(x)))
+    return float(np.sqrt(np.sum(np.square(slope_weights * gap_se / gap))))
+
+
+def _e2_stability(round1: dict[str, Any], repeat: dict[str, Any]) -> list[dict[str, Any]]:
+    old = _keyed(round1["experiments"]["E2"]["rates"], ("parameter_set",))
+    new = _keyed(repeat["experiments"]["E2"]["rates"], ("parameter_set",))
+    output: list[dict[str, Any]] = []
+    for key in sorted(old):
+        first = float(old[key]["fitted_rate"])
+        second = float(new[key]["fitted_rate"])
+        combined_se = math.hypot(
+            _rate_se(round1, str(key[0])),
+            _rate_se(repeat, str(key[0])),
+        )
+        z_score = abs(second - first) / combined_se
+        output.append(
+            {
+                "item": "E2 fitted gap rate",
+                "parameter_set": key[0],
+                "case": "all dt",
+                "round1_value": first,
+                "repeat_value": second,
+                "units": "log-log slope",
+                "noise_statistic": z_score,
+                "criterion": "|rate difference| / delta-method combined MC SE <= 3",
+                "passed": z_score <= 3.0,
+            }
+        )
+    return output
+
+
+def _e3_stability(round1: dict[str, Any], repeat: dict[str, Any]) -> list[dict[str, Any]]:
+    fields = ("parameter_set", "variant", "dt")
+    old = _keyed(round1["experiments"]["E3"]["records"], fields)
+    new = _keyed(repeat["experiments"]["E3"]["records"], fields)
+    output: list[dict[str, Any]] = []
+    for key in sorted(key for key in old if key[1] == "baseline"):
+        first = float(old[key]["relative_sup_density_error"])
+        second = float(new[key]["relative_sup_density_error"])
+        difference = abs(second - first)
+        output.append(
+            {
+                "item": "E3 baseline relative sup-density error",
+                "parameter_set": key[0],
+                "case": f"dt={key[2]:.8g}",
+                "round1_value": first,
+                "repeat_value": second,
+                "units": "relative error",
+                "noise_statistic": difference,
+                "criterion": "absolute repeat-run difference <= 0.10",
+                "passed": difference <= 0.10,
+                "limitation": (
+                    "Stored density grids do not permit a block-bootstrap SE; 0.10 is the "
+                    "declared repeat-run sampling tolerance."
+                ),
+            }
+        )
+    return output
+
+
+def _e4_stability(round1: dict[str, Any], repeat: dict[str, Any]) -> list[dict[str, Any]]:
+    fields = ("kappa2_hat", "power", "dt")
+    old = _keyed(round1["experiments"]["E4"]["records"], fields)
+    new = _keyed(repeat["experiments"]["E4"]["records"], fields)
+    output: list[dict[str, Any]] = []
+    selected = [key for key in old if float(key[0]) in (0.0, 4.25) and key in new]
+    for key in sorted(selected):
+        first = float(old[key]["moment"])
+        second = float(new[key]["moment"])
+        combined_se = math.hypot(
+            float(old[key]["standard_error"]),
+            float(new[key]["standard_error"]),
+        )
+        z_score = abs(second - first) / combined_se if combined_se > 0.0 else 0.0
+        output.append(
+            {
+                "item": "E4 selected moment",
+                "parameter_set": "crypto",
+                "case": f"k2hat={key[0]:g}, p={key[1]:g}, dt={key[2]:.8g}",
+                "round1_value": first,
+                "repeat_value": second,
+                "units": "moment",
+                "noise_statistic": z_score,
+                "criterion": "|moment difference| / combined MC SE <= 3",
+                "passed": z_score <= 3.0,
+            }
+        )
+    return output
+
+
+def build_r1_stability(round1: dict[str, Any], repeat: dict[str, Any]) -> dict[str, Any]:
+    """Build the blocking R1 one-table comparison against the archived run."""
+    rows = (
+        _e1_stability(round1, repeat)
+        + _e2_stability(round1, repeat)
+        + _e3_stability(round1, repeat)
+        + _e4_stability(round1, repeat)
+    )
+    return {
+        "blocking_gate_passed": bool(rows) and all(row["passed"] for row in rows),
+        "rows": rows,
+        "baseline_tag": repeat["provenance"]["repository_describe"],
+        "baseline_head": repeat["provenance"]["repository_head"],
+        "round1_archive_tag": round1["provenance"]["repository_describe"],
+        "interpretation": (
+            "E1, E2, and E4 use combined Monte Carlo uncertainty. E3 uses an explicit "
+            "repeat-run tolerance because the archived stationary samples were not stored."
+        ),
+    }
+
+
+def _provenance(
+    *,
+    profile: StudyProfile,
+    round1_json: Path,
+    r1_json: Path,
+    background_note: Path,
+) -> dict[str, Any]:
+    git = _require_clean_exact_tag()
+    packages = ("numpy", "scipy", "matplotlib", "numba", "pandas", "stochvolmodels")
+    code_dir = Path(__file__).resolve().parent
+    code_files = sorted(code_dir.glob("*.py"))
+    return {
+        "script": "python -m volatility_book.ch_discrete_vol.round2",
+        "profile": profile.value,
+        "python": sys.version.replace("\n", " "),
+        "platform": platform.platform(),
+        "package_versions": {package: importlib.metadata.version(package) for package in packages},
+        **git,
+        "code_sha256": {path.name: _sha256(path) for path in code_files},
+        "input_sha256": {
+            "updated_brief": _sha256(
+                DEFAULT_NOTES_DIR / "SOL_BRIEF_discrete_vs_continuous_tgarch_study.md"
+            ),
+            "background_note": _sha256(background_note),
+            "round1_results_json": _sha256(round1_json),
+            "r1_repeat_results_json": _sha256(r1_json),
+        },
+        "round1_archive_expected_sha256": ROUND1_ARCHIVE_HASHES,
+        "round1_archive_observed_sha256": {
+            name: _sha256(Path(round1_json).resolve().parent / name)
+            for name in ROUND1_ARCHIVE_HASHES
+        },
+        "seeds": {
+            "R1_repeat_E1_to_E7": "20260824 through 20260830",
+            "R2_R3_base_seed": 20260823,
+            "R2_R3_stream_rule": (
+                "numpy SeedSequence([20260823, *parts]); stage/dt/chunk parts are "
+                "stored in the R2/R3 section metadata"
+            ),
+            "R4": 20260829,
+            "R5_replay": "20260830 + replication",
+        },
+    }
+
+
+def _validate_r1_inputs(
+    *,
+    round1: Mapping[str, Any],
+    repeat: Mapping[str, Any],
+    round1_json: Path,
+) -> None:
+    archive_dir = Path(round1_json).resolve().parent
+    mismatches = {
+        name: (_sha256(archive_dir / name), expected)
+        for name, expected in ROUND1_ARCHIVE_HASHES.items()
+        if _sha256(archive_dir / name) != expected
+    }
+    if mismatches:
+        raise RuntimeError(f"Round-1 archive hash validation failed: {mismatches}")
+    if repeat.get("profile") != "reference":
+        raise RuntimeError("R1 clean repeat must use the reference profile")
+    repeat_provenance = repeat.get("provenance", {})
+    if not isinstance(repeat_provenance, Mapping):
+        raise RuntimeError("R1 clean repeat has no provenance mapping")
+    if repeat_provenance.get("repository_status"):
+        raise RuntimeError("R1 clean repeat reports a non-clean repository status")
+    baseline_tag = str(repeat_provenance.get("repository_describe", ""))
+    baseline_head = str(repeat_provenance.get("repository_head", ""))
+    if not baseline_tag or not baseline_head:
+        raise RuntimeError("R1 clean repeat is missing its exact tag or HEAD")
+    resolved_head = _git(_repo_root(), "rev-list", "-n", "1", baseline_tag)
+    if resolved_head != baseline_head:
+        raise RuntimeError(
+            "R1 clean-repeat tag does not resolve to its embedded HEAD: "
+            f"{baseline_tag} -> {resolved_head}, embedded {baseline_head}"
+        )
+    archive_provenance = round1.get("provenance", {})
+    if not isinstance(archive_provenance, Mapping):
+        raise RuntimeError("Round-1 archive is missing provenance")
+
+
+def _unwrap(value: dict[str, Any], key: str) -> dict[str, Any]:
+    nested = value.get(key)
+    return nested if isinstance(nested, dict) else value
+
+
+def run_round2(
+    *,
+    output_dir: Path,
+    profile: StudyProfile,
+    round1_json: Path,
+    r1_json: Path,
+    background_note: Path = DEFAULT_BACKGROUND_NOTE,
+) -> dict[str, Any]:
+    """Execute R1--R6 and write the round-2 memo, audit JSON, and combined PDF."""
+    started = time.perf_counter()
+    _require_clean_exact_tag()
+    output_dir = Path(output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    round1 = _json(round1_json)
+    repeat = _json(r1_json)
+    _validate_r1_inputs(
+        round1=round1,
+        repeat=repeat,
+        round1_json=Path(round1_json),
+    )
+    r1 = build_r1_stability(round1, repeat)
+    if not r1["blocking_gate_passed"]:
+        raise RuntimeError("R1 stability gate failed; R2--R6 were not started")
+
+    params = parameter_sets()
+    print("[TGARCH round 2] R3 headline: start", flush=True)
+    r3 = run_round2_r3(params["crypto"], profile.value)
+    print("[TGARCH round 2] R4: start", flush=True)
+    e6 = run_round2_e6(params, profile.value)
+    print("[TGARCH round 2] R2: start", flush=True)
+    r2 = run_round2_r2(params["crypto"], profile.value)
+    print("[TGARCH round 2] R5: start", flush=True)
+    e7 = run_round2_e7(round1, params, profile.value)
+
+    results: dict[str, Any] = {
+        "title": "Discrete versus continuous log-normal beta SV study - round 2",
+        "profile": profile.value,
+        "conventions": {
+            "volatility_and_rates": "annualized",
+            "time_and_dt": "years",
+            "returns": "log returns",
+            "scaling": "square-root time-step kernel scaling",
+        },
+        "parameters": round1["parameters"],
+        "R1": r1,
+        "R2": r2,
+        "R3": r3,
+        "R4": _unwrap(e6, "R4"),
+        "R5": _unwrap(e7, "R5"),
+        "contradictions": [
+            {
+                "item": "R2 finite-step defect",
+                "finding": (
+                    "Every finite-dt Q_LIMIT step has conditional discounted mean one. "
+                    "A negative fixed-N estimate is a rare-tail/non-uniform-integrability "
+                    "diagnostic, not a finite-step martingale defect or proof of lost mass."
+                ),
+            },
+            {
+                "item": "R4 forgetting intercept",
+                "finding": (
+                    "For a log-decay regression the asymptotic intercept is kappa_lin + "
+                    "0.5*(eps*m1/s1)^2, not kappa_lin. Both the requested and corrected "
+                    "comparisons are reported."
+                ),
+            },
+            {
+                "item": "R5 option-identification interpretation",
+                "finding": (
+                    "The requested profiled variant fixes physical kappa2 at its simulation "
+                    "truth but neither imposes d0 nor uses option-implied risk-neutral "
+                    "kappa2_hat. It is an oracle ridge-removal proxy and cannot quantify the "
+                    "brief's claimed option-plus-d0 identification gain."
+                ),
+            },
+        ],
+        "standing_caveats": [
+            (
+                "All convergence statements in this memo are relative to the square-root "
+                "time-step kernel scaling. The experiments do not establish transfer of "
+                "statistical inference between the discrete and continuous models."
+            ),
+            (
+                "The R5 fixed-kappa2 fit is an oracle physical-parameter experiment; it does "
+                "not by itself quantify identification from an option-implied kappa2_hat."
+            ),
+            (
+                "R5 eigendirection cosines use theta fixed at its simulation truth; because "
+                "theta is estimated jointly, they are conditional local ridge diagnostics."
+            ),
+        ],
+        "provenance": _provenance(
+            profile=profile,
+            round1_json=Path(round1_json),
+            r1_json=Path(r1_json),
+            background_note=Path(background_note),
+        ),
+    }
+    results["runtime_seconds"] = time.perf_counter() - started
+
+    json_path = output_dir / "round2_results.json"
+    markdown_path = output_dir / "round2_results.md"
+    figures_path = output_dir / "round2_figures.pdf"
+    write_round2_results_json(results, json_path)
+    write_round2_markdown(results, markdown_path, json_path=json_path)
+    write_round2_figures_pdf(
+        results,
+        figures_path,
+        round1_results=round1,
+    )
+    print(f"[TGARCH round 2] artifacts written to {output_dir}", flush=True)
+    return results
+
+
+def run_local_test(
+    local_test: LocalTests,
+    *,
+    output_dir: Path = DEFAULT_NOTES_DIR,
+    round1_json: Path | None = None,
+    r1_json: Path | None = None,
+    background_note: Path = DEFAULT_BACKGROUND_NOTE,
+) -> dict[str, Any]:
+    """Run one named workload through the production round-2 entry point."""
+    if not isinstance(local_test, LocalTests):
+        raise ValueError("local_test must be a LocalTests member")
+    notes = Path(output_dir)
+    return run_round2(
+        output_dir=notes,
+        profile=StudyProfile(local_test.value),
+        round1_json=Path(round1_json) if round1_json else notes / "results.json",
+        r1_json=Path(r1_json) if r1_json else notes / "r1_reference" / "results.json",
+        background_note=background_note,
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", choices=[item.value for item in LocalTests], default="smoke")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_NOTES_DIR)
+    parser.add_argument("--round1-json", type=Path)
+    parser.add_argument("--r1-json", type=Path)
+    parser.add_argument("--background-note", type=Path, default=DEFAULT_BACKGROUND_NOTE)
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run the command-line selected round-2 workload."""
+    arguments = _parse_args()
+    run_local_test(
+        LocalTests(arguments.profile),
+        output_dir=arguments.output_dir,
+        round1_json=arguments.round1_json,
+        r1_json=arguments.r1_json,
+        background_note=arguments.background_note,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/volatility_book/ch_discrete_vol/round2.py
+++ b/volatility_book/ch_discrete_vol/round2.py
@@ -35,12 +35,13 @@ from volatility_book.ch_discrete_vol.round2_reporting import (
 
 BASE_DIR = Path(__file__).resolve().parent
 DEFAULT_NOTES_DIR = BASE_DIR / "notes"
-DEFAULT_BACKGROUND_NOTE = Path(
-    r"C:\Users\artur\OneDrive\My Papers\Volatility Book 2026\My Reference Papers"
-    r"\Chapter on Discrete Volatility Estimation. Zurich. Aug 2026"
-    r"\tgarch_quadratic_drift_note.tex"
-)
-ROUND1_ARCHIVE_HASHES = {
+ACCEPTANCE_MANIFEST = BASE_DIR / "acceptance_manifest.json"
+DEFAULT_BACKGROUND_NOTE = DEFAULT_NOTES_DIR / "tgarch_quadratic_drift_note.tex"
+OUTPUT_ROOT = BASE_DIR.parents[1] / "outputs" / "volatility_book" / "ch_discrete_vol"
+DEFAULT_OUTPUT_DIR = OUTPUT_ROOT / "round2"
+DEFAULT_ROUND1_JSON = OUTPUT_ROOT / "round1" / "results.json"
+DEFAULT_R1_JSON = OUTPUT_ROOT / "round1_reference" / "results.json"
+ROUND1_ARCHIVED_WHOLE_ARTIFACT_PROVENANCE_HASHES = {
     "results.md": "3d368fe8f93b9ecaf55bd156325187a8ea53b465397148b168eadd14f8070f5c",
     "results.json": "f4c08fe9a5df7b1967a57155d93762ff78d87463f3d774223427a21705629196",
     "figures.pdf": "0262aad5c07b6a612300a1435891a8c021926f1c22334976628b205f37d5d336",
@@ -88,17 +89,20 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def _require_clean_exact_tag() -> dict[str, str]:
+def _require_clean_exact_tag(profile: StudyProfile) -> dict[str, str]:
     repo = _repo_root()
-    status = _git(repo, "status", "--short")
-    if status:
+    status = _git(repo, "status", "--short", "--untracked-files=all")
+    if profile is StudyProfile.FULL and status:
         raise RuntimeError("Round 2 must run from a clean tree; git status is:\n" + status)
     try:
         tag = _git(repo, "describe", "--tags", "--exact-match", "HEAD")
     except subprocess.CalledProcessError as error:
-        raise RuntimeError("Round 2 must run from an exactly tagged commit") from error
+        if profile is StudyProfile.FULL:
+            raise RuntimeError("Round 2 must run from an exactly tagged commit") from error
+        tag = ""
     executed_inputs = sorted(BASE_DIR.glob("*.py")) + [
-        DEFAULT_NOTES_DIR / "SOL_BRIEF_discrete_vs_continuous_tgarch_study.md"
+        DEFAULT_NOTES_DIR / "SOL_BRIEF_discrete_vs_continuous_tgarch_study.md",
+        ACCEPTANCE_MANIFEST,
     ]
     for path in executed_inputs:
         relative = path.resolve().relative_to(repo.resolve()).as_posix()
@@ -107,10 +111,12 @@ def _require_clean_exact_tag() -> dict[str, str]:
             head_blob = _git(repo, "rev-parse", f"HEAD:{relative}")
             working_blob = _git(repo, "hash-object", str(path))
         except subprocess.CalledProcessError as error:
-            raise RuntimeError(
-                f"Executed study input is not tracked at HEAD: {relative}"
-            ) from error
-        if head_blob != working_blob:
+            if profile is StudyProfile.FULL:
+                raise RuntimeError(
+                    f"Executed study input is not tracked at HEAD: {relative}"
+                ) from error
+            continue
+        if profile is StudyProfile.FULL and head_blob != working_blob:
             raise RuntimeError(f"Executed study input differs from tagged HEAD: {relative}")
     return {
         "repository_head": _git(repo, "rev-parse", "HEAD"),
@@ -293,10 +299,19 @@ def _provenance(
     r1_json: Path,
     background_note: Path,
 ) -> dict[str, Any]:
-    git = _require_clean_exact_tag()
+    git = _require_clean_exact_tag(profile)
     packages = ("numpy", "scipy", "matplotlib", "numba", "pandas", "stochvolmodels")
     code_dir = Path(__file__).resolve().parent
     code_files = sorted(code_dir.glob("*.py"))
+    archive_dir = Path(round1_json).resolve().parent
+    observed_archive_hashes = {
+        name: _sha256(archive_dir / name)
+        for name in ROUND1_ARCHIVED_WHOLE_ARTIFACT_PROVENANCE_HASHES
+    }
+    archive_hash_matches = {
+        name: observed_archive_hashes[name] == expected
+        for name, expected in ROUND1_ARCHIVED_WHOLE_ARTIFACT_PROVENANCE_HASHES.items()
+    }
     return {
         "script": "python -m volatility_book.ch_discrete_vol.round2",
         "profile": profile.value,
@@ -312,12 +327,26 @@ def _provenance(
             "background_note": _sha256(background_note),
             "round1_results_json": _sha256(round1_json),
             "r1_repeat_results_json": _sha256(r1_json),
+            "acceptance_manifest": _sha256(ACCEPTANCE_MANIFEST),
         },
-        "round1_archive_expected_sha256": ROUND1_ARCHIVE_HASHES,
-        "round1_archive_observed_sha256": {
-            name: _sha256(Path(round1_json).resolve().parent / name)
-            for name in ROUND1_ARCHIVE_HASHES
+        "portable_acceptance_manifest": {
+            "path": ACCEPTANCE_MANIFEST.resolve().relative_to(_repo_root().resolve()).as_posix(),
+            "sha256": _sha256(ACCEPTANCE_MANIFEST),
+            "role": "portable content-level numerical acceptance contract",
         },
+        "round1_archived_whole_artifact_provenance": {
+            "expected_sha256": ROUND1_ARCHIVED_WHOLE_ARTIFACT_PROVENANCE_HASHES,
+            "observed_sha256": observed_archive_hashes,
+            "matches": archive_hash_matches,
+            "blocking": False,
+            "portable_numerical_golden": False,
+            "role": (
+                "Historical whole-artifact provenance only; hashes include revision, paths, "
+                "versions, runtime, and rendering metadata."
+            ),
+        },
+        # Backward-compatible reporting alias; never use as a portable acceptance gate.
+        "round1_archive_observed_sha256": observed_archive_hashes,
         "seeds": {
             "R1_repeat_E1_to_E7": "20260824 through 20260830",
             "R2_R3_base_seed": 20260823,
@@ -335,16 +364,9 @@ def _validate_r1_inputs(
     *,
     round1: Mapping[str, Any],
     repeat: Mapping[str, Any],
-    round1_json: Path,
 ) -> None:
-    archive_dir = Path(round1_json).resolve().parent
-    mismatches = {
-        name: (_sha256(archive_dir / name), expected)
-        for name, expected in ROUND1_ARCHIVE_HASHES.items()
-        if _sha256(archive_dir / name) != expected
-    }
-    if mismatches:
-        raise RuntimeError(f"Round-1 archive hash validation failed: {mismatches}")
+    if round1.get("profile") != "full":
+        raise RuntimeError("Round-1 input must use the full profile")
     if repeat.get("profile") != "reference":
         raise RuntimeError("R1 clean repeat must use the reference profile")
     repeat_provenance = repeat.get("provenance", {})
@@ -372,9 +394,15 @@ def _unwrap(value: dict[str, Any], key: str) -> dict[str, Any]:
     return nested if isinstance(nested, dict) else value
 
 
+def _default_output_dir(profile: StudyProfile) -> Path:
+    if profile is StudyProfile.FULL:
+        return DEFAULT_OUTPUT_DIR
+    return OUTPUT_ROOT / f"round2_{profile.value}"
+
+
 def run_round2(
     *,
-    output_dir: Path,
+    output_dir: Path | None = None,
     profile: StudyProfile,
     round1_json: Path,
     r1_json: Path,
@@ -382,15 +410,15 @@ def run_round2(
 ) -> dict[str, Any]:
     """Execute R1--R6 and write the round-2 memo, audit JSON, and combined PDF."""
     started = time.perf_counter()
-    _require_clean_exact_tag()
-    output_dir = Path(output_dir).resolve()
+    _require_clean_exact_tag(profile)
+    selected_output = _default_output_dir(profile) if output_dir is None else Path(output_dir)
+    output_dir = selected_output.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
     round1 = _json(round1_json)
     repeat = _json(r1_json)
     _validate_r1_inputs(
         round1=round1,
         repeat=repeat,
-        round1_json=Path(round1_json),
     )
     r1 = build_r1_stability(round1, repeat)
     if not r1["blocking_gate_passed"]:
@@ -489,7 +517,7 @@ def run_round2(
 def run_local_test(
     local_test: LocalTests,
     *,
-    output_dir: Path = DEFAULT_NOTES_DIR,
+    output_dir: Path | None = None,
     round1_json: Path | None = None,
     r1_json: Path | None = None,
     background_note: Path = DEFAULT_BACKGROUND_NOTE,
@@ -497,12 +525,14 @@ def run_local_test(
     """Run one named workload through the production round-2 entry point."""
     if not isinstance(local_test, LocalTests):
         raise ValueError("local_test must be a LocalTests member")
-    notes = Path(output_dir)
+    profile = StudyProfile(local_test.value)
     return run_round2(
-        output_dir=notes,
-        profile=StudyProfile(local_test.value),
-        round1_json=Path(round1_json) if round1_json else notes / "results.json",
-        r1_json=Path(r1_json) if r1_json else notes / "r1_reference" / "results.json",
+        output_dir=(
+            Path(output_dir) if output_dir is not None else _default_output_dir(profile)
+        ),
+        profile=profile,
+        round1_json=Path(round1_json) if round1_json else DEFAULT_ROUND1_JSON,
+        r1_json=Path(r1_json) if r1_json else DEFAULT_R1_JSON,
         background_note=background_note,
     )
 
@@ -510,7 +540,14 @@ def run_local_test(
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--profile", choices=[item.value for item in LocalTests], default="smoke")
-    parser.add_argument("--output-dir", type=Path, default=DEFAULT_NOTES_DIR)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help=(
+            "Artifact directory; defaults under outputs/volatility_book/ch_discrete_vol "
+            "to round2, round2_reference, or round2_smoke according to --profile."
+        ),
+    )
     parser.add_argument("--round1-json", type=Path)
     parser.add_argument("--r1-json", type=Path)
     parser.add_argument("--background-note", type=Path, default=DEFAULT_BACKGROUND_NOTE)

--- a/volatility_book/ch_discrete_vol/round2_e4.py
+++ b/volatility_book/ch_discrete_vol/round2_e4.py
@@ -1,0 +1,1409 @@
+"""Round-2 E4 martingale and spot-moment diagnostics.
+
+This module is deliberately self-contained.  It implements the corrected E4a/E4b
+experiment without changing the established simulation API in :mod:`.sim`:
+
+* R2 reports fixed-budget Monte Carlo estimates of the discounted-spot defect under
+  ``Q_LIMIT`` and exact-martingale controls under ``Q_EXACT``;
+* R3 estimates slopes of log spot moments against ``log(1 / dt)`` on the four corrected
+  time steps (the weekly point is excluded), then bootstraps the complete slope;
+* antithetic pairs are kept together inside equal-size bootstrap batches;
+* paths are simulated in memory-bounded chunks, with common random numbers across all
+  ``kappa2_hat`` values and powers evaluated on the same terminal paths.
+
+The R2 bootstrap is conditional on the observed paths.  It cannot measure mass carried
+by rare paths that were never sampled, and therefore cannot by itself establish a
+strict-local-martingale limit.  Path-count sensitivity and log-domain diagnostics are
+returned to make that limitation visible.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .sim import M1, S1, SIGMA_FLOOR, TgarchParams, derived_limit_params
+
+FloatArray = NDArray[np.float64]
+
+BASE_SEED = 20260823
+R2_KAPPA_GRID = np.array((0.0, 0.5, 1.0, 2.0, 4.25), dtype=np.float64)
+R3_KAPPA_GRID = np.array((0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5), dtype=np.float64)
+R3_POWERS = np.arange(1.1, 2.0, 0.1, dtype=np.float64)
+R2_DTS = (1.0 / 52.0, 1.0 / 252.0, 1.0 / 1008.0, 1.0 / 4032.0, 1.0 / 16128.0)
+R3_DTS = (1.0 / 252.0, 1.0 / 1008.0, 1.0 / 4032.0, 1.0 / 16128.0)
+R2_MATURITIES = (0.25, 1.0)
+R3_MATURITY = 0.25
+TAIL_FRACTION = 0.001
+TAIL_SHARE_LIMIT = 0.2
+
+
+class Round2Profile(str, Enum):
+    """Execution size for development, reference analysis, or the full brief."""
+
+    SMOKE = "smoke"
+    REFERENCE = "reference"
+    FULL = "full"
+
+
+@dataclass(frozen=True, slots=True)
+class Round2Config:
+    """Numerical workload for :func:`run_round2_e4`."""
+
+    profile: Round2Profile
+    r2_paths: int
+    r3_pilot_paths: int
+    bootstrap_replications: int
+    bootstrap_batch_pairs: int
+    path_chunk: int
+    permit_tail_doubling: bool
+
+
+def _make_config(profile: Round2Profile) -> Round2Config:
+    if profile is Round2Profile.FULL:
+        return Round2Config(
+            profile=profile,
+            r2_paths=2**20,
+            r3_pilot_paths=2**17,
+            bootstrap_replications=400,
+            bootstrap_batch_pairs=128,
+            path_chunk=2**15,
+            permit_tail_doubling=True,
+        )
+    if profile is Round2Profile.REFERENCE:
+        return Round2Config(
+            profile=profile,
+            r2_paths=2**16,
+            r3_pilot_paths=2**14,
+            bootstrap_replications=200,
+            bootstrap_batch_pairs=64,
+            path_chunk=2**13,
+            permit_tail_doubling=True,
+        )
+    return Round2Config(
+        profile=profile,
+        r2_paths=2**12,
+        r3_pilot_paths=2**10,
+        bootstrap_replications=80,
+        bootstrap_batch_pairs=16,
+        path_chunk=2**12,
+        permit_tail_doubling=False,
+    )
+
+
+def _as_profile(profile: Round2Profile | str) -> Round2Profile:
+    if isinstance(profile, Round2Profile):
+        return profile
+    try:
+        return Round2Profile(str(profile).lower())
+    except ValueError as error:
+        choices = ", ".join(item.value for item in Round2Profile)
+        raise ValueError(f"profile must be one of {choices}") from error
+
+
+def _seed(*parts: int) -> int:
+    sequence = np.random.SeedSequence([BASE_SEED, *parts])
+    return int(sequence.generate_state(1, dtype=np.uint64)[0])
+
+
+def _r2_chunk_seed_records(dt: float, n_paths: int, path_chunk: int) -> list[dict[str, int]]:
+    dt_code = int(round(1.0 / dt))
+    return [
+        {
+            "path_start": start,
+            "path_stop": min(start + path_chunk, n_paths),
+            "derived_seed": _seed(200, dt_code, start),
+        }
+        for start in range(0, n_paths, path_chunk)
+    ]
+
+
+def _r3_chunk_seed_records(
+    dt: float,
+    n_paths: int,
+    path_chunk: int,
+    tranche: int,
+) -> list[dict[str, int]]:
+    dt_code = int(round(1.0 / dt))
+    return [
+        {
+            "tranche": tranche,
+            "path_start": start,
+            "path_stop": min(start + path_chunk, n_paths),
+            "derived_seed": _seed(300, dt_code, tranche, start),
+        }
+        for start in range(0, n_paths, path_chunk)
+    ]
+
+
+def _logsumexp(values: FloatArray, axis: int = -1) -> FloatArray:
+    maximum = np.max(values, axis=axis, keepdims=True)
+    shifted = np.exp(values - maximum)
+    result = maximum + np.log(np.sum(shifted, axis=axis, keepdims=True))
+    return np.squeeze(result, axis=axis)
+
+
+def _logmeanexp(values: FloatArray, axis: int = -1) -> FloatArray:
+    return _logsumexp(values, axis=axis) - math.log(values.shape[axis])
+
+
+def _pair_batch_logmeans(
+    log_normalized_spot: FloatArray,
+    powers: FloatArray,
+    batch_pairs: int,
+) -> FloatArray:
+    """Return log means for equal batches whose atomic units are antithetic pairs."""
+
+    if log_normalized_spot.ndim != 2:
+        raise ValueError("log_normalized_spot must have shape (kappa, path)")
+    kappa_count, n_paths = log_normalized_spot.shape
+    if n_paths % 2:
+        raise ValueError("n_paths must be even for antithetic-pair batching")
+    pair_count = n_paths // 2
+    if pair_count % batch_pairs:
+        raise ValueError("the antithetic-pair count must be divisible by batch_pairs")
+    batch_count = pair_count // batch_pairs
+    result = np.empty((kappa_count, powers.size, batch_count), dtype=np.float64)
+    for power_index, power in enumerate(powers):
+        scaled = power * log_normalized_spot
+        pair_logs = np.logaddexp(scaled[:, 0::2], scaled[:, 1::2]) - math.log(2.0)
+        reshaped = pair_logs.reshape(kappa_count, batch_count, batch_pairs)
+        result[:, power_index, :] = _logmeanexp(reshaped, axis=-1)
+    return result
+
+
+def _bootstrap_logmeans(
+    batch_logmeans: FloatArray,
+    replications: int,
+    seed: int,
+) -> FloatArray:
+    """Jointly resample equal-size pair batches and return bootstrap log means."""
+
+    batch_count = batch_logmeans.shape[-1]
+    if batch_count < 8:
+        raise ValueError("at least eight bootstrap batches are required")
+    rng = np.random.Generator(np.random.PCG64(seed))
+    indices = rng.integers(
+        0,
+        batch_count,
+        size=(replications, batch_count),
+        dtype=np.int64,
+    )
+    flat = batch_logmeans.reshape(-1, batch_count)
+    boot_flat = np.empty((replications, flat.shape[0]), dtype=np.float64)
+    for metric_index, row in enumerate(flat):
+        # Re-stabilize every resample.  A full-sample shift is unsafe when the draw
+        # omits the dominant batch and all selected exponentials would underflow.
+        boot_flat[:, metric_index] = _logmeanexp(row[indices], axis=1)
+    if not np.isfinite(boot_flat).all():
+        raise FloatingPointError("pair-batch bootstrap produced a non-finite log mean")
+    return boot_flat.reshape((replications, *batch_logmeans.shape[:-1]))
+
+
+def _tail_share(log_normalized_spot: FloatArray, power: float) -> float:
+    """Share of a sample moment supplied by the largest 0.1 percent of paths."""
+
+    n_paths = log_normalized_spot.size
+    top_count = max(1, int(math.ceil(TAIL_FRACTION * n_paths)))
+    scaled = power * log_normalized_spot
+    split = n_paths - top_count
+    top = np.partition(scaled, split)[split:]
+    log_total = float(_logsumexp(scaled.reshape(1, -1), axis=1)[0])
+    log_top = float(_logsumexp(top.reshape(1, -1), axis=1)[0])
+    return float(math.exp(log_top - log_total))
+
+
+def _antithetic_normals(rng: np.random.Generator, n_paths: int) -> FloatArray:
+    draws = rng.standard_normal(n_paths // 2)
+    result = np.empty(n_paths, dtype=np.float64)
+    result[0::2] = draws
+    result[1::2] = -draws
+    return result
+
+
+def _validate_grid_step(maturity: float, dt: float) -> int:
+    n_steps = int(round(maturity / dt))
+    if n_steps <= 0 or not math.isclose(n_steps * dt, maturity, rel_tol=0.0, abs_tol=1.0e-12):
+        raise ValueError(f"dt={dt:.12g} does not divide maturity={maturity:.12g}")
+    return n_steps
+
+
+def _simulate_r2_dt(
+    params: TgarchParams,
+    *,
+    dt: float,
+    n_paths: int,
+    path_chunk: int,
+    kappa_grid: FloatArray,
+) -> tuple[FloatArray, FloatArray, NDArray[np.int64], NDArray[np.int64]]:
+    """Simulate Q_LIMIT variants and Q_EXACT controls on common base normals."""
+
+    base = derived_limit_params(params)
+    snap_steps = tuple(_validate_grid_step(maturity, dt) for maturity in R2_MATURITIES)
+    n_steps = snap_steps[-1]
+    limit_logs = np.empty((len(R2_MATURITIES), kappa_grid.size, n_paths), dtype=np.float64)
+    exact_logs = np.empty((len(R2_MATURITIES), 1, n_paths), dtype=np.float64)
+    limit_floor = np.zeros((len(R2_MATURITIES), kappa_grid.size), dtype=np.int64)
+    exact_floor = np.zeros((len(R2_MATURITIES), 1), dtype=np.int64)
+    sqrt_dt = math.sqrt(dt)
+    log_spot0 = math.log(params.spot0)
+    dt_code = int(round(1.0 / dt))
+
+    for start in range(0, n_paths, path_chunk):
+        stop = min(start + path_chunk, n_paths)
+        chunk_paths = stop - start
+        if chunk_paths % 2:
+            raise ValueError("every path chunk must contain complete antithetic pairs")
+        rng = np.random.Generator(np.random.PCG64(_seed(200, dt_code, start)))
+        sigma_limit = np.full((kappa_grid.size, chunk_paths), params.sigma0)
+        log_limit = np.full((kappa_grid.size, chunk_paths), log_spot0)
+        sigma_exact = np.full(chunk_paths, params.sigma0)
+        log_exact = np.full(chunk_paths, log_spot0)
+        floor_limit_chunk = np.zeros(kappa_grid.size, dtype=np.int64)
+        floor_exact_chunk = 0
+
+        with np.errstate(over="ignore", invalid="ignore"):
+            for step in range(1, n_steps + 1):
+                base_z = _antithetic_normals(rng, chunk_paths)
+                common_w = (np.abs(base_z) - M1) / S1
+                common_vol = params.beta * base_z + params.eps * common_w
+
+                log_limit += (
+                    params.r - 0.5 * sigma_limit * sigma_limit
+                ) * dt + sigma_limit * sqrt_dt * base_z[None, :]
+                limit_drift = (
+                    base.d0
+                    + base.d1_hat * sigma_limit
+                    - kappa_grid[:, None] * sigma_limit * sigma_limit
+                )
+                sigma_limit_next = (
+                    sigma_limit + limit_drift * dt + sigma_limit * sqrt_dt * common_vol[None, :]
+                )
+                hit_limit = sigma_limit_next < SIGMA_FLOOR
+                floor_limit_chunk += np.count_nonzero(hit_limit, axis=1)
+                np.maximum(sigma_limit_next, SIGMA_FLOOR, out=sigma_limit_next)
+                sigma_limit = sigma_limit_next
+
+                denominator = 1.0 - 2.0 * sqrt_dt * params.eta(sigma_exact)
+                if np.any(denominator <= 0.0) or not np.isfinite(denominator).all():
+                    minimum = float(np.nanmin(denominator))
+                    raise ValueError(
+                        "Q_EXACT kernel is inadmissible: minimum denominator "
+                        f"is {minimum:.12g} at dt={dt:.12g}"
+                    )
+                variance = 1.0 / denominator
+                mean = -sqrt_dt * params.gamma(sigma_exact) - 0.5 * sigma_exact * sqrt_dt * (
+                    variance - 1.0
+                )
+                exact_z = mean + np.sqrt(variance) * base_z
+                log_exact += (
+                    params.r
+                    + params.gamma(sigma_exact) * sigma_exact
+                    - 0.5 * sigma_exact * sigma_exact
+                ) * dt + sigma_exact * sqrt_dt * exact_z
+                exact_w = (np.abs(exact_z) - M1) / S1
+                sigma_exact_next = (
+                    sigma_exact
+                    + params.drift(sigma_exact) * dt
+                    + sigma_exact * sqrt_dt * (params.beta * exact_z + params.eps * exact_w)
+                )
+                hit_exact = sigma_exact_next < SIGMA_FLOOR
+                floor_exact_chunk += int(np.count_nonzero(hit_exact))
+                np.maximum(sigma_exact_next, SIGMA_FLOOR, out=sigma_exact_next)
+                sigma_exact = sigma_exact_next
+
+                if step in snap_steps:
+                    maturity_index = snap_steps.index(step)
+                    maturity = R2_MATURITIES[maturity_index]
+                    normalization = log_spot0 + params.r * maturity
+                    limit_logs[maturity_index, :, start:stop] = log_limit - normalization
+                    exact_logs[maturity_index, 0, start:stop] = log_exact - normalization
+                    limit_floor[maturity_index] += floor_limit_chunk
+                    exact_floor[maturity_index, 0] += floor_exact_chunk
+
+                if step % 256 == 0:
+                    if not np.isfinite(sigma_limit).all() or not np.isfinite(log_limit).all():
+                        raise FloatingPointError(
+                            f"non-finite Q_LIMIT state at dt={dt:.12g}, step={step}"
+                        )
+                    if not np.isfinite(sigma_exact).all() or not np.isfinite(log_exact).all():
+                        raise FloatingPointError(
+                            f"non-finite Q_EXACT state at dt={dt:.12g}, step={step}"
+                        )
+
+        if not np.isfinite(limit_logs[:, :, start:stop]).all():
+            raise FloatingPointError(f"non-finite Q_LIMIT terminal log spot at dt={dt:.12g}")
+        if not np.isfinite(exact_logs[:, :, start:stop]).all():
+            raise FloatingPointError(f"non-finite Q_EXACT terminal log spot at dt={dt:.12g}")
+
+    return limit_logs, exact_logs, limit_floor, exact_floor
+
+
+def _simulate_r3_tranche(
+    params: TgarchParams,
+    *,
+    dt: float,
+    n_paths: int,
+    path_chunk: int,
+    kappa_grid: FloatArray,
+    tranche: int,
+) -> tuple[FloatArray, NDArray[np.int64]]:
+    """Simulate a memory-bounded Q_LIMIT tranche with CRN across kappa values."""
+
+    base = derived_limit_params(params)
+    n_steps = _validate_grid_step(R3_MATURITY, dt)
+    terminal = np.empty((kappa_grid.size, n_paths), dtype=np.float64)
+    floor_hits = np.zeros(kappa_grid.size, dtype=np.int64)
+    sqrt_dt = math.sqrt(dt)
+    log_spot0 = math.log(params.spot0)
+    dt_code = int(round(1.0 / dt))
+
+    for start in range(0, n_paths, path_chunk):
+        stop = min(start + path_chunk, n_paths)
+        chunk_paths = stop - start
+        if chunk_paths % 2:
+            raise ValueError("every path chunk must contain complete antithetic pairs")
+        rng = np.random.Generator(np.random.PCG64(_seed(300, dt_code, tranche, start)))
+        sigma = np.full((kappa_grid.size, chunk_paths), params.sigma0)
+        log_spot = np.full((kappa_grid.size, chunk_paths), log_spot0)
+
+        with np.errstate(over="ignore", invalid="ignore"):
+            for step in range(1, n_steps + 1):
+                z = _antithetic_normals(rng, chunk_paths)
+                w = (np.abs(z) - M1) / S1
+                volatility_innovation = params.beta * z + params.eps * w
+                log_spot += (params.r - 0.5 * sigma * sigma) * dt + sigma * sqrt_dt * z[None, :]
+                drift = base.d0 + base.d1_hat * sigma - kappa_grid[:, None] * sigma * sigma
+                sigma_next = sigma + drift * dt + sigma * sqrt_dt * volatility_innovation[None, :]
+                hit = sigma_next < SIGMA_FLOOR
+                floor_hits += np.count_nonzero(hit, axis=1)
+                np.maximum(sigma_next, SIGMA_FLOOR, out=sigma_next)
+                sigma = sigma_next
+                if step % 256 == 0 and (
+                    not np.isfinite(sigma).all() or not np.isfinite(log_spot).all()
+                ):
+                    raise FloatingPointError(
+                        f"non-finite Q_LIMIT state at dt={dt:.12g}, step={step}"
+                    )
+
+        if not np.isfinite(sigma).all() or not np.isfinite(log_spot).all():
+            raise FloatingPointError(f"non-finite Q_LIMIT terminal state at dt={dt:.12g}")
+        terminal[:, start:stop] = log_spot - (log_spot0 + params.r * R3_MATURITY)
+
+    return terminal, floor_hits
+
+
+def _cumulative_diagnostics(log_normalized_spot: FloatArray) -> list[dict[str, float | int]]:
+    n_paths = log_normalized_spot.size
+    maximum_power = int(math.log2(n_paths))
+    minimum_power = max(8, maximum_power - 6)
+    path_counts = [2**power for power in range(minimum_power, maximum_power + 1)]
+    if path_counts[-1] != n_paths:
+        path_counts.append(n_paths)
+    records: list[dict[str, float | int]] = []
+    for path_count in path_counts:
+        sample = log_normalized_spot[:path_count]
+        log_mean = float(_logmeanexp(sample.reshape(1, -1), axis=1)[0])
+        records.append(
+            {
+                "n_paths": path_count,
+                "log_mean_discounted_spot": log_mean,
+                "empirical_defect": float(np.expm1(log_mean)),
+                "maximum_log_discounted_spot": float(np.max(sample)),
+                "top_0.1pct_share": _tail_share(sample, 1.0),
+            }
+        )
+    return records
+
+
+def _percentile_interval(values: FloatArray) -> tuple[float, float]:
+    low, high = np.percentile(values, (2.5, 97.5))
+    return float(low), float(high)
+
+
+def _run_r2(params: TgarchParams, config: Round2Config) -> dict[str, Any]:
+    started = time.perf_counter()
+    base = derived_limit_params(params)
+    q_limit_records: list[dict[str, Any]] = []
+    q_exact_records: list[dict[str, Any]] = []
+    seed_records: list[dict[str, Any]] = []
+
+    for dt_index, dt in enumerate(R2_DTS):
+        seed_records.append(
+            {
+                "dt_index": dt_index,
+                "dt": dt,
+                "reciprocal_dt_code": int(round(1.0 / dt)),
+                "simulation_chunks": _r2_chunk_seed_records(
+                    dt,
+                    config.r2_paths,
+                    config.path_chunk,
+                ),
+                "bootstrap_derived_seed": _seed(400, dt_index),
+            }
+        )
+        limit_logs, exact_logs, limit_floor, exact_floor = _simulate_r2_dt(
+            params,
+            dt=dt,
+            n_paths=config.r2_paths,
+            path_chunk=config.path_chunk,
+            kappa_grid=R2_KAPPA_GRID,
+        )
+        limit_batches = np.empty(
+            (
+                len(R2_MATURITIES),
+                R2_KAPPA_GRID.size,
+                config.r2_paths // (2 * config.bootstrap_batch_pairs),
+            ),
+            dtype=np.float64,
+        )
+        exact_batches = np.empty(
+            (
+                len(R2_MATURITIES),
+                1,
+                config.r2_paths // (2 * config.bootstrap_batch_pairs),
+            ),
+            dtype=np.float64,
+        )
+        for maturity_index in range(len(R2_MATURITIES)):
+            limit_batches[maturity_index] = _pair_batch_logmeans(
+                limit_logs[maturity_index],
+                np.array((1.0,)),
+                config.bootstrap_batch_pairs,
+            )[:, 0, :]
+            exact_batches[maturity_index] = _pair_batch_logmeans(
+                exact_logs[maturity_index],
+                np.array((1.0,)),
+                config.bootstrap_batch_pairs,
+            )[:, 0, :]
+
+        all_batches = np.concatenate((limit_batches, exact_batches), axis=1)
+        point_logs = _logmeanexp(all_batches, axis=-1)
+        boot_logs = _bootstrap_logmeans(
+            all_batches,
+            config.bootstrap_replications,
+            _seed(400, dt_index),
+        )
+        with np.errstate(over="ignore"):
+            boot_defects = np.expm1(boot_logs)
+        if not np.isfinite(boot_defects).all():
+            raise FloatingPointError(
+                "R2 bootstrap defect overflowed; use the returned log-domain kernel diagnostics"
+            )
+
+        for maturity_index, maturity in enumerate(R2_MATURITIES):
+            for kappa_index, kappa2_hat in enumerate(R2_KAPPA_GRID):
+                log_mean = float(point_logs[maturity_index, kappa_index])
+                ci_low, ci_high = _percentile_interval(boot_defects[:, maturity_index, kappa_index])
+                sample = limit_logs[maturity_index, kappa_index]
+                q_limit_records.append(
+                    {
+                        "measure": "Q_LIMIT",
+                        "dt": dt,
+                        "n_steps": _validate_grid_step(maturity, dt),
+                        "maturity": maturity,
+                        "n_paths": config.r2_paths,
+                        "kappa2_hat": float(kappa2_hat),
+                        "log_mean_discounted_spot": log_mean,
+                        "empirical_fixed_budget_defect": float(np.expm1(log_mean)),
+                        "bootstrap_ci_95": [ci_low, ci_high],
+                        "bootstrap_ci_contains_zero": ci_low <= 0.0 <= ci_high,
+                        "maximum_log_discounted_spot": float(np.max(sample)),
+                        "top_0.1pct_share": _tail_share(sample, 1.0),
+                        "floor_hits": int(limit_floor[maturity_index, kappa_index]),
+                        "path_count_sensitivity": _cumulative_diagnostics(sample),
+                    }
+                )
+
+            exact_metric_index = R2_KAPPA_GRID.size
+            exact_log_mean = float(point_logs[maturity_index, exact_metric_index])
+            exact_low, exact_high = _percentile_interval(
+                boot_defects[:, maturity_index, exact_metric_index]
+            )
+            exact_sample = exact_logs[maturity_index, 0]
+            q_exact_records.append(
+                {
+                    "measure": "Q_EXACT",
+                    "dt": dt,
+                    "n_steps": _validate_grid_step(maturity, dt),
+                    "maturity": maturity,
+                    "n_paths": config.r2_paths,
+                    "log_mean_discounted_spot": exact_log_mean,
+                    "empirical_fixed_budget_defect": float(np.expm1(exact_log_mean)),
+                    "bootstrap_ci_95": [exact_low, exact_high],
+                    "bootstrap_ci_contains_zero": exact_low <= 0.0 <= exact_high,
+                    "maximum_log_discounted_spot": float(np.max(exact_sample)),
+                    "top_0.1pct_share": _tail_share(exact_sample, 1.0),
+                    "floor_hits": int(exact_floor[maturity_index, 0]),
+                    "path_count_sensitivity": _cumulative_diagnostics(exact_sample),
+                }
+            )
+
+        # Release the roughly 100 MB full-profile terminal cube before the next dt.
+        del (
+            limit_logs,
+            exact_logs,
+            limit_batches,
+            exact_batches,
+            all_batches,
+            point_logs,
+            boot_logs,
+            boot_defects,
+        )
+
+    finest_dt = min(R2_DTS)
+    finest_two_dts = sorted(R2_DTS)[:2]
+    finest_limit = [row for row in q_limit_records if row["dt"] == finest_dt]
+    finest_exact = [row for row in q_exact_records if row["dt"] == finest_dt]
+    kappa_zero_negative = all(
+        row["bootstrap_ci_95"][1] < 0.0 for row in finest_limit if row["kappa2_hat"] == 0.0
+    )
+    high_kappa_zero_compatible = all(
+        row["bootstrap_ci_contains_zero"] for row in finest_limit if row["kappa2_hat"] == 4.25
+    )
+    exact_controls_zero_compatible = all(
+        bool(row["bootstrap_ci_contains_zero"]) for row in q_exact_records
+    )
+    finest_exact_zero_compatible = all(
+        bool(row["bootstrap_ci_contains_zero"]) for row in finest_exact
+    )
+    finest_two_kappa_zero = [
+        row for row in q_limit_records if row["dt"] in finest_two_dts and row["kappa2_hat"] == 0.0
+    ]
+    finest_two_kappa_zero_negative = all(
+        row["bootstrap_ci_95"][1] < 0.0 for row in finest_two_kappa_zero
+    )
+    kappa_zero_plateau_ci_overlap = all(
+        max(
+            row["bootstrap_ci_95"][0]
+            for row in finest_two_kappa_zero
+            if row["maturity"] == maturity
+        )
+        <= min(
+            row["bootstrap_ci_95"][1]
+            for row in finest_two_kappa_zero
+            if row["maturity"] == maturity
+        )
+        for maturity in R2_MATURITIES
+    )
+    finest_two_high_kappa_zero_compatible = all(
+        row["bootstrap_ci_contains_zero"]
+        for row in q_limit_records
+        if row["dt"] in finest_two_dts and row["kappa2_hat"] == 4.25
+    )
+    no_floor_hits = all(row["floor_hits"] == 0 for row in (*q_limit_records, *q_exact_records))
+    descriptive_acceptance = (
+        exact_controls_zero_compatible
+        and finest_two_kappa_zero_negative
+        and kappa_zero_plateau_ci_overlap
+        and finest_two_high_kappa_zero_compatible
+        and no_floor_hits
+    )
+
+    return {
+        "name": "E4a fixed-budget discounted-spot diagnostic",
+        "profile": config.profile.value,
+        "config": {
+            "dt_grid": list(R2_DTS),
+            "maturities": list(R2_MATURITIES),
+            "kappa2_hat_grid": R2_KAPPA_GRID.tolist(),
+            "n_paths_per_cell": config.r2_paths,
+            "bootstrap_replications": config.bootstrap_replications,
+            "bootstrap_batch_pairs": config.bootstrap_batch_pairs,
+            "fixed_limit_drift": {
+                "d0": base.d0,
+                "d1_hat": base.d1_hat,
+                "vartheta": base.vartheta,
+            },
+            "common_random_numbers": "shared across kappa2_hat and Q_EXACT within dt",
+            "q_exact_antithetic_note": (
+                "Base normals are paired, but state-dependent Q_EXACT transforms mean the "
+                "paired innovations need not share absolute value after the first step."
+            ),
+        },
+        "seed_metadata": {
+            "base_seed": BASE_SEED,
+            "generator": "numpy.random.Generator(PCG64(derived_seed))",
+            "derivation": (
+                "derived_seed = SeedSequence([BASE_SEED, *parts]).generate_state("
+                "1, dtype=uint64)[0]"
+            ),
+            "stage_rules": {
+                "simulation": [
+                    "BASE_SEED",
+                    200,
+                    "round(1 / dt)",
+                    "path_start",
+                ],
+                "bootstrap": ["BASE_SEED", 400, "dt_index"],
+            },
+            "per_dt": seed_records,
+            "dependence": (
+                "Within a dt and path chunk, one base-normal stream is reused by every "
+                "Q_LIMIT kappa2_hat and the Q_EXACT control. Distinct dt/chunk keys are "
+                "independent. Bootstrap streams are independent of simulation and each other, "
+                "while resampling all maturities/measures/kappa values jointly within dt."
+            ),
+        },
+        "q_limit": q_limit_records,
+        "q_exact_controls": q_exact_records,
+        "checks": {
+            "all_q_exact_intervals_contain_zero": exact_controls_zero_compatible,
+            "finest_dt_q_exact_intervals_contain_zero": finest_exact_zero_compatible,
+            "finest_dt_kappa0_empirical_interval_strictly_negative": kappa_zero_negative,
+            "finest_dt_kappa4.25_empirical_interval_contains_zero": high_kappa_zero_compatible,
+            "finest_two_dt_kappa0_intervals_strictly_negative": (finest_two_kappa_zero_negative),
+            "finest_two_dt_kappa0_plateau_intervals_overlap": kappa_zero_plateau_ci_overlap,
+            "finest_two_dt_kappa4.25_intervals_contain_zero": (
+                finest_two_high_kappa_zero_compatible
+            ),
+            "no_sigma_floor_interventions": no_floor_hits,
+            "brief_descriptive_pattern_observed": descriptive_acceptance,
+            "fixed_budget_diagnostic_acceptance_pass": descriptive_acceptance,
+        },
+        "interpretation": {
+            "estimand": "fixed-budget empirical discounted-spot mean minus one",
+            "finite_step_identity": (
+                "Every Q_LIMIT and admissible Q_EXACT price step has conditional discounted "
+                "expectation one."
+            ),
+            "bootstrap_scope": (
+                "The ordinary pair-batch bootstrap quantifies variability conditional on the "
+                "observed paths; it assigns no mass to unseen rare paths."
+            ),
+            "strict_local_claim": (
+                "A negative empirical plateau is evidence of rare-tail/non-uniform-integrability "
+                "stress at the chosen path budget, not proof of strict-local mass loss."
+            ),
+        },
+        "runtime_seconds": time.perf_counter() - started,
+    }
+
+
+def _slope_weights(dts: tuple[float, ...]) -> FloatArray:
+    x_values = np.log(1.0 / np.asarray(dts, dtype=np.float64))
+    centered = x_values - np.mean(x_values)
+    return centered / float(np.dot(centered, centered))
+
+
+def _pava_non_decreasing(values: FloatArray) -> FloatArray:
+    """Unweighted pool-adjacent-violators projection onto non-decreasing values."""
+
+    levels: list[float] = []
+    weights: list[int] = []
+    for item in values:
+        levels.append(float(item))
+        weights.append(1)
+        while len(levels) >= 2 and levels[-2] > levels[-1]:
+            combined_weight = weights[-2] + weights[-1]
+            combined_level = (weights[-2] * levels[-2] + weights[-1] * levels[-1]) / combined_weight
+            levels[-2:] = [combined_level]
+            weights[-2:] = [combined_weight]
+    result = np.empty(values.size, dtype=np.float64)
+    start = 0
+    for level, weight in zip(levels, weights, strict=True):
+        result[start : start + weight] = level
+        start += weight
+    return result
+
+
+def _crossing(powers: FloatArray, monotone_slopes: FloatArray) -> tuple[str, float | None]:
+    if monotone_slopes[0] > 0.0:
+        return "left_censored", None
+    if monotone_slopes[-1] <= 0.0:
+        return "right_censored", None
+    upper_index = int(np.flatnonzero(monotone_slopes > 0.0)[0])
+    lower_index = upper_index - 1
+    lower_slope = float(monotone_slopes[lower_index])
+    upper_slope = float(monotone_slopes[upper_index])
+    if upper_slope == lower_slope:
+        return "finite", float(powers[lower_index])
+    fraction = -lower_slope / (upper_slope - lower_slope)
+    root = powers[lower_index] + fraction * (powers[upper_index] - powers[lower_index])
+    return "finite", float(root)
+
+
+def _bootstrap_crossing_interval(
+    powers: FloatArray,
+    bootstrap_slopes: FloatArray,
+) -> dict[str, Any]:
+    encoded = np.empty(bootstrap_slopes.shape[0], dtype=np.float64)
+    left_count = 0
+    right_count = 0
+    for replication, row in enumerate(bootstrap_slopes):
+        kind, value = _crossing(powers, _pava_non_decreasing(row))
+        if kind == "left_censored":
+            encoded[replication] = -np.inf
+            left_count += 1
+        elif kind == "right_censored":
+            encoded[replication] = np.inf
+            right_count += 1
+        else:
+            if value is None:  # pragma: no cover - guarded by the branch above
+                raise RuntimeError("finite crossing is missing its value")
+            encoded[replication] = value
+    low, high = np.quantile(encoded, (0.025, 0.975), method="nearest")
+    return {
+        "low": None if np.isneginf(low) else float(low),
+        "high": None if np.isposinf(high) else float(high),
+        "low_censor": f"<{powers[0]:.1f}" if np.isneginf(low) else None,
+        "high_censor": f">{powers[-1]:.1f}" if np.isposinf(high) else None,
+        "left_censored_fraction": left_count / bootstrap_slopes.shape[0],
+        "right_censored_fraction": right_count / bootstrap_slopes.shape[0],
+    }
+
+
+def _grid_bracket(powers: FloatArray, classifications: list[str]) -> dict[str, Any]:
+    growth = [index for index, value in enumerate(classifications) if value == "growth"]
+    if not growth:
+        nonpositive = [
+            index for index, value in enumerate(classifications) if value == "nonpositive"
+        ]
+        if not nonpositive:
+            return {
+                "low": None,
+                "high": None,
+                "status": "fully_unresolved_no_confirmed_grid_endpoint",
+            }
+        lower_index = nonpositive[-1]
+        if lower_index != powers.size - 1:
+            return {
+                "low": float(powers[lower_index]),
+                "high": None,
+                "status": "unresolved_cells_above_last_confirmed_nonpositive",
+            }
+        return {
+            "low": float(powers[-1]),
+            "high": None,
+            "high_censor": f">{powers[-1]:.1f}",
+            "status": "confirmed_nonpositive_through_grid_maximum",
+        }
+    first_growth = growth[0]
+    nonpositive = [
+        index for index in range(first_growth) if classifications[index] == "nonpositive"
+    ]
+    if not nonpositive:
+        if first_growth > 0:
+            return {
+                "low": None,
+                "high": float(powers[first_growth]),
+                "status": "unresolved_cells_below_first_confirmed_growth",
+            }
+        return {
+            "low": None,
+            "high": float(powers[first_growth]),
+            "low_censor": f"<{powers[0]:.1f}",
+            "status": "confirmed_growth_from_grid_minimum",
+        }
+    lower_index = nonpositive[-1]
+    unresolved_between = classifications[lower_index + 1 : first_growth]
+    return {
+        "low": float(powers[lower_index]),
+        "high": float(powers[first_growth]),
+        "status": (
+            "resolved_adjacent_grid_bracket"
+            if not unresolved_between
+            else "contains_unresolved_grid_cells"
+        ),
+    }
+
+
+def _sufficient_curve(params: TgarchParams, powers: FloatArray) -> FloatArray:
+    return params.beta * powers + params.vartheta * np.sqrt(powers * (powers - 1.0))
+
+
+def _sufficient_inverse(params: TgarchParams, kappa2_hat: float) -> dict[str, Any]:
+    lower = float(R3_POWERS[0])
+    upper = float(R3_POWERS[-1])
+
+    def curve(power: float) -> float:
+        return params.beta * power + params.vartheta * math.sqrt(power * (power - 1.0))
+
+    if kappa2_hat < curve(lower):
+        return {"value": None, "censor": f"<{lower:.1f}"}
+    if kappa2_hat > curve(upper):
+        return {"value": None, "censor": f">{upper:.1f}"}
+    for _ in range(80):
+        midpoint = 0.5 * (lower + upper)
+        if curve(midpoint) <= kappa2_hat:
+            lower = midpoint
+        else:
+            upper = midpoint
+    return {"value": 0.5 * (lower + upper), "censor": None}
+
+
+def _classify_slope(
+    ci_low: float,
+    ci_high: float,
+    tail_unresolved: bool,
+    floor_affected: bool,
+) -> tuple[str, str]:
+    if ci_low > 0.0:
+        statistical = "growth"
+    elif ci_high <= 0.0:
+        statistical = "nonpositive"
+    else:
+        statistical = "unresolved"
+    if tail_unresolved and floor_affected:
+        final = "tail_and_floor_unresolved"
+    elif tail_unresolved:
+        final = "tail_unresolved"
+    elif floor_affected:
+        final = "floor_affected"
+    else:
+        final = statistical
+    return statistical, final
+
+
+def _run_r3(params: TgarchParams, config: Round2Config) -> dict[str, Any]:
+    started = time.perf_counter()
+    base = derived_limit_params(params)
+    dt_count = len(R3_DTS)
+    kappa_count = R3_KAPPA_GRID.size
+    power_count = R3_POWERS.size
+    point_log_moments = np.empty((dt_count, kappa_count, power_count), dtype=np.float64)
+    bootstrap_log_moments = np.empty(
+        (dt_count, config.bootstrap_replications, kappa_count, power_count),
+        dtype=np.float64,
+    )
+    final_tail_shares = np.empty((dt_count, kappa_count, power_count), dtype=np.float64)
+    initial_tail_shares = np.empty_like(final_tail_shares)
+    path_counts = np.empty(dt_count, dtype=np.int64)
+    floor_hits = np.zeros((dt_count, kappa_count), dtype=np.int64)
+    escalation_records: list[dict[str, Any]] = []
+    seed_records: list[dict[str, Any]] = []
+    pilot_terminals: list[FloatArray] = []
+
+    # The pilot is completed at every dt before deciding whether to double.  A global
+    # decision keeps path budgets equal across dt and prevents N-dependent rare-tail
+    # discovery from masquerading as a positive refinement slope.
+    for dt_index, dt in enumerate(R3_DTS):
+        terminal, hits = _simulate_r3_tranche(
+            params,
+            dt=dt,
+            n_paths=config.r3_pilot_paths,
+            path_chunk=config.path_chunk,
+            kappa_grid=R3_KAPPA_GRID,
+            tranche=0,
+        )
+        pilot_terminals.append(terminal)
+        floor_hits[dt_index] = hits
+        for kappa_index in range(kappa_count):
+            for power_index, power in enumerate(R3_POWERS):
+                initial_tail_shares[dt_index, kappa_index, power_index] = _tail_share(
+                    terminal[kappa_index], float(power)
+                )
+
+    global_needs_escalation = bool(np.any(initial_tail_shares > TAIL_SHARE_LIMIT))
+    global_double = global_needs_escalation and config.permit_tail_doubling
+
+    for dt_index, dt in enumerate(R3_DTS):
+        terminal = pilot_terminals[dt_index]
+        initial_max = float(np.max(initial_tail_shares[dt_index]))
+        status = "not_needed"
+        if global_double:
+            second, second_hits = _simulate_r3_tranche(
+                params,
+                dt=dt,
+                n_paths=config.r3_pilot_paths,
+                path_chunk=config.path_chunk,
+                kappa_grid=R3_KAPPA_GRID,
+                tranche=1,
+            )
+            terminal = np.concatenate((terminal, second), axis=1)
+            floor_hits[dt_index] += second_hits
+            del second
+            status = "all_dt_pilots_doubled_once"
+        elif global_needs_escalation:
+            status = "global_doubling_skipped_in_smoke_profile"
+
+        path_counts[dt_index] = terminal.shape[1]
+        batch_logs = _pair_batch_logmeans(
+            terminal,
+            R3_POWERS,
+            config.bootstrap_batch_pairs,
+        )
+        point_log_moments[dt_index] = _logmeanexp(batch_logs, axis=-1)
+        bootstrap_log_moments[dt_index] = _bootstrap_logmeans(
+            batch_logs,
+            config.bootstrap_replications,
+            _seed(500, dt_index),
+        )
+        for kappa_index in range(kappa_count):
+            for power_index, power in enumerate(R3_POWERS):
+                final_tail_shares[dt_index, kappa_index, power_index] = _tail_share(
+                    terminal[kappa_index], float(power)
+                )
+        final_max = float(np.max(final_tail_shares[dt_index]))
+        unresolved = final_max > TAIL_SHARE_LIMIT
+        tranches_used = 2 if global_double else 1
+        simulation_chunk_seeds = [
+            record
+            for tranche in range(tranches_used)
+            for record in _r3_chunk_seed_records(
+                dt,
+                config.r3_pilot_paths,
+                config.path_chunk,
+                tranche,
+            )
+        ]
+        seed_records.append(
+            {
+                "dt_index": dt_index,
+                "dt": dt,
+                "reciprocal_dt_code": int(round(1.0 / dt)),
+                "simulation_chunks": simulation_chunk_seeds,
+                "bootstrap_derived_seed": _seed(500, dt_index),
+            }
+        )
+        escalation_records.append(
+            {
+                "dt": dt,
+                "pilot_paths": config.r3_pilot_paths,
+                "final_paths": int(path_counts[dt_index]),
+                "initial_max_top_0.1pct_share": initial_max,
+                "final_max_top_0.1pct_share": final_max,
+                "status": status,
+                "global_escalation_triggered": global_needs_escalation,
+                "equal_path_budget_across_dt": True,
+                "unresolved_after_escalation": unresolved,
+                "importance_sampling": (
+                    "timeboxed and not implemented; unresolved cells are explicitly flagged"
+                    if unresolved
+                    else "not required"
+                ),
+            }
+        )
+        # Concatenated terminal paths can be released immediately; pilots remain a modest
+        # fixed-size cache until the global decision and all four analyses are complete.
+        del terminal, batch_logs
+    del pilot_terminals
+
+    weights = _slope_weights(R3_DTS)
+    slopes = np.tensordot(weights, point_log_moments, axes=(0, 0))
+    bootstrap_slopes = np.tensordot(weights, bootstrap_log_moments, axes=(0, 0))
+    ci_low = np.percentile(bootstrap_slopes, 2.5, axis=0)
+    ci_high = np.percentile(bootstrap_slopes, 97.5, axis=0)
+    numerical_outputs_finite = all(
+        np.isfinite(values).all()
+        for values in (
+            point_log_moments,
+            bootstrap_log_moments,
+            slopes,
+            bootstrap_slopes,
+            ci_low,
+            ci_high,
+            final_tail_shares,
+        )
+    )
+    if not numerical_outputs_finite:
+        raise FloatingPointError(
+            "R3 produced non-finite moments, slopes, intervals, or tail shares"
+        )
+    tail_unresolved = np.any(final_tail_shares > TAIL_SHARE_LIMIT, axis=0)
+    floor_affected = np.any(floor_hits > 0, axis=0)
+    no_floor_hits = not bool(np.any(floor_hits))
+    equal_path_budget = bool(np.all(path_counts == path_counts[0]))
+    sufficient = _sufficient_curve(params, R3_POWERS)
+
+    statistical_classes: list[list[str]] = []
+    final_classes: list[list[str]] = []
+    cell_records: list[dict[str, Any]] = []
+    for kappa_index, kappa2_hat in enumerate(R3_KAPPA_GRID):
+        statistical_row: list[str] = []
+        final_row: list[str] = []
+        for power_index, power in enumerate(R3_POWERS):
+            statistical, final = _classify_slope(
+                float(ci_low[kappa_index, power_index]),
+                float(ci_high[kappa_index, power_index]),
+                bool(tail_unresolved[kappa_index, power_index]),
+                bool(floor_affected[kappa_index]),
+            )
+            statistical_row.append(statistical)
+            final_row.append(final)
+            cell_records.append(
+                {
+                    "kappa2_hat": float(kappa2_hat),
+                    "power": float(power),
+                    "slope": float(slopes[kappa_index, power_index]),
+                    "bootstrap_ci_95": [
+                        float(ci_low[kappa_index, power_index]),
+                        float(ci_high[kappa_index, power_index]),
+                    ],
+                    "statistical_classification": statistical,
+                    "classification": final,
+                    "tail_unresolved": bool(tail_unresolved[kappa_index, power_index]),
+                    "floor_affected": bool(floor_affected[kappa_index]),
+                    "floor_hits_by_dt": floor_hits[:, kappa_index].tolist(),
+                    "floor_hits_total": int(np.sum(floor_hits[:, kappa_index])),
+                    "inside_strict_sufficient_region": bool(kappa2_hat > sufficient[power_index]),
+                    "sufficient_kappa2_hat": float(sufficient[power_index]),
+                    "log_moments_by_dt": point_log_moments[:, kappa_index, power_index].tolist(),
+                    "top_0.1pct_share_by_dt": final_tail_shares[
+                        :, kappa_index, power_index
+                    ].tolist(),
+                    "paths_by_dt": path_counts.tolist(),
+                }
+            )
+        statistical_classes.append(statistical_row)
+        final_classes.append(final_row)
+
+    crossing_records: list[dict[str, Any]] = []
+    raw_nonmonotone_count = 0
+    for kappa_index, kappa2_hat in enumerate(R3_KAPPA_GRID):
+        raw = slopes[kappa_index]
+        if np.any(np.diff(raw) < 0.0):
+            raw_nonmonotone_count += 1
+        monotone = _pava_non_decreasing(raw)
+        kind, value = _crossing(R3_POWERS, monotone)
+        point_crossing = {
+            "value": value,
+            "censor": (
+                f"<{R3_POWERS[0]:.1f}"
+                if kind == "left_censored"
+                else f">{R3_POWERS[-1]:.1f}"
+                if kind == "right_censored"
+                else None
+            ),
+        }
+        crossing_records.append(
+            {
+                "kappa2_hat": float(kappa2_hat),
+                "point_crossing_after_pava": point_crossing,
+                "bootstrap_interval_95": _bootstrap_crossing_interval(
+                    R3_POWERS,
+                    bootstrap_slopes[:, kappa_index, :],
+                ),
+                "confirmed_grid_bracket": _grid_bracket(
+                    R3_POWERS,
+                    final_classes[kappa_index],
+                ),
+                "sufficient_curve_crossing": _sufficient_inverse(params, float(kappa2_hat)),
+                "raw_slopes_nonmonotone": bool(np.any(np.diff(raw) < 0.0)),
+                "raw_slopes": raw.tolist(),
+                "pava_slopes": monotone.tolist(),
+                "tail_unresolved_on_row": any(
+                    "tail" in item for item in final_classes[kappa_index]
+                ),
+                "floor_affected_on_row": bool(floor_affected[kappa_index]),
+            }
+        )
+
+    sufficient_contradictions = [
+        row
+        for row in cell_records
+        if row["inside_strict_sufficient_region"]
+        and row["statistical_classification"] == "growth"
+        and not row["tail_unresolved"]
+        and not row["floor_affected"]
+    ]
+    all_tail_resolved = not bool(np.any(tail_unresolved))
+    acceptance_pass = (
+        numerical_outputs_finite
+        and equal_path_budget
+        and all_tail_resolved
+        and no_floor_hits
+        and not sufficient_contradictions
+    )
+
+    return {
+        "name": "E4b corrected empirical spot-moment critical curve",
+        "profile": config.profile.value,
+        "config": {
+            "maturity": R3_MATURITY,
+            "maturity_assumption": (
+                "The round-2 brief does not restate maturity; 0.25 years is inherited from E4."
+            ),
+            "dt_grid": list(R3_DTS),
+            "weekly_dt_excluded_from_slope": True,
+            "kappa2_hat_grid": R3_KAPPA_GRID.tolist(),
+            "powers": R3_POWERS.tolist(),
+            "pilot_paths_per_dt": config.r3_pilot_paths,
+            "bootstrap_replications": config.bootstrap_replications,
+            "bootstrap_batch_pairs": config.bootstrap_batch_pairs,
+            "fixed_limit_drift": {
+                "d0": base.d0,
+                "d1_hat": base.d1_hat,
+                "vartheta": base.vartheta,
+            },
+            "slope_regressor": "log(1 / dt)",
+            "tail_escalation_policy": (
+                "If any pilot cell breaches the tail-share threshold, every dt is doubled so "
+                "the refinement slope always compares equal path budgets."
+            ),
+            "sufficient_curve_interpretation": (
+                "The displayed strict inequality is a sufficient supersolution condition, "
+                "not a necessary or sharp empirical boundary."
+            ),
+            "common_random_numbers": (
+                "shared across kappa2_hat; every power reuses the same terminal paths; "
+                "different dt values use independent streams"
+            ),
+        },
+        "seed_metadata": {
+            "base_seed": BASE_SEED,
+            "generator": "numpy.random.Generator(PCG64(derived_seed))",
+            "derivation": (
+                "derived_seed = SeedSequence([BASE_SEED, *parts]).generate_state("
+                "1, dtype=uint64)[0]"
+            ),
+            "stage_rules": {
+                "simulation": [
+                    "BASE_SEED",
+                    300,
+                    "round(1 / dt)",
+                    "tranche",
+                    "path_start",
+                ],
+                "bootstrap": ["BASE_SEED", 500, "dt_index"],
+            },
+            "per_dt": seed_records,
+            "dependence": (
+                "Within each dt/chunk/tranche, one base-normal stream is reused by all "
+                "kappa2_hat values, and all powers reuse those terminal paths. Distinct "
+                "dt/chunk/tranche keys are independent. Bootstrap streams are independent of "
+                "simulation and each other, while resampling every kappa/power jointly within dt."
+            ),
+        },
+        "cells": cell_records,
+        "crossings": crossing_records,
+        "heatmap": {
+            "kappa2_hat_axis": R3_KAPPA_GRID.tolist(),
+            "power_axis": R3_POWERS.tolist(),
+            "slope_matrix": slopes.tolist(),
+            "ci_low_matrix": ci_low.tolist(),
+            "ci_high_matrix": ci_high.tolist(),
+            "statistical_classification_matrix": statistical_classes,
+            "classification_matrix": final_classes,
+            "sufficient_curve_kappa2_hat": sufficient.tolist(),
+        },
+        "tail_diagnostics": {
+            "threshold": TAIL_SHARE_LIMIT,
+            "tail_fraction": TAIL_FRACTION,
+            "escalation": escalation_records,
+            "unresolved_cell_count": int(np.count_nonzero(tail_unresolved)),
+            "all_cells_resolved": all_tail_resolved,
+        },
+        "floor_diagnostics": {
+            "floor": SIGMA_FLOOR,
+            "floor_hits_matrix_dt_by_kappa": floor_hits.tolist(),
+            "floor_hits_total": int(np.sum(floor_hits)),
+            "no_floor_hits": no_floor_hits,
+            "interpretation": (
+                "Any hit means clipping altered the requested Euler dynamics; affected cells "
+                "are not accepted as critical-curve evidence."
+            ),
+        },
+        "checks": {
+            "corrected_four_dt_slope_used": len(R3_DTS) == 4 and 1.0 / 52.0 not in R3_DTS,
+            "configured_full_profile_pilot_at_least_2^17": (
+                _make_config(Round2Profile.FULL).r3_pilot_paths >= 2**17
+            ),
+            "numerical_outputs_finite": numerical_outputs_finite,
+            "equal_path_budget_across_dt": equal_path_budget,
+            "raw_nonmonotone_kappa_rows": raw_nonmonotone_count,
+            "resolved_growth_inside_strict_sufficient_region": len(sufficient_contradictions),
+            "no_resolved_sufficient_region_contradiction": not sufficient_contradictions,
+            "all_tail_share_flags_resolved": all_tail_resolved,
+            "no_sigma_floor_interventions": no_floor_hits,
+            "acceptance_pass": acceptance_pass,
+        },
+        "runtime_seconds": time.perf_counter() - started,
+    }
+
+
+def _self_checks(config: Round2Config) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+
+    x_values = np.log(1.0 / np.asarray(R3_DTS))
+    synthetic_slope = float(np.dot(_slope_weights(R3_DTS), 3.0 + 0.25 * x_values))
+    checks.append(
+        {
+            "name": "synthetic_log_moment_slope",
+            "passed": math.isclose(synthetic_slope, 0.25, rel_tol=0.0, abs_tol=1.0e-12),
+            "value": synthetic_slope,
+        }
+    )
+
+    pava_value = _pava_non_decreasing(np.array((0.2, -0.1, 0.3)))
+    checks.append(
+        {
+            "name": "pava_projection",
+            "passed": bool(np.allclose(pava_value, (0.05, 0.05, 0.3))),
+            "value": pava_value.tolist(),
+        }
+    )
+
+    kind, crossing = _crossing(
+        np.array((1.1, 1.9)),
+        np.array((-0.2, 0.2)),
+    )
+    checks.append(
+        {
+            "name": "linear_crossing_interpolation",
+            "passed": kind == "finite" and math.isclose(float(crossing), 1.5),
+            "value": crossing,
+        }
+    )
+
+    beta = 1.0
+    vartheta = math.sqrt(3.25)
+    sufficient_at_1_5 = beta * 1.5 + vartheta * math.sqrt(1.5 * 0.5)
+    checks.append(
+        {
+            "name": "published_sufficient_curve_formula",
+            "passed": math.isclose(
+                sufficient_at_1_5,
+                3.0612494995995996,
+                rel_tol=0.0,
+                abs_tol=1.0e-12,
+            ),
+            "value": sufficient_at_1_5,
+        }
+    )
+
+    sample = np.zeros((1, 2 * config.bootstrap_batch_pairs * 8), dtype=np.float64)
+    batch_logs = _pair_batch_logmeans(sample, np.array((1.0,)), config.bootstrap_batch_pairs)
+    checks.append(
+        {
+            "name": "pair_batch_logmean_identity",
+            "passed": bool(np.all(batch_logs == 0.0)),
+            "value": float(np.max(np.abs(batch_logs))),
+        }
+    )
+
+    extreme_batches = np.full((1, 1, 8), -1000.0)
+    extreme_batches[0, 0, 0] = 0.0
+    extreme_bootstrap = _bootstrap_logmeans(extreme_batches, 64, _seed(900))
+    checks.append(
+        {
+            "name": "bootstrap_resample_specific_log_stabilization",
+            "passed": bool(np.isfinite(extreme_bootstrap).all()),
+            "minimum": float(np.min(extreme_bootstrap)),
+            "maximum": float(np.max(extreme_bootstrap)),
+        }
+    )
+
+    fully_unresolved = _grid_bracket(
+        np.array((1.1, 1.2, 1.3)),
+        ["tail_unresolved", "tail_unresolved", "tail_unresolved"],
+    )
+    checks.append(
+        {
+            "name": "fully_unresolved_grid_has_no_false_endpoint",
+            "passed": fully_unresolved["low"] is None and fully_unresolved["high"] is None,
+            "value": fully_unresolved,
+        }
+    )
+
+    dt = 1.0 / 252.0
+    sqrt_dt = math.sqrt(dt)
+    sigma = 0.7
+    gamma = 0.2
+    eta = -0.1
+    variance = 1.0 / (1.0 - 2.0 * sqrt_dt * eta)
+    mean = -sqrt_dt * gamma - 0.5 * sigma * sqrt_dt * (variance - 1.0)
+    exact_log_conditional_mean = (
+        (gamma * sigma - 0.5 * sigma * sigma) * dt
+        + sigma * sqrt_dt * mean
+        + 0.5 * sigma * sigma * dt * variance
+    )
+    limit_log_conditional_mean = -0.5 * sigma * sigma * dt + 0.5 * sigma * sigma * dt
+    checks.append(
+        {
+            "name": "one_step_discounted_martingale_identities",
+            "passed": math.isclose(exact_log_conditional_mean, 0.0, abs_tol=1.0e-15)
+            and limit_log_conditional_mean == 0.0,
+            "q_exact_log_conditional_mean": exact_log_conditional_mean,
+            "q_limit_log_conditional_mean": limit_log_conditional_mean,
+        }
+    )
+
+    full_config = _make_config(Round2Profile.FULL)
+    full_minimums = full_config.r2_paths >= 2**20 and full_config.r3_pilot_paths >= 2**17
+    checks.append(
+        {
+            "name": "full_profile_path_minimums",
+            "passed": full_minimums,
+            "r2_paths": full_config.r2_paths,
+            "r3_pilot_paths": full_config.r3_pilot_paths,
+        }
+    )
+
+    all_passed = all(bool(item["passed"]) for item in checks)
+    if not all_passed:
+        failed = [str(item["name"]) for item in checks if not item["passed"]]
+        raise RuntimeError(f"round2_e4 self-checks failed: {', '.join(failed)}")
+    return checks
+
+
+def _validated_run_inputs(
+    params: TgarchParams,
+    profile: Round2Profile | str,
+) -> tuple[Round2Config, list[dict[str, Any]]]:
+    if not isinstance(params, TgarchParams):
+        raise ValueError("params must be a TgarchParams instance")
+    config = _make_config(_as_profile(profile))
+    if config.r2_paths % (2 * config.bootstrap_batch_pairs):
+        raise RuntimeError("R2 path count is incompatible with pair-batch bootstrap")
+    if config.r3_pilot_paths % (2 * config.bootstrap_batch_pairs):
+        raise RuntimeError("R3 path count is incompatible with pair-batch bootstrap")
+    return config, _self_checks(config)
+
+
+def run_round2_r2(
+    params: TgarchParams,
+    profile: Round2Profile | str,
+) -> dict[str, Any]:
+    """Run only R2/E4a after applying the shared validation gate."""
+    config, checks = _validated_run_inputs(params, profile)
+    result = _run_r2(params, config)
+    result["self_checks"] = checks
+    return result
+
+
+def run_round2_r3(
+    params: TgarchParams,
+    profile: Round2Profile | str,
+) -> dict[str, Any]:
+    """Run only the headline R3/E4b after applying the shared validation gate."""
+    config, checks = _validated_run_inputs(params, profile)
+    result = _run_r3(params, config)
+    result["self_checks"] = checks
+    return result
+
+
+def run_round2_e4(
+    params: TgarchParams,
+    profile: Round2Profile | str,
+) -> dict[str, dict[str, Any]]:
+    """Run the corrected round-2 E4a/E4b study in the brief's priority order.
+
+    Parameters
+    ----------
+    params
+        TGARCH parameter set.  The brief calls for the crypto set.
+    profile
+        ``"smoke"``, ``"reference"``, or ``"full"``.  The full profile uses at
+        least ``2**20`` R2 paths and an R3 pilot of at least ``2**17`` paths.
+
+    Returns
+    -------
+    dict
+        Exactly two top-level entries, ``R2`` and ``R3``.  Every value is JSON-ready.
+    """
+
+    # R3 is the round-two headline and is intentionally completed before slow R2.
+    return {
+        "R3": run_round2_r3(params, profile),
+        "R2": run_round2_r2(params, profile),
+    }
+
+
+__all__ = ["Round2Profile", "run_round2_e4", "run_round2_r2", "run_round2_r3"]

--- a/volatility_book/ch_discrete_vol/round2_e6.py
+++ b/volatility_book/ch_discrete_vol/round2_e6.py
@@ -1,0 +1,464 @@
+"""Round-two E6a diagnostics for the discrete TGARCH filtering study.
+
+The point estimates deliberately reuse the round-one E6 seed, path construction,
+wrong-start perturbation, burn convention, and forgetting-rate estimator.  Reference
+and full profiles add one observation scale and therefore use a four-times finer
+two-shock source path.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import Any
+
+import numpy as np
+from scipy.stats import t as student_t
+
+from volatility_book.ch_discrete_vol.experiments import (
+    BASE_SEED,
+    StudyProfile,
+    make_study_config,
+)
+from volatility_book.ch_discrete_vol.sim import (
+    M1,
+    S1,
+    Measure,
+    TgarchParams,
+    filter_discrete_returns,
+    simulate_discrete_path,
+    simulate_two_shock_limit_path,
+)
+
+_DAILY_DT = 1.0 / 252.0
+_ORIGINAL_OBSERVATION_DTS = (1.0 / 52.0, _DAILY_DT, 1.0 / 1008.0, 1.0 / 4032.0)
+_FINER_OBSERVATION_DT = 1.0 / 16128.0
+_ORIGINAL_SOURCE_DT = 1.0 / 16128.0
+_FINER_SOURCE_DT = 1.0 / 64512.0
+_RELATIVE_TOLERANCE = 0.15
+
+
+def _as_profile(profile: StudyProfile | str) -> StudyProfile:
+    if isinstance(profile, StudyProfile):
+        return profile
+    try:
+        return StudyProfile(profile)
+    except (TypeError, ValueError) as exc:
+        choices = ", ".join(item.value for item in StudyProfile)
+        raise ValueError(f"profile must be one of: {choices}") from exc
+
+
+def _observation_indices(times: np.ndarray, observation_dt: float) -> np.ndarray:
+    target = (
+        np.arange(
+            int(math.floor(times[-1] / observation_dt + 1.0e-12)) + 1,
+            dtype=np.float64,
+        )
+        * observation_dt
+    )
+    if target[-1] < times[-1] - 1.0e-12:
+        target = np.append(target, times[-1])
+    indices = np.rint(target / (times[1] - times[0])).astype(np.int64)
+    indices = np.clip(indices, 0, times.size - 1)
+    return np.unique(indices)
+
+
+def _forgetting_rate(times: np.ndarray, difference: np.ndarray) -> float:
+    """Match the round-one transient-decay estimator exactly."""
+
+    mask = (times > 0.0) & (times <= min(5.0, times[-1])) & (difference > 1.0e-8)
+    if np.count_nonzero(mask) < 5:
+        return float("nan")
+    slope, _ = np.polyfit(times[mask], np.log(difference[mask]), 1)
+    return float(-slope)
+
+
+def _ols_fit(x: np.ndarray, y: np.ndarray) -> dict[str, Any]:
+    """Fit an intercept and slope and return descriptive 95% OLS intervals."""
+
+    valid = np.isfinite(x) & np.isfinite(y)
+    x_valid = np.asarray(x[valid], dtype=np.float64)
+    y_valid = np.asarray(y[valid], dtype=np.float64)
+    if x_valid.size < 2 or np.ptp(x_valid) <= 0.0:
+        raise ValueError("at least two distinct finite regression points are required")
+
+    design = np.column_stack((np.ones(x_valid.size), x_valid))
+    coefficients, _, _, _ = np.linalg.lstsq(design, y_valid, rcond=None)
+    fitted = design @ coefficients
+    residuals = y_valid - fitted
+    residual_sum_squares = float(residuals @ residuals)
+    centered_sum_squares = float(np.sum(np.square(y_valid - np.mean(y_valid))))
+    r_squared = (
+        1.0 - residual_sum_squares / centered_sum_squares if centered_sum_squares > 0.0 else 1.0
+    )
+
+    degrees_of_freedom = int(x_valid.size - 2)
+    intervals: list[list[float]] | None = None
+    standard_errors: list[float] | None = None
+    if degrees_of_freedom > 0:
+        covariance = residual_sum_squares / degrees_of_freedom * np.linalg.inv(design.T @ design)
+        errors = np.sqrt(np.maximum(np.diag(covariance), 0.0))
+        critical_value = float(student_t.ppf(0.975, degrees_of_freedom))
+        intervals = [
+            [float(value - critical_value * error), float(value + critical_value * error)]
+            for value, error in zip(coefficients, errors)
+        ]
+        standard_errors = [float(error) for error in errors]
+
+    return {
+        "n_points": int(x_valid.size),
+        "degrees_of_freedom": degrees_of_freedom,
+        "intercept": float(coefficients[0]),
+        "slope": float(coefficients[1]),
+        "standard_errors": standard_errors,
+        "ci95": intervals,
+        "r_squared": float(r_squared),
+        "residual_sum_squares": residual_sum_squares,
+    }
+
+
+def _ratio(value: float, target: float) -> float:
+    if not math.isfinite(value) or not math.isfinite(target) or target == 0.0:
+        return float("nan")
+    return value / target
+
+
+def _within_tolerance(ratio: float) -> bool:
+    return bool(math.isfinite(ratio) and abs(ratio - 1.0) <= _RELATIVE_TOLERANCE)
+
+
+def _sample_record(
+    *,
+    name: str,
+    params: TgarchParams,
+    source: Any,
+    observation_dt: float,
+    years: float,
+    seed: int,
+    sigma_bar: float,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    indices = _observation_indices(source.times, observation_dt)
+    observation_times = source.times[indices]
+    log_prices = source.log_prices[indices]
+    true_sigma = source.sigmas[indices]
+    filtered = filter_discrete_returns(
+        log_prices=log_prices,
+        observation_times=observation_times,
+        params=params,
+        sigma0=params.sigma0,
+    )
+    wrong = filter_discrete_returns(
+        log_prices=log_prices,
+        observation_times=observation_times,
+        params=params,
+        sigma0=1.5 * params.sigma0,
+    )
+    burn_time = min(1.0, 0.1 * observation_times[-1])
+    burn_mask = observation_times >= burn_time
+    rmse = float(np.sqrt(np.mean(np.square(filtered[burn_mask] - true_sigma[burn_mask]))))
+    wrong_rmse = float(np.sqrt(np.mean(np.square(wrong[burn_mask] - true_sigma[burn_mask]))))
+    difference = np.abs(wrong - filtered)
+    forgetting_rate = _forgetting_rate(observation_times, difference)
+    effective_dts = np.diff(observation_times)
+
+    coefficient = math.sqrt(params.eps * S1 / M1)
+    c_gain = params.eps * M1 / S1
+    kappa_linear = params.kappa1 + params.kappa2 * params.theta
+    log_decay_intercept = kappa_linear + 0.5 * c_gain * c_gain
+    mean_dt = float(np.mean(effective_dts))
+    predicted_rmse_actual = sigma_bar * coefficient * mean_dt**0.25
+    predicted_rmse_theta = params.theta * coefficient * mean_dt**0.25
+    predicted_forgetting_standing = kappa_linear + c_gain / math.sqrt(mean_dt)
+    predicted_forgetting_log_decay = log_decay_intercept + c_gain / math.sqrt(mean_dt)
+
+    record = {
+        "parameter_set": name,
+        "source_dt_nominal": float(source.dt),
+        "dt_observation_nominal": observation_dt,
+        "dt_observation_mean": mean_dt,
+        "dt_observation_min": float(np.min(effective_dts)),
+        "dt_observation_max": float(np.max(effective_dts)),
+        "years": years,
+        "seed": seed,
+        "burn_time": burn_time,
+        "sigma_bar_actual": sigma_bar,
+        "theta": params.theta,
+        "rmse_correct_start": rmse,
+        "rmse_wrong_start": wrong_rmse,
+        "rmse_predicted_actual_sigma_bar": predicted_rmse_actual,
+        "rmse_predicted_theta": predicted_rmse_theta,
+        "rmse_to_actual_prediction_ratio": _ratio(rmse, predicted_rmse_actual),
+        "rmse_to_theta_prediction_ratio": _ratio(rmse, predicted_rmse_theta),
+        "forgetting_rate": forgetting_rate,
+        "forgetting_predicted_standing_text": predicted_forgetting_standing,
+        "forgetting_predicted_asymptotic_log_decay": predicted_forgetting_log_decay,
+        "forgetting_to_standing_prediction_ratio": _ratio(
+            forgetting_rate, predicted_forgetting_standing
+        ),
+        "forgetting_to_asymptotic_log_decay_prediction_ratio": _ratio(
+            forgetting_rate, predicted_forgetting_log_decay
+        ),
+        "source_floor_hits": int(source.floor_hits),
+    }
+    stride = max(1, observation_times.size // 600)
+    series = {
+        "parameter_set": name,
+        "dt_observation_nominal": observation_dt,
+        "times": observation_times[::stride].tolist(),
+        "wrong_minus_correct_abs": difference[::stride].tolist(),
+    }
+    return record, series
+
+
+def _regression_summary(
+    name: str,
+    params: TgarchParams,
+    records: list[dict[str, Any]],
+) -> dict[str, Any]:
+    fine = sorted(
+        (
+            row
+            for row in records
+            if row["parameter_set"] == name and row["dt_observation_nominal"] <= _DAILY_DT + 1.0e-15
+        ),
+        key=lambda row: row["dt_observation_mean"],
+        reverse=True,
+    )
+    if len(fine) < 2:
+        raise ValueError(f"E6a requires at least two fine-grid records for {name}")
+
+    dts = np.asarray([row["dt_observation_mean"] for row in fine], dtype=np.float64)
+    rmses = np.asarray([row["rmse_correct_start"] for row in fine], dtype=np.float64)
+    rates = np.asarray([row["forgetting_rate"] for row in fine], dtype=np.float64)
+    if np.any(rmses <= 0.0):
+        raise FloatingPointError(f"non-positive RMSE encountered for {name}")
+
+    rmse_fit = _ols_fit(np.log(dts), np.log(rmses))
+    forgetting_fit = _ols_fit(1.0 / np.sqrt(dts), rates)
+    fitted_rmse_level = math.exp(rmse_fit["intercept"])
+    rmse_level_ci95 = None
+    if rmse_fit["ci95"] is not None:
+        rmse_level_ci95 = [
+            math.exp(rmse_fit["ci95"][0][0]),
+            math.exp(rmse_fit["ci95"][0][1]),
+        ]
+
+    sigma_bar = float(fine[0]["sigma_bar_actual"])
+    rmse_level_actual_target = sigma_bar * math.sqrt(params.eps * S1 / M1)
+    rmse_level_theta_target = params.theta * math.sqrt(params.eps * S1 / M1)
+    c_gain = params.eps * M1 / S1
+    kappa_linear = params.kappa1 + params.kappa2 * params.theta
+    log_decay_intercept = kappa_linear + 0.5 * c_gain * c_gain
+
+    exponent_ratio = _ratio(rmse_fit["slope"], 0.25)
+    actual_level_ratio = _ratio(fitted_rmse_level, rmse_level_actual_target)
+    theta_level_ratio = _ratio(fitted_rmse_level, rmse_level_theta_target)
+    slope_ratio = _ratio(forgetting_fit["slope"], c_gain)
+    standing_intercept_ratio = _ratio(forgetting_fit["intercept"], kappa_linear)
+    log_decay_intercept_ratio = _ratio(forgetting_fit["intercept"], log_decay_intercept)
+
+    shared_passes = {
+        "rmse_exponent_within_15pct": _within_tolerance(exponent_ratio),
+        "rmse_actual_level_within_15pct": _within_tolerance(actual_level_ratio),
+        "forgetting_slope_within_15pct": _within_tolerance(slope_ratio),
+    }
+    standing_intercept_pass = _within_tolerance(standing_intercept_ratio)
+    log_decay_intercept_pass = _within_tolerance(log_decay_intercept_ratio)
+    standing_pass = bool(all(shared_passes.values()) and standing_intercept_pass)
+    log_decay_pass = bool(all(shared_passes.values()) and log_decay_intercept_pass)
+
+    return {
+        "parameter_set": name,
+        "fit_grid_nominal": [float(row["dt_observation_nominal"]) for row in fine],
+        "interval_method": (
+            "two-sided 95% Student-t OLS interval across observation scales; descriptive "
+            "because scale points share one common-random-number source path"
+        ),
+        "sigma_bar_actual": sigma_bar,
+        "theta": params.theta,
+        "rmse": {
+            "fit": rmse_fit,
+            "exponent": rmse_fit["slope"],
+            "exponent_ci95": (None if rmse_fit["ci95"] is None else rmse_fit["ci95"][1]),
+            "expected_exponent": 0.25,
+            "exponent_ratio": exponent_ratio,
+            "fitted_level": fitted_rmse_level,
+            "fitted_level_ci95": rmse_level_ci95,
+            "actual_sigma_bar_level_target": rmse_level_actual_target,
+            "theta_level_target": rmse_level_theta_target,
+            "actual_sigma_bar_level_ratio": actual_level_ratio,
+            "theta_level_ratio": theta_level_ratio,
+        },
+        "forgetting": {
+            "fit": forgetting_fit,
+            "fitted_slope": forgetting_fit["slope"],
+            "slope_target_eps_m1_over_s1": c_gain,
+            "slope_ratio": slope_ratio,
+            "fitted_intercept": forgetting_fit["intercept"],
+            "standing_text_intercept_target_kappa_lin": kappa_linear,
+            "standing_text_intercept_ratio": standing_intercept_ratio,
+            "asymptotic_log_decay_intercept_target": log_decay_intercept,
+            "asymptotic_log_decay_intercept_ratio": log_decay_intercept_ratio,
+            "log_decay_c_squared_over_two": 0.5 * c_gain * c_gain,
+        },
+        "standing_text_formal_acceptance": {
+            **shared_passes,
+            "forgetting_intercept_within_15pct": standing_intercept_pass,
+            "pass": standing_pass,
+        },
+        "asymptotic_log_decay_comparison": {
+            **shared_passes,
+            "forgetting_intercept_within_15pct": log_decay_intercept_pass,
+            "pass": log_decay_pass,
+        },
+    }
+
+
+def run_round2_e6(
+    params_by_name: dict[str, TgarchParams],
+    profile: StudyProfile | str,
+) -> dict[str, Any]:
+    """Run R4/E6a and return JSON-serialisable diagnostics.
+
+    Parameters
+    ----------
+    params_by_name
+        Named physical-measure TGARCH parameter sets.
+    profile
+        ``smoke``, ``reference``, or ``full``.  Reference and full use a
+        ``1/64512`` source grid and add the ``1/16128`` observation scale.
+    """
+
+    if not isinstance(params_by_name, dict) or not params_by_name:
+        raise ValueError("params_by_name must be a non-empty dictionary")
+    for name, params in params_by_name.items():
+        if not isinstance(name, str) or not name:
+            raise ValueError("parameter-set names must be non-empty strings")
+        if not isinstance(params, TgarchParams):
+            raise ValueError(f"parameter set {name!r} must be a TgarchParams instance")
+
+    started = time.perf_counter()
+    profile_value = _as_profile(profile)
+    config = make_study_config(profile_value)
+    seed = BASE_SEED + 6
+    if profile_value in (StudyProfile.REFERENCE, StudyProfile.FULL):
+        source_dt = _FINER_SOURCE_DT
+        observation_dts = _ORIGINAL_OBSERVATION_DTS + (_FINER_OBSERVATION_DT,)
+    elif profile_value is StudyProfile.SMOKE:
+        source_dt = _ORIGINAL_SOURCE_DT
+        # The round-one smoke subset has only two scales.  Add the two omitted
+        # original scales so the requested regressions have positive residual df.
+        observation_dts = _ORIGINAL_OBSERVATION_DTS
+    else:  # pragma: no cover - exhaustive enum guard
+        raise RuntimeError(f"unsupported profile {profile_value}")
+
+    records: list[dict[str, Any]] = []
+    self_checks: list[dict[str, Any]] = []
+    forgetting_series: list[dict[str, Any]] = []
+    source_summaries: list[dict[str, Any]] = []
+
+    for name, params in params_by_name.items():
+        self_path = simulate_discrete_path(
+            params=params,
+            measure=Measure.P,
+            dt=_DAILY_DT,
+            years=min(config.e6_years, 2.0),
+            seed=seed,
+        )
+        self_filtered = filter_discrete_returns(
+            log_prices=self_path.log_prices,
+            observation_times=self_path.times,
+            params=params,
+            sigma0=params.sigma0,
+        )
+        maximum_error = float(np.max(np.abs(self_filtered - self_path.sigmas)))
+        self_checks.append(
+            {
+                "parameter_set": name,
+                "max_abs_filter_error_own_model": maximum_error,
+                "pass": bool(maximum_error <= 1.0e-10),
+            }
+        )
+
+        source = simulate_two_shock_limit_path(
+            params=params,
+            dt=source_dt,
+            years=config.e6_years,
+            seed=seed,
+        )
+        burn_time = min(1.0, 0.1 * source.times[-1])
+        source_burn_mask = source.times >= burn_time
+        sigma_bar = float(np.mean(source.sigmas[source_burn_mask]))
+        source_summaries.append(
+            {
+                "parameter_set": name,
+                "source_dt_nominal": source_dt,
+                "source_dt_actual": float(source.dt),
+                "source_steps": int(source.times.size - 1),
+                "source_floor_hits": int(source.floor_hits),
+                "sigma_bar_actual": sigma_bar,
+                "theta": params.theta,
+                "burn_time": burn_time,
+            }
+        )
+        for observation_dt in observation_dts:
+            record, series = _sample_record(
+                name=name,
+                params=params,
+                source=source,
+                observation_dt=observation_dt,
+                years=config.e6_years,
+                seed=seed,
+                sigma_bar=sigma_bar,
+            )
+            records.append(record)
+            forgetting_series.append(series)
+
+    regressions = [
+        _regression_summary(name, params, records) for name, params in params_by_name.items()
+    ]
+    standing_pass = bool(
+        all(row["pass"] for row in self_checks)
+        and all(row["standing_text_formal_acceptance"]["pass"] for row in regressions)
+    )
+    log_decay_pass = bool(
+        all(row["pass"] for row in self_checks)
+        and all(row["asymptotic_log_decay_comparison"]["pass"] for row in regressions)
+    )
+
+    return {
+        "claim": "E6a tests the dt scaling and wrong-start forgetting formulas",
+        "profile": profile_value.value,
+        "seed": seed,
+        "years": config.e6_years,
+        "source_dt_nominal": source_dt,
+        "observation_dts_nominal": list(observation_dts),
+        "fit_grid_rule": "dt_observation_nominal <= 1/252",
+        "relative_acceptance_tolerance": _RELATIVE_TOLERANCE,
+        "records": records,
+        "self_model_checks": self_checks,
+        "source_summaries": source_summaries,
+        "forgetting_series": forgetting_series,
+        "regressions": regressions,
+        "standing_text_formal_acceptance": {
+            "criterion": (
+                "RMSE exponent versus 0.25, RMSE level versus actual-sigma-bar level, "
+                "forgetting slope versus eps*M1/S1, and forgetting intercept versus "
+                "kappa_lin must each be within 15% on dt <= 1/252."
+            ),
+            "pass": standing_pass,
+        },
+        "asymptotic_log_decay_comparison": {
+            "criterion": (
+                "The same comparisons, replacing the standing intercept kappa_lin with "
+                "the asymptotic log-decay intercept kappa_lin + 0.5*(eps*M1/S1)^2."
+            ),
+            "pass": log_decay_pass,
+        },
+        "interpretation_caveat": (
+            "The reported OLS intervals use scale points from one common source path and "
+            "are descriptive, not independent-sample confidence intervals.  Exactness "
+            "continues to apply only to the one-shock discrete recursion."
+        ),
+        "runtime_seconds": float(time.perf_counter() - started),
+    }

--- a/volatility_book/ch_discrete_vol/round2_e7.py
+++ b/volatility_book/ch_discrete_vol/round2_e7.py
@@ -1,0 +1,685 @@
+"""Round-2 E7a derived-identification and oracle-profile experiment.
+
+The unrestricted estimates are read from the immutable round-1 artifact.  Return paths are
+regenerated from its recorded seeds only for the constrained likelihood calculation.  Before
+each constrained fit, the regenerated path is checked by replaying the stored unrestricted
+log likelihood.
+
+The constrained experiment fixes the *physical* ``kappa2`` at its simulation truth.  It is an
+oracle identification diagnostic: it neither fixes ``d0`` nor represents an option-implied
+``kappa2_hat`` estimate.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+from scipy.optimize import OptimizeResult, minimize
+
+from volatility_book.ch_discrete_vol import experiments as round1
+from volatility_book.ch_discrete_vol.sim import Measure, TgarchParams, simulate_discrete_path
+
+_PARAMETER_NAMES = ("kappa1", "kappa2", "theta", "beta", "eps", "gamma1")
+_DERIVED_NAMES = ("d0", "d1", "kappa_lin", "vartheta")
+_EXPECTED_YEARS = (5, 10, 20, 40)
+_FREE_INDICES = np.array((0, 2, 3, 4, 5), dtype=np.int64)
+_TRANSFORMED_BOUNDS = (
+    (math.log(0.1), math.log(20.0)),
+    (math.log(0.01), math.log(20.0)),
+    (math.log(0.03), math.log(2.5)),
+    (-3.0, 3.0),
+    (math.log(0.05), math.log(4.0)),
+    (-2.0, 2.0),
+)
+_FREE_BOUNDS = tuple(_TRANSFORMED_BOUNDS[index] for index in _FREE_INDICES)
+_PROFILE_REPLICATIONS = {
+    round1.StudyProfile.SMOKE: 2,
+    round1.StudyProfile.REFERENCE: 32,
+    round1.StudyProfile.FULL: 200,
+}
+_REPLAY_ATOL = 1.0e-7
+_REPLAY_RTOL = 1.0e-10
+_PROFILE_DOMINANCE_ATOL = 1.0e-3
+
+
+def _field(value: object, name: str) -> Any:
+    if isinstance(value, Mapping):
+        if name not in value:
+            raise ValueError(f"round1_results is missing '{name}'")
+        return value[name]
+    if hasattr(value, name):
+        return getattr(value, name)
+    raise ValueError(f"round1_results is missing '{name}'")
+
+
+def _as_profile(profile: round1.StudyProfile | str) -> round1.StudyProfile:
+    if isinstance(profile, round1.StudyProfile):
+        return profile
+    value = getattr(profile, "value", profile)
+    try:
+        return round1.StudyProfile(str(value))
+    except ValueError as error:
+        choices = ", ".join(member.value for member in round1.StudyProfile)
+        raise ValueError(f"unknown profile '{profile}'; choose one of: {choices}") from error
+
+
+def _natural_truth(params: TgarchParams) -> np.ndarray:
+    return np.array(
+        (
+            params.kappa1,
+            params.kappa2,
+            params.theta,
+            params.beta,
+            params.eps,
+            params.gamma1,
+        ),
+        dtype=np.float64,
+    )
+
+
+def _derived_values(natural: np.ndarray) -> np.ndarray:
+    kappa1, kappa2, theta, beta, eps, _ = natural
+    return np.array(
+        (
+            kappa1 * theta,
+            kappa2 * theta - kappa1,
+            kappa1 + kappa2 * theta,
+            math.hypot(beta, eps),
+        ),
+        dtype=np.float64,
+    )
+
+
+def _validated_estimate(row: Mapping[str, Any]) -> np.ndarray:
+    estimate = np.asarray(row.get("estimate"), dtype=np.float64)
+    if estimate.shape != (6,) or not np.all(np.isfinite(estimate)):
+        raise ValueError("each round-1 E7 estimate must contain six finite values")
+    if np.any(estimate[[0, 1, 2, 4]] <= 0.0):
+        raise ValueError("round-1 kappa1, kappa2, theta, and eps estimates must be positive")
+    return estimate
+
+
+def _round1_rows(
+    round1_results: object,
+    params_by_name: Mapping[str, TgarchParams],
+    profile: round1.StudyProfile,
+) -> tuple[dict[tuple[str, int, int], Mapping[str, Any]], tuple[str, ...], tuple[int, ...]]:
+    experiments = _field(round1_results, "experiments")
+    if not isinstance(experiments, Mapping) or "E7" not in experiments:
+        raise ValueError("round1_results must contain experiments['E7']")
+    estimates = _field(experiments["E7"], "estimates")
+    if not isinstance(estimates, Sequence) or isinstance(estimates, (str, bytes)):
+        raise ValueError("round1_results experiments['E7']['estimates'] must be a sequence")
+
+    parameter_sets = tuple(params_by_name)
+    if not parameter_sets:
+        raise ValueError("params_by_name cannot be empty")
+    for name, params in params_by_name.items():
+        if not isinstance(name, str) or not isinstance(params, TgarchParams):
+            raise ValueError("params_by_name must map string names to TgarchParams")
+
+    indexed: dict[tuple[str, int, int], Mapping[str, Any]] = {}
+    years_by_name: dict[str, set[int]] = {name: set() for name in parameter_sets}
+    replications_by_name_year: dict[tuple[str, int], set[int]] = {}
+    for raw_row in estimates:
+        if not isinstance(raw_row, Mapping):
+            raise ValueError("each round-1 E7 estimate must be a mapping")
+        name = str(raw_row.get("parameter_set"))
+        if name not in params_by_name:
+            continue
+        years = int(raw_row.get("years"))
+        replication = int(raw_row.get("replication"))
+        seed = int(raw_row.get("seed"))
+        if years <= 0 or replication < 0 or seed < 0:
+            raise ValueError("round-1 E7 years, replication, and seed must be non-negative")
+        _validated_estimate(raw_row)
+        key = (name, years, replication)
+        if key in indexed:
+            raise ValueError(f"duplicate round-1 E7 estimate key: {key}")
+        indexed[key] = raw_row
+        years_by_name[name].add(years)
+        replications_by_name_year.setdefault((name, years), set()).add(replication)
+
+    target_count = _PROFILE_REPLICATIONS[profile]
+    selected_replications: set[int] | None = None
+    for name in parameter_sets:
+        years = tuple(sorted(years_by_name[name]))
+        if years != _EXPECTED_YEARS:
+            raise ValueError(f"round-1 E7 years for {name} are {years}; expected {_EXPECTED_YEARS}")
+        common = set.intersection(
+            *(replications_by_name_year[(name, years_value)] for years_value in years)
+        )
+        if len(common) < target_count:
+            raise ValueError(
+                f"round-1 E7 has {len(common)} complete replications for {name}; "
+                f"profile '{profile.value}' requires {target_count}"
+            )
+        selected = set(sorted(common)[:target_count])
+        if selected_replications is None:
+            selected_replications = selected
+        elif selected != selected_replications:
+            raise ValueError("selected round-1 replication identifiers differ by parameter set")
+
+    if selected_replications is None:
+        raise ValueError("no round-1 E7 replications were selected")
+    replications = tuple(sorted(selected_replications))
+    selected_index = {
+        key: row
+        for key, row in indexed.items()
+        if key[0] in params_by_name and key[2] in selected_replications
+    }
+    return selected_index, parameter_sets, replications
+
+
+def _orient(vector: np.ndarray, reference: np.ndarray) -> np.ndarray:
+    return -vector if float(vector @ reference) < 0.0 else vector
+
+
+def _eigendecomposition(matrix: np.ndarray, theta: float) -> dict[str, Any] | None:
+    if matrix.shape[0] < 2:
+        return None
+    covariance = np.cov(matrix[:, :2], rowvar=False, ddof=1)
+    if covariance.shape != (2, 2) or not np.all(np.isfinite(covariance)):
+        return None
+    eigenvalues, eigenvectors = np.linalg.eigh(covariance)
+    tolerance = 1.0e-12 * max(1.0, float(np.max(np.abs(eigenvalues))))
+    eigenvalues[np.abs(eigenvalues) <= tolerance] = 0.0
+    speed_direction = np.array((1.0, theta), dtype=np.float64)
+    speed_direction /= np.linalg.norm(speed_direction)
+    ridge_direction = np.array((-theta, 1.0), dtype=np.float64)
+    ridge_direction /= np.linalg.norm(ridge_direction)
+    small_vector = _orient(eigenvectors[:, 0], speed_direction)
+    large_vector = _orient(eigenvectors[:, 1], ridge_direction)
+    small = float(eigenvalues[0])
+    large = float(eigenvalues[1])
+    standard_deviations = np.sqrt(np.maximum(np.diag(covariance), 0.0))
+    denominator = float(standard_deviations[0] * standard_deviations[1])
+    correlation = float(covariance[0, 1] / denominator) if denominator > 0.0 else None
+    return {
+        "n_replications": int(matrix.shape[0]),
+        "covariance": covariance.tolist(),
+        "correlation": correlation,
+        "eigenvalues_ascending": [small, large],
+        "small_eigenvector": small_vector.tolist(),
+        "large_eigenvector": large_vector.tolist(),
+        "eigenvalue_ratio_large_to_small": large / small if small > tolerance else None,
+        "speed_direction": speed_direction.tolist(),
+        "ridge_direction": ridge_direction.tolist(),
+        "small_eigenvector_speed_abs_cosine": abs(float(small_vector @ speed_direction)),
+        "large_eigenvector_ridge_abs_cosine": abs(float(large_vector @ ridge_direction)),
+    }
+
+
+def _covariance_rows(
+    selected_rows: Mapping[tuple[str, int, int], Mapping[str, Any]],
+    params_by_name: Mapping[str, TgarchParams],
+    parameter_sets: Sequence[str],
+    replications: Sequence[int],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for name in parameter_sets:
+        for years in _EXPECTED_YEARS:
+            matrix = np.vstack(
+                [_validated_estimate(selected_rows[(name, years, rep)]) for rep in replications]
+            )
+            lower_hits = np.isclose(matrix[:, 1], 0.01)
+            upper_hits = np.isclose(matrix[:, 1], 20.0)
+            interior = ~(lower_hits | upper_hits)
+            rows.append(
+                {
+                    "parameter_set": name,
+                    "years": years,
+                    "kappa2_lower_bound_hits": int(np.count_nonzero(lower_hits)),
+                    "kappa2_upper_bound_hits": int(np.count_nonzero(upper_hits)),
+                    "kappa2_any_bound_fraction": float(np.mean(~interior)),
+                    "all_estimates": _eigendecomposition(matrix, params_by_name[name].theta),
+                    "interior_kappa2_estimates": _eigendecomposition(
+                        matrix[interior], params_by_name[name].theta
+                    ),
+                }
+            )
+    return rows
+
+
+def _derived_results(
+    selected_rows: Mapping[tuple[str, int, int], Mapping[str, Any]],
+    params_by_name: Mapping[str, TgarchParams],
+    parameter_sets: Sequence[str],
+    replications: Sequence[int],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    estimates: list[dict[str, Any]] = []
+    summaries: list[dict[str, Any]] = []
+    for name in parameter_sets:
+        truth = _derived_values(_natural_truth(params_by_name[name]))
+        for years in _EXPECTED_YEARS:
+            group_values: list[np.ndarray] = []
+            for replication in replications:
+                row = selected_rows[(name, years, replication)]
+                values = _derived_values(_validated_estimate(row))
+                group_values.append(values)
+                estimates.append(
+                    {
+                        "parameter_set": name,
+                        "years": years,
+                        "replication": replication,
+                        "seed": int(row["seed"]),
+                        **{
+                            quantity: float(values[index])
+                            for index, quantity in enumerate(_DERIVED_NAMES)
+                        },
+                    }
+                )
+            matrix = np.vstack(group_values)
+            for index, quantity in enumerate(_DERIVED_NAMES):
+                errors = matrix[:, index] - truth[index]
+                summaries.append(
+                    {
+                        "parameter_set": name,
+                        "years": years,
+                        "quantity": quantity,
+                        "truth": float(truth[index]),
+                        "mean_estimate": float(np.mean(matrix[:, index])),
+                        "bias": float(np.mean(errors)),
+                        "rmse": float(np.sqrt(np.mean(np.square(errors)))),
+                        "n_replications": len(replications),
+                    }
+                )
+    return estimates, summaries
+
+
+def _full_transformed(free: np.ndarray, fixed_kappa2: float) -> np.ndarray:
+    full = np.empty(6, dtype=np.float64)
+    full[1] = math.log(fixed_kappa2)
+    full[_FREE_INDICES] = free
+    return full
+
+
+def _optimizer_start(truth: np.ndarray) -> np.ndarray:
+    start = truth * np.array((0.85, 1.15, 1.05, 0.8, 1.1, 0.5))
+    if abs(start[3]) < 0.05:
+        start[3] = -0.1
+    start[1] = truth[1]
+    return start
+
+
+def _fit_fixed_physical_kappa2(
+    log_returns: np.ndarray,
+    *,
+    dt: float,
+    r: float,
+    fixed_kappa2: float,
+    archived_start: np.ndarray,
+    truth_start: np.ndarray,
+) -> tuple[np.ndarray, OptimizeResult, float, str, int]:
+    def objective(free: np.ndarray) -> float:
+        transformed = _full_transformed(free, fixed_kappa2)
+        values = round1._qmle_observations(transformed, log_returns, dt, r)
+        result = -float(np.mean(values))
+        return result if np.isfinite(result) else 1.0e12
+
+    candidates = (
+        ("archived_unrestricted", archived_start),
+        ("truth_biased", truth_start),
+    )
+    fitted_candidates: list[tuple[str, OptimizeResult, float]] = []
+    seen_starts: list[np.ndarray] = []
+    for label, natural_start in candidates:
+        transformed_start = round1._to_transformed(natural_start)[_FREE_INDICES]
+        duplicate_start = any(
+            np.allclose(transformed_start, seen, rtol=0.0, atol=1.0e-12) for seen in seen_starts
+        )
+        if duplicate_start:
+            continue
+        seen_starts.append(transformed_start)
+        fitted = minimize(
+            objective,
+            transformed_start,
+            method="L-BFGS-B",
+            bounds=_FREE_BOUNDS,
+            options={"maxiter": 350, "ftol": 1.0e-10, "gtol": 1.0e-6},
+        )
+        full = _full_transformed(np.asarray(fitted.x, dtype=np.float64), fixed_kappa2)
+        observations = round1._qmle_observations(full, log_returns, dt, r)
+        log_likelihood = float(np.sum(observations))
+        fitted_candidates.append((label, fitted, log_likelihood))
+
+    converged = [candidate for candidate in fitted_candidates if bool(candidate[1].success)]
+    eligible = converged if converged else fitted_candidates
+    label, fitted, log_likelihood = max(eligible, key=lambda candidate: candidate[2])
+    transformed = _full_transformed(np.asarray(fitted.x, dtype=np.float64), fixed_kappa2)
+    natural = round1._to_natural(transformed)
+    return natural, fitted, log_likelihood, label, len(fitted_candidates)
+
+
+def _free_bound_hits(natural: np.ndarray) -> list[str]:
+    natural_bounds = {
+        "kappa1": (natural[0], 0.1, 20.0),
+        "theta": (natural[2], 0.03, 2.5),
+        "beta": (natural[3], -3.0, 3.0),
+        "eps": (natural[4], 0.05, 4.0),
+        "gamma1": (natural[5], -2.0, 2.0),
+    }
+    hits: list[str] = []
+    for name, (value, lower, upper) in natural_bounds.items():
+        if np.isclose(value, lower, rtol=1.0e-6, atol=1.0e-8):
+            hits.append(f"{name}:lower")
+        if np.isclose(value, upper, rtol=1.0e-6, atol=1.0e-8):
+            hits.append(f"{name}:upper")
+    return hits
+
+
+def _profile_results(
+    selected_rows: Mapping[tuple[str, int, int], Mapping[str, Any]],
+    params_by_name: Mapping[str, TgarchParams],
+    parameter_sets: Sequence[str],
+    replications: Sequence[int],
+    dt: float,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    estimates: list[dict[str, Any]] = []
+    maximum_years = float(max(_EXPECTED_YEARS))
+    for name in parameter_sets:
+        params = params_by_name[name]
+        truth = _natural_truth(params)
+        truth_start = _optimizer_start(truth)
+        for replication in replications:
+            group = [selected_rows[(name, years, replication)] for years in _EXPECTED_YEARS]
+            seeds = {int(row["seed"]) for row in group}
+            if len(seeds) != 1:
+                raise ValueError(
+                    f"round-1 E7 seeds differ across horizons for {name}, replication {replication}"
+                )
+            seed = seeds.pop()
+            path = simulate_discrete_path(
+                params=params,
+                measure=Measure.P,
+                dt=dt,
+                years=maximum_years,
+                seed=seed,
+            )
+            if not math.isclose(path.dt, dt, rel_tol=0.0, abs_tol=1.0e-15):
+                raise RuntimeError(f"regenerated path dt={path.dt} differs from E7 dt={dt}")
+            all_returns = np.diff(path.log_prices)
+            for years, archived_row in zip(_EXPECTED_YEARS, group):
+                archived_floor_hits = int(archived_row.get("floor_hits", 0))
+                if path.floor_hits != archived_floor_hits:
+                    raise RuntimeError(
+                        "regenerated path floor hits do not match round 1 for "
+                        f"{name}, {years}y, replication {replication}"
+                    )
+                count = int(round(years / dt))
+                log_returns = all_returns[:count]
+                archived_estimate = _validated_estimate(archived_row)
+                replayed = float(
+                    np.sum(
+                        round1._qmle_observations(
+                            round1._to_transformed(archived_estimate),
+                            log_returns,
+                            dt,
+                            params.r,
+                        )
+                    )
+                )
+                archived_log_likelihood = float(archived_row["log_likelihood"])
+                replay_error = abs(replayed - archived_log_likelihood)
+                replay_tolerance = _REPLAY_ATOL + _REPLAY_RTOL * abs(archived_log_likelihood)
+                if replay_error > replay_tolerance:
+                    raise RuntimeError(
+                        "round-1 likelihood replay failed for "
+                        f"{name}, {years}y, replication {replication}: "
+                        f"error={replay_error:.6g}, tolerance={replay_tolerance:.6g}"
+                    )
+
+                archived_start = archived_estimate.copy()
+                archived_start[1] = params.kappa2
+                fitted, optimizer, profile_likelihood, start_label, starts_tried = (
+                    _fit_fixed_physical_kappa2(
+                        log_returns,
+                        dt=dt,
+                        r=params.r,
+                        fixed_kappa2=params.kappa2,
+                        archived_start=archived_start,
+                        truth_start=truth_start,
+                    )
+                )
+                bound_hits = _free_bound_hits(fitted)
+                likelihood_excess = profile_likelihood - archived_log_likelihood
+                estimates.append(
+                    {
+                        "parameter_set": name,
+                        "years": years,
+                        "replication": replication,
+                        "seed": seed,
+                        "fixed_physical_kappa2": params.kappa2,
+                        "estimate": fitted.tolist(),
+                        "converged": bool(optimizer.success),
+                        "optimizer_status": int(optimizer.status),
+                        "optimizer_message": str(optimizer.message),
+                        "optimizer_iterations": int(getattr(optimizer, "nit", 0)),
+                        "optimizer_function_evaluations": int(getattr(optimizer, "nfev", 0)),
+                        "selected_start": start_label,
+                        "starts_tried": starts_tried,
+                        "free_parameter_bound_hits": bound_hits,
+                        "profile_log_likelihood": profile_likelihood,
+                        "round1_log_likelihood": archived_log_likelihood,
+                        "profile_log_likelihood_loss": archived_log_likelihood - profile_likelihood,
+                        "profile_above_unrestricted_excess": likelihood_excess,
+                        "profile_not_above_unrestricted": likelihood_excess
+                        <= _PROFILE_DOMINANCE_ATOL,
+                        "profile_dominance_tolerance": _PROFILE_DOMINANCE_ATOL,
+                        "likelihood_replay_abs_error": replay_error,
+                        "likelihood_replay_tolerance": replay_tolerance,
+                        "likelihood_replay_pass": True,
+                        "floor_hits": path.floor_hits,
+                    }
+                )
+
+    summaries: list[dict[str, Any]] = []
+    diagnostics: list[dict[str, Any]] = []
+    for name in parameter_sets:
+        truth = _natural_truth(params_by_name[name])
+        for years in _EXPECTED_YEARS:
+            profile_group = [
+                row for row in estimates if row["parameter_set"] == name and row["years"] == years
+            ]
+            profile_matrix = np.vstack([row["estimate"] for row in profile_group])
+            baseline_matrix = np.vstack(
+                [
+                    _validated_estimate(selected_rows[(name, years, replication)])
+                    for replication in replications
+                ]
+            )
+            for index in (0, 2):
+                baseline_errors = baseline_matrix[:, index] - truth[index]
+                profile_errors = profile_matrix[:, index] - truth[index]
+                baseline_rmse = float(np.sqrt(np.mean(np.square(baseline_errors))))
+                profile_rmse = float(np.sqrt(np.mean(np.square(profile_errors))))
+                ratio = profile_rmse / baseline_rmse if baseline_rmse > 0.0 else None
+                summaries.append(
+                    {
+                        "parameter_set": name,
+                        "years": years,
+                        "parameter": _PARAMETER_NAMES[index],
+                        "truth": float(truth[index]),
+                        "unrestricted_bias": float(np.mean(baseline_errors)),
+                        "unrestricted_rmse": baseline_rmse,
+                        "oracle_fixed_kappa2_bias": float(np.mean(profile_errors)),
+                        "oracle_fixed_kappa2_rmse": profile_rmse,
+                        "rmse_ratio_fixed_to_unrestricted": ratio,
+                        "rmse_improvement_fraction": 1.0 - ratio if ratio is not None else None,
+                        "n_replications": len(replications),
+                    }
+                )
+            bound_names = sorted(
+                {hit for row in profile_group for hit in row["free_parameter_bound_hits"]}
+            )
+            above = [
+                float(row["profile_above_unrestricted_excess"])
+                for row in profile_group
+                if not row["profile_not_above_unrestricted"]
+            ]
+            positive_excess = [
+                max(float(row["profile_above_unrestricted_excess"]), 0.0) for row in profile_group
+            ]
+            diagnostics.append(
+                {
+                    "parameter_set": name,
+                    "years": years,
+                    "n_replications": len(profile_group),
+                    "convergence_fraction": float(
+                        np.mean([row["converged"] for row in profile_group])
+                    ),
+                    "any_free_parameter_bound_fraction": float(
+                        np.mean([bool(row["free_parameter_bound_hits"]) for row in profile_group])
+                    ),
+                    "free_parameter_bound_hit_counts": {
+                        hit: sum(hit in row["free_parameter_bound_hits"] for row in profile_group)
+                        for hit in bound_names
+                    },
+                    "likelihood_replay_all_pass": all(
+                        row["likelihood_replay_pass"] for row in profile_group
+                    ),
+                    "maximum_likelihood_replay_abs_error": max(
+                        float(row["likelihood_replay_abs_error"]) for row in profile_group
+                    ),
+                    "profile_above_unrestricted_count": len(above),
+                    "maximum_profile_above_unrestricted_excess": max(above, default=0.0),
+                    "maximum_positive_profile_excess": max(positive_excess, default=0.0),
+                    "profile_dominance_tolerance": _PROFILE_DOMINANCE_ATOL,
+                    "maximum_floor_hits": max(int(row["floor_hits"]) for row in profile_group),
+                }
+            )
+    return estimates, summaries, diagnostics
+
+
+def run_round2_e7(
+    round1_results: object,
+    params_by_name: Mapping[str, TgarchParams],
+    profile: round1.StudyProfile | str,
+) -> dict[str, Any]:
+    """Run round-2 E7a using archived estimates and oracle fixed-``kappa2`` QMLE.
+
+    Parameters
+    ----------
+    round1_results
+        Loaded round-1 ``results.json`` mapping, or the equivalent ``StudyResults`` object.
+        Its per-replication E7 estimates are treated as immutable inputs.
+    params_by_name
+        Physical simulation parameters keyed by the round-1 parameter-set names.
+    profile
+        ``smoke`` uses 2, ``reference`` 32, and ``full`` 200 complete replications per
+        parameter set and horizon.
+
+    Returns
+    -------
+    dict
+        JSON-ready derived estimates and summaries, covariance ridge diagnostics, replayed
+        likelihood checks, and oracle fixed-physical-``kappa2`` profile results.
+    """
+
+    started = time.perf_counter()
+    resolved_profile = _as_profile(profile)
+    selected_rows, parameter_sets, replications = _round1_rows(
+        round1_results,
+        params_by_name,
+        resolved_profile,
+    )
+    experiments = _field(round1_results, "experiments")
+    e7 = experiments["E7"]
+    dt = float(_field(e7, "dt"))
+    if not math.isfinite(dt) or dt <= 0.0:
+        raise ValueError("round-1 E7 dt must be finite and positive")
+
+    derived_estimates, derived_summaries = _derived_results(
+        selected_rows,
+        params_by_name,
+        parameter_sets,
+        replications,
+    )
+    covariance = _covariance_rows(
+        selected_rows,
+        params_by_name,
+        parameter_sets,
+        replications,
+    )
+    profile_estimates, profile_summaries, profile_diagnostics = _profile_results(
+        selected_rows,
+        params_by_name,
+        parameter_sets,
+        replications,
+        dt,
+    )
+    all_covariance = [row["all_estimates"] for row in covariance]
+    valid_covariance = [row for row in all_covariance if row is not None]
+    replay_errors = [float(row["likelihood_replay_abs_error"]) for row in profile_estimates]
+    profile_excesses = [
+        float(row["profile_above_unrestricted_excess"]) for row in profile_estimates
+    ]
+    dominance_failures = [excess for excess in profile_excesses if excess > _PROFILE_DOMINANCE_ATOL]
+
+    return {
+        "claim": (
+            "Derived quantities can be better identified than kappa1 and kappa2 separately; "
+            "an oracle fixed-physical-kappa2 fit measures the ridge-removal gain."
+        ),
+        "verdict": "MEASUREMENT ONLY - oracle identification experiment",
+        "profile": resolved_profile.value,
+        "dt": dt,
+        "sample_years": list(_EXPECTED_YEARS),
+        "parameter_sets": list(parameter_sets),
+        "replications_per_parameter_set_year": len(replications),
+        "selected_replications": list(replications),
+        "round1_seed_rule": _field(e7, "seed_rule"),
+        "round1_rows_reused": len(selected_rows),
+        "path_regeneration": (
+            "One 40-year P path per parameter set and replication, regenerated from the "
+            "round-1 seed and sliced to the archived 5/10/20/40-year horizons."
+        ),
+        "derived_estimates": derived_estimates,
+        "derived_summaries": derived_summaries,
+        "covariance_eigendecomposition": covariance,
+        "profile_estimates": profile_estimates,
+        "profile_summaries": profile_summaries,
+        "profile_diagnostics": profile_diagnostics,
+        "likelihood_replay": {
+            "all_passed": all(row["likelihood_replay_pass"] for row in profile_estimates),
+            "absolute_tolerance": _REPLAY_ATOL,
+            "relative_tolerance": _REPLAY_RTOL,
+            "maximum_absolute_error": max(replay_errors, default=0.0),
+        },
+        "profile_likelihood_dominance": {
+            "all_passed_within_optimizer_tolerance": not dominance_failures,
+            "absolute_tolerance": _PROFILE_DOMINANCE_ATOL,
+            "failure_count": len(dominance_failures),
+            "maximum_positive_excess": max(
+                (max(excess, 0.0) for excess in profile_excesses),
+                default=0.0,
+            ),
+        },
+        "ridge_hypothesis_diagnostics": {
+            "minimum_small_eigenvector_speed_abs_cosine": min(
+                (float(row["small_eigenvector_speed_abs_cosine"]) for row in valid_covariance),
+                default=None,
+            ),
+            "minimum_large_eigenvector_ridge_abs_cosine": min(
+                (float(row["large_eigenvector_ridge_abs_cosine"]) for row in valid_covariance),
+                default=None,
+            ),
+        },
+        "oracle_caveat": (
+            "The profile fixes physical kappa2 at its simulation truth. It does not impose "
+            "d0=kappa1*theta, does not fix risk-neutral kappa2_hat, and therefore must not be "
+            "reported as identification supplied by option data."
+        ),
+        "interpretation_caveat": (
+            "This simulation diagnostic does not transfer statistical inference between the "
+            "discrete and continuous models."
+        ),
+        "runtime_seconds": time.perf_counter() - started,
+    }
+
+
+__all__ = ["run_round2_e7"]

--- a/volatility_book/ch_discrete_vol/round2_reporting.py
+++ b/volatility_book/ch_discrete_vol/round2_reporting.py
@@ -1,0 +1,966 @@
+"""Reporting for the round-two discrete-versus-continuous TGARCH study."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import math
+import textwrap
+from collections.abc import Mapping, Sequence
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.colors import TwoSlopeNorm
+from matplotlib.figure import Figure
+
+from volatility_book.ch_discrete_vol import reporting as round1_reporting
+
+
+def _json_ready(value: Any) -> Any:
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {
+            field.name: _json_ready(getattr(value, field.name))
+            for field in dataclasses.fields(value)
+        }
+    if isinstance(value, Mapping):
+        return {str(key): _json_ready(item) for key, item in value.items()}
+    if isinstance(value, np.ndarray):
+        return [_json_ready(item) for item in value.tolist()]
+    if isinstance(value, np.generic):
+        return _json_ready(value.item())
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    return value
+
+
+def write_round2_results_json(results: Mapping[str, Any], path: Path) -> None:
+    """Write the strict, deterministic round-two audit record."""
+    output = Path(path)
+    if output.suffix.lower() != ".json":
+        raise ValueError("Round-two JSON output must end in .json")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(_json_ready(results), indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _sequence(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, Mapping):
+        return list(value.values())
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return list(value)
+    return [value]
+
+
+def _rows(section: Mapping[str, Any], *names: str) -> list[dict[str, Any]]:
+    for name in names:
+        value = section.get(name)
+        if value is not None:
+            return [dict(row) for row in _sequence(value) if isinstance(row, Mapping)]
+    return []
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "NA"
+    if isinstance(value, bool):
+        return "PASS" if value else "FAIL"
+    if isinstance(value, (float, np.floating)):
+        number = float(value)
+        if not math.isfinite(number):
+            return "NA"
+        magnitude = abs(number)
+        if magnitude != 0.0 and (magnitude < 1.0e-4 or magnitude >= 1.0e5):
+            return f"{number:.4e}"
+        return f"{number:.6g}"
+    if isinstance(value, (list, tuple)):
+        return ", ".join(_fmt(item) for item in value)
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _mapping_text(value: Any) -> str:
+    if not isinstance(value, Mapping):
+        return str(value or "")
+    return " ".join(
+        f"{str(key).replace('_', ' ').capitalize()}: {item}" for key, item in value.items()
+    )
+
+
+def _table(rows: Sequence[Mapping[str, Any]], columns: Sequence[tuple[str, str]]) -> str:
+    if not rows:
+        return "_No records._\n"
+    header = "| " + " | ".join(label for label, _ in columns) + " |"
+    rule = "| " + " | ".join("---" for _ in columns) + " |"
+    body = ["| " + " | ".join(_fmt(row.get(field)) for _, field in columns) + " |" for row in rows]
+    return "\n".join((header, rule, *body)) + "\n"
+
+
+def _provenance(results: Mapping[str, Any], seed: Any) -> str:
+    provenance = results["provenance"]
+    versions = ", ".join(
+        f"{name}={version}" for name, version in provenance["package_versions"].items()
+    )
+    return (
+        f"Provenance for every number in this section: script=`{provenance['script']}`; "
+        f"seed={_fmt(seed)}; versions={versions}; exact tag=`{provenance['repository_tag']}`; "
+        f"HEAD=`{provenance['repository_head']}`."
+    )
+
+
+def _section_seed(section: Mapping[str, Any]) -> Any:
+    metadata = section.get("seed_metadata")
+    if not isinstance(metadata, Mapping):
+        return section.get("seed", section.get("seed_rule", "see JSON seed ledger"))
+    base = metadata.get("base_seed", metadata.get("BASE_SEED", 20260823))
+    rule = metadata.get(
+        "stream_rule",
+        metadata.get(
+            "seed_sequence_rule",
+            metadata.get("derivation", "numpy SeedSequence([base_seed, *parts])"),
+        ),
+    )
+    return f"base={base}; {rule}; exact stream ledger in JSON"
+
+
+def _r2_markdown(section: Mapping[str, Any]) -> str:
+    rows = _r2_rows(section)
+    columns = (
+        ("Kernel", "measure"),
+        ("T", "maturity"),
+        ("dt", "dt"),
+        ("kappa2_hat", "kappa2_hat"),
+        ("Paths", "n_paths"),
+        ("Empirical defect", "defect"),
+        ("CI low", "bootstrap_ci_lower"),
+        ("CI high", "bootstrap_ci_upper"),
+        ("Top 0.1%", "top_0_1pct_share"),
+    )
+    return _table(rows, columns)
+
+
+def _r2_rows(section: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw = (
+        _rows(section, "q_limit")
+        + _rows(section, "q_exact_controls")
+        + _rows(section, "records", "defect_records", "martingale_records")
+    )
+    output: list[dict[str, Any]] = []
+    for source in raw:
+        row = dict(source)
+        row["measure"] = row.get("measure", row.get("kernel", "Q_LIMIT"))
+        row["defect"] = row.get(
+            "empirical_fixed_budget_defect",
+            row.get("empirical_defect", row.get("defect", row.get("estimate"))),
+        )
+        row["top_0_1pct_share"] = row.get("top_0_1pct_share", row.get("top_0.1pct_share"))
+        interval = row.get("bootstrap_ci_95")
+        if isinstance(interval, Sequence) and len(interval) == 2:
+            row["bootstrap_ci_lower"] = interval[0]
+            row["bootstrap_ci_upper"] = interval[1]
+        output.append(row)
+    return output
+
+
+def _r3_cell_rows(section: Mapping[str, Any]) -> list[dict[str, Any]]:
+    output: list[dict[str, Any]] = []
+    for source in _rows(section, "cells", "slope_records", "records"):
+        row = dict(source)
+        interval = row.get("bootstrap_ci_95")
+        if isinstance(interval, Sequence) and len(interval) == 2:
+            row["bootstrap_ci_lower"] = interval[0]
+            row["bootstrap_ci_upper"] = interval[1]
+        shares = row.get("top_0.1pct_share_by_dt", ())
+        row["top_0_1pct_share"] = max(shares, default=None)
+        row["n_paths"] = max(row.get("paths_by_dt", ()), default=None)
+        output.append(row)
+    return output
+
+
+def _r3_crossing_rows(section: Mapping[str, Any]) -> list[dict[str, Any]]:
+    output: list[dict[str, Any]] = []
+    for source in _rows(section, "crossings", "crossing_records", "critical_curve"):
+        row = dict(source)
+        point = row.get("point_crossing_after_pava", {})
+        interval = row.get("bootstrap_interval_95", {})
+        sufficient = row.get("sufficient_curve_crossing", {})
+        bracket = row.get("confirmed_grid_bracket", {})
+        if isinstance(point, Mapping):
+            row["crossing_power"] = point.get("value")
+            row["crossing_display"] = point.get("value", point.get("censor"))
+            if row["crossing_display"] is None:
+                row["crossing_display"] = point.get("censor")
+        if isinstance(interval, Mapping):
+            row["bootstrap_ci_lower"] = interval.get("low")
+            row["bootstrap_ci_upper"] = interval.get("high")
+            low = (
+                interval.get("low")
+                if interval.get("low") is not None
+                else interval.get("low_censor")
+            )
+            high = (
+                interval.get("high")
+                if interval.get("high") is not None
+                else interval.get("high_censor")
+            )
+            row["bootstrap_ci_display"] = f"{_fmt(low)} to {_fmt(high)}"
+        if isinstance(sufficient, Mapping):
+            row["sufficient_crossing_power"] = sufficient.get("value")
+            row["sufficient_display"] = (
+                sufficient.get("value")
+                if sufficient.get("value") is not None
+                else sufficient.get("censor")
+            )
+        if isinstance(bracket, Mapping):
+            row["status"] = bracket.get("status")
+            low = (
+                bracket.get("low") if bracket.get("low") is not None else bracket.get("low_censor")
+            )
+            high = (
+                bracket.get("high")
+                if bracket.get("high") is not None
+                else bracket.get("high_censor")
+            )
+            row["grid_bracket"] = f"{_fmt(low)} to {_fmt(high)}"
+        output.append(row)
+    return output
+
+
+def _r3_markdown(section: Mapping[str, Any]) -> tuple[str, str, str]:
+    crossings = _r3_crossing_rows(section)
+    cells = _r3_cell_rows(section)
+    crossing_table = _table(
+        crossings,
+        (
+            ("kappa2_hat", "kappa2_hat"),
+            ("Empirical p*", "crossing_display"),
+            ("Bootstrap 95% interval", "bootstrap_ci_display"),
+            ("Confirmed grid bracket", "grid_bracket"),
+            ("Sufficient p", "sufficient_display"),
+            ("Status", "status"),
+        ),
+    )
+    tail_rows = [
+        row
+        for row in cells
+        if float(row.get("top_0_1pct_share", 0.0) or 0.0) > 0.2
+        or bool(row.get("tail_unresolved", False))
+    ]
+    tail_table = _table(
+        tail_rows,
+        (
+            ("p", "power"),
+            ("kappa2_hat", "kappa2_hat"),
+            ("Slope", "slope"),
+            ("CI low", "bootstrap_ci_lower"),
+            ("CI high", "bootstrap_ci_upper"),
+            ("Top 0.1%", "top_0_1pct_share"),
+            ("Paths", "n_paths"),
+            ("Classification", "classification"),
+        ),
+    )
+    tail_diagnostics = section.get("tail_diagnostics", {})
+    escalation = (
+        _rows(tail_diagnostics, "escalation") if isinstance(tail_diagnostics, Mapping) else []
+    )
+    for row in escalation:
+        row["unresolved_display"] = (
+            "UNRESOLVED" if row.get("unresolved_after_escalation") else "resolved"
+        )
+    escalation_table = _table(
+        escalation,
+        (
+            ("dt", "dt"),
+            ("Pilot paths", "pilot_paths"),
+            ("Final paths", "final_paths"),
+            ("Initial max top 0.1%", "initial_max_top_0.1pct_share"),
+            ("Final max top 0.1%", "final_max_top_0.1pct_share"),
+            ("Action", "status"),
+            ("Tail status", "unresolved_display"),
+            ("Importance sampling", "importance_sampling"),
+        ),
+    )
+    return crossing_table, tail_table, escalation_table
+
+
+def _r4_rows(section: Mapping[str, Any]) -> list[dict[str, Any]]:
+    output: list[dict[str, Any]] = []
+    for row in _rows(section, "regressions"):
+        rmse = row["rmse"]
+        forgetting = row["forgetting"]
+        output.append(
+            {
+                "parameter_set": row["parameter_set"],
+                "exponent": rmse["exponent"],
+                "exponent_ci95": rmse["exponent_ci95"],
+                "exponent_with_ci": (
+                    f"{_fmt(rmse['exponent'])} "
+                    f"[{_fmt(rmse['exponent_ci95'][0])}, "
+                    f"{_fmt(rmse['exponent_ci95'][1])}]"
+                    if rmse["exponent_ci95"] is not None
+                    else _fmt(rmse["exponent"])
+                ),
+                "exponent_target": rmse["expected_exponent"],
+                "sigma_bar_actual": row["sigma_bar_actual"],
+                "theta": row["theta"],
+                "fitted_level": rmse["fitted_level"],
+                "actual_level_target": rmse["actual_sigma_bar_level_target"],
+                "theta_level_target": rmse["theta_level_target"],
+                "level_ratio_actual": rmse["actual_sigma_bar_level_ratio"],
+                "level_ratio_theta": rmse["theta_level_ratio"],
+                "slope": forgetting["fitted_slope"],
+                "slope_target": forgetting["slope_target_eps_m1_over_s1"],
+                "slope_ratio": forgetting["slope_ratio"],
+                "intercept": forgetting["fitted_intercept"],
+                "raw_target": forgetting["standing_text_intercept_target_kappa_lin"],
+                "raw_ratio": forgetting["standing_text_intercept_ratio"],
+                "log_decay_target": forgetting["asymptotic_log_decay_intercept_target"],
+                "log_decay_ratio": forgetting["asymptotic_log_decay_intercept_ratio"],
+                "formal_pass": row["standing_text_formal_acceptance"]["pass"],
+                "log_decay_pass": row["asymptotic_log_decay_comparison"]["pass"],
+            }
+        )
+    return output
+
+
+def _r5_tables(section: Mapping[str, Any]) -> tuple[str, str, str]:
+    derived = _rows(section, "derived_summaries", "derived", "summaries")
+    eigen_raw = _rows(
+        section,
+        "covariance_eigendecomposition",
+        "eigendecomposition",
+        "eigen",
+    )
+    eigen: list[dict[str, Any]] = []
+    for row in eigen_raw:
+        decomposition = row.get("all_estimates")
+        if not isinstance(decomposition, Mapping):
+            continue
+        values = decomposition.get("eigenvalues_ascending", (None, None))
+        eigen.append(
+            {
+                "parameter_set": row["parameter_set"],
+                "years": row["years"],
+                "small_eigenvalue": values[0],
+                "large_eigenvalue": values[1],
+                "eigenvalue_ratio": decomposition.get("eigenvalue_ratio_large_to_small"),
+                "speed_alignment_cosine": decomposition.get("small_eigenvector_speed_abs_cosine"),
+                "ridge_alignment_cosine": decomposition.get("large_eigenvector_ridge_abs_cosine"),
+                "kappa2_any_bound_fraction": row.get("kappa2_any_bound_fraction"),
+            }
+        )
+    profile = _rows(section, "profile_summaries", "profiled", "profile_results")
+    diagnostics = {
+        (row["parameter_set"], row["years"]): row for row in _rows(section, "profile_diagnostics")
+    }
+    for row in profile:
+        row["profiled_rmse"] = row.get("profiled_rmse", row.get("oracle_fixed_kappa2_rmse"))
+        diagnostic = diagnostics.get((row["parameter_set"], row["years"]), {})
+        row["convergence_fraction"] = diagnostic.get("convergence_fraction")
+    return (
+        _table(
+            derived,
+            (
+                ("Set", "parameter_set"),
+                ("Years", "years"),
+                ("Quantity", "quantity"),
+                ("Truth", "truth"),
+                ("Bias", "bias"),
+                ("RMSE", "rmse"),
+            ),
+        ),
+        _table(
+            eigen,
+            (
+                ("Set", "parameter_set"),
+                ("Years", "years"),
+                ("Small eigenvalue", "small_eigenvalue"),
+                ("Large eigenvalue", "large_eigenvalue"),
+                ("Ratio", "eigenvalue_ratio"),
+                ("Speed cosine", "speed_alignment_cosine"),
+                ("Ridge cosine", "ridge_alignment_cosine"),
+                ("kappa2 bound fraction", "kappa2_any_bound_fraction"),
+            ),
+        ),
+        _table(
+            profile,
+            (
+                ("Set", "parameter_set"),
+                ("Years", "years"),
+                ("Parameter", "parameter"),
+                ("Unrestricted RMSE", "unrestricted_rmse"),
+                ("Oracle RMSE", "profiled_rmse"),
+                ("Improvement", "rmse_improvement_fraction"),
+                ("Convergence", "convergence_fraction"),
+            ),
+        ),
+    )
+
+
+def write_round2_markdown(
+    results: Mapping[str, Any],
+    path: Path,
+    *,
+    json_path: Path,
+) -> None:
+    """Write the contradiction-first round-two analysis memo."""
+    r3_crossings, r3_tails, r3_escalation = _r3_markdown(results["R3"])
+    r5_derived, r5_eigen, r5_profile = _r5_tables(results["R5"])
+    r4_rows = _r4_rows(results["R4"])
+    r1_rows = results["R1"]["rows"]
+    r3_tail = results["R3"].get("tail_diagnostics", {})
+    r3_floor = results["R3"].get("floor_diagnostics", {})
+    r3_checks = results["R3"].get("checks", {})
+    lines = [
+        "# Discrete versus continuous log-normal beta SV study - round 2",
+        "",
+        f"Profile: **{results['profile']}**. R1 blocking stability gate: "
+        f"**{'PASS' if results['R1']['blocking_gate_passed'] else 'FAIL'}**.",
+        "",
+        "## Contradictions and corrected interpretation",
+        "",
+    ]
+    for item in results["contradictions"]:
+        lines.extend((f"- **{item['item']}.** {item['finding']}", ""))
+    lines.extend(
+        (
+            "These are mathematical corrections to the requested diagnostics, not silent changes "
+            "to their grids or estimators.",
+            "",
+            "## R1 - clean-tag stability gate",
+            "",
+            _provenance(results, "round-1 seed map 20260824--20260830"),
+            "",
+            _table(
+                r1_rows,
+                (
+                    ("Item", "item"),
+                    ("Set", "parameter_set"),
+                    ("Case", "case"),
+                    ("Round 1", "round1_value"),
+                    ("Clean repeat", "repeat_value"),
+                    ("Round 1 max (E1)", "round1_max_value"),
+                    ("Clean max (E1)", "repeat_max_value"),
+                    ("Units", "units"),
+                    ("Noise statistic", "noise_statistic"),
+                    ("Criterion", "criterion"),
+                    ("Pass", "passed"),
+                ),
+            ),
+            results["R1"]["interpretation"],
+            "",
+            "## R2 - E4a empirical fixed-budget martingale diagnostic",
+            "",
+            _provenance(results, _section_seed(results["R2"])),
+            "",
+            _r2_markdown(results["R2"]),
+            _mapping_text(results["R2"].get("interpretation", results["R2"].get("limitation", ""))),
+            "",
+            "## R3 - E4b empirical critical curve",
+            "",
+            _provenance(results, _section_seed(results["R3"])),
+            "",
+            "### Crossing estimates",
+            "",
+            r3_crossings,
+            "### Tail-concentrated cells and path escalation",
+            "",
+            r3_tails,
+            "### Per-dt path escalation audit",
+            "",
+            r3_escalation,
+            (
+                "Corrected four-dt slope test: "
+                f"{_fmt(r3_checks.get('corrected_four_dt_slope_used'))}; "
+                f"unresolved tail cells: {_fmt(r3_tail.get('unresolved_cell_count'))}; "
+                f"volatility-floor hits: {_fmt(r3_floor.get('floor_hits_total'))}; "
+                "resolved growth inside the strict sufficient region: "
+                f"{_fmt(r3_checks.get('resolved_growth_inside_strict_sufficient_region'))}; "
+                f"formal diagnostic pass: {_fmt(r3_checks.get('acceptance_pass'))}. "
+                "The analytic boundary is sufficient, not necessary."
+            ),
+            "",
+            "## R4 - E6a filter formulas",
+            "",
+            _provenance(results, results["R4"].get("seed", "see record seeds")),
+            "",
+            _table(
+                r4_rows,
+                (
+                    ("Set", "parameter_set"),
+                    ("RMSE exponent [95% CI]", "exponent_with_ci"),
+                    ("Exponent target", "exponent_target"),
+                    ("sigma_bar", "sigma_bar_actual"),
+                    ("theta", "theta"),
+                    ("Fitted level", "fitted_level"),
+                    ("Actual-sigma target", "actual_level_target"),
+                    ("Actual ratio", "level_ratio_actual"),
+                    ("Theta target", "theta_level_target"),
+                    ("Theta ratio", "level_ratio_theta"),
+                ),
+            ),
+            "Predicted-versus-observed forgetting fit:",
+            "",
+            _table(
+                r4_rows,
+                (
+                    ("Set", "parameter_set"),
+                    ("Forgetting slope", "slope"),
+                    ("Slope target", "slope_target"),
+                    ("Slope ratio", "slope_ratio"),
+                    ("Intercept", "intercept"),
+                    ("Requested target", "raw_target"),
+                    ("Requested ratio", "raw_ratio"),
+                    ("Log-decay target", "log_decay_target"),
+                    ("Log-decay ratio", "log_decay_ratio"),
+                    ("Formal", "formal_pass"),
+                    ("Log-decay", "log_decay_pass"),
+                ),
+            ),
+            "Requested formal acceptance: "
+            f"**{_fmt(results['R4']['standing_text_formal_acceptance']['pass'])}**. "
+            "Asymptotic log-decay comparison: "
+            f"**{_fmt(results['R4']['asymptotic_log_decay_comparison']['pass'])}**.",
+            "",
+            str(results["R4"].get("interpretation_caveat", "")),
+            "",
+            "## R5 - E7a derived-quantity identification",
+            "",
+            _provenance(
+                results,
+                results["R5"].get("round1_seed_rule", "20260830 + replication"),
+            ),
+            "",
+            (
+                "R5 input provenance: unrestricted per-replication estimates came from "
+                "archived `results.json` with SHA-256 `"
+                f"{results['provenance']['round1_archive_observed_sha256']['results.json']}` "
+                "and embedded repository description `"
+                f"{results['R1']['round1_archive_tag']}`. They were transformed and their "
+                f"likelihoods replayed by exact tag `{results['provenance']['repository_tag']}`."
+            ),
+            "",
+            "### Derived bias and RMSE",
+            "",
+            r5_derived,
+            "### Covariance ridge",
+            "",
+            r5_eigen,
+            "### Oracle fixed-physical-kappa2 profile",
+            "",
+            r5_profile,
+            str(results["R5"].get("oracle_caveat", "")),
+            "",
+            str(results["R5"].get("interpretation_caveat", "")),
+            "",
+            "## Standing interpretation caveats",
+            "",
+        )
+    )
+    lines.extend(f"- {caveat}" for caveat in results["standing_caveats"])
+    lines.extend(
+        (
+            "",
+            "## Reproducibility and audit record",
+            "",
+            _provenance(results, "section-specific deterministic seed map"),
+            "",
+            f"- Full JSON audit record SHA-256: `{_sha256(json_path)}`.",
+            f"- Runtime: {_fmt(results['runtime_seconds'])} seconds.",
+            f"- R1 baseline exact tag: `{results['R1']['baseline_tag']}`.",
+            f"- Round-2 exact tag: `{results['provenance']['repository_tag']}`.",
+            "- The archived round-1 files were preserved; round-2 uses distinct filenames.",
+            "",
+        )
+    )
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _caption(figure: Figure, title: str, caption: str) -> None:
+    figure.suptitle(title, fontsize=14, weight="bold", y=0.985)
+    figure.text(
+        0.01,
+        0.008,
+        textwrap.fill(caption, width=145),
+        ha="left",
+        va="bottom",
+        fontsize=7.2,
+    )
+    figure.tight_layout(rect=(0.02, 0.11, 0.98, 0.94))
+
+
+def _write_round2_cover(results: Mapping[str, Any], pdf: PdfPages) -> None:
+    figure = plt.figure(figsize=(8.27, 11.69))
+    figure.text(
+        0.08,
+        0.91,
+        textwrap.fill(str(results["title"]), width=48),
+        fontsize=19,
+        weight="bold",
+        va="top",
+    )
+    figure.text(0.08, 0.82, f"Profile: {results['profile']}", fontsize=11, va="top")
+    figure.text(
+        0.08,
+        0.75,
+        textwrap.fill(
+            "Contradictions first: finite-step Q_LIMIT is martingale-preserving in "
+            "expectation; the requested R4 log-decay intercept omits c^2/2; the R5 "
+            "oracle profile is not an option-plus-d0 identification experiment.",
+            width=90,
+        ),
+        fontsize=11,
+        va="top",
+        color="#8b0000",
+    )
+    figure.text(
+        0.08,
+        0.64,
+        textwrap.fill(
+            _provenance(results, "section-specific seed map"),
+            width=95,
+        ),
+        fontsize=8.5,
+        va="top",
+    )
+    figure.text(
+        0.08,
+        0.48,
+        "Pages 2--9 reproduce the archived round-1 cover and E1--E7 figures.\n"
+        "The new R1--R5 diagnostic figures follow them.",
+        fontsize=10,
+        va="top",
+    )
+    pdf.savefig(figure)
+    plt.close(figure)
+
+
+def _plot_r1(results: Mapping[str, Any]) -> Figure:
+    rows = results["R1"]["rows"]
+    groups = ("E1", "E2", "E3", "E4")
+    values = []
+    labels = []
+    colors = []
+    for group in groups:
+        selected = [row for row in rows if row["item"].startswith(group)]
+        values.append(max(float(row["noise_statistic"]) for row in selected))
+        labels.append(group)
+        colors.append("#2a9d8f" if all(row["passed"] for row in selected) else "#e76f51")
+    figure, axis = plt.subplots(figsize=(11.0, 6.8))
+    bars = axis.bar(labels, values, color=colors)
+    for bar, value in zip(bars, values):
+        axis.text(
+            bar.get_x() + bar.get_width() / 2, value, f"{value:.3g}", ha="center", va="bottom"
+        )
+    axis.axhline(3.0, color="black", linestyle="--", label="3-SE criterion (E1/E2/E4)")
+    axis.axhline(0.10, color="gray", linestyle=":", label="E3 absolute tolerance")
+    axis.set(ylabel="Maximum stability statistic", title="Clean-tag repeat versus round 1")
+    axis.legend()
+    _caption(
+        figure,
+        "R1 - blocking clean-tag stability gate",
+        _provenance(results, "20260824--20260830")
+        + " E3 is on an absolute-error-difference scale; the others are combined-SE ratios.",
+    )
+    return figure
+
+
+def _r2_value(row: Mapping[str, Any], *names: str) -> float:
+    for name in names:
+        if row.get(name) is not None:
+            return float(row[name])
+    return float("nan")
+
+
+def _plot_r2(results: Mapping[str, Any]) -> Figure:
+    section = results["R2"]
+    rows = _r2_rows(section)
+    figure, axes = plt.subplots(1, 2, figsize=(11.0, 6.8), squeeze=False)
+    for axis, maturity in zip(axes[0], sorted({row.get("maturity") for row in rows})):
+        subset = [row for row in rows if row.get("maturity") == maturity]
+        for measure, linestyle in (("Q_LIMIT", "-"), ("Q_EXACT", "--")):
+            measure_rows = [row for row in subset if row.get("measure") == measure]
+            kappas = (
+                sorted({float(row["kappa2_hat"]) for row in measure_rows})
+                if measure == "Q_LIMIT"
+                else [None]
+            )
+            for kappa in kappas:
+                group = sorted(
+                    (
+                        row
+                        for row in measure_rows
+                        if kappa is None or float(row["kappa2_hat"]) == kappa
+                    ),
+                    key=lambda row: float(row["dt"]),
+                )
+                if not group:
+                    continue
+                x = [float(row["dt"]) for row in group]
+                y = [float(row["defect"]) for row in group]
+                lower = [_r2_value(row, "bootstrap_ci_lower", "ci_lower") for row in group]
+                upper = [_r2_value(row, "bootstrap_ci_upper", "ci_upper") for row in group]
+                label = measure if kappa is None else f"{measure}, k2={kappa:g}"
+                axis.plot(x, y, marker="o", linestyle=linestyle, label=label)
+                if np.all(np.isfinite(lower)) and np.all(np.isfinite(upper)):
+                    axis.fill_between(x, lower, upper, alpha=0.10)
+        axis.axhline(0.0, color="black", linewidth=0.8)
+        axis.set(
+            xscale="log",
+            xlabel="dt (years)",
+            ylabel="Empirical discounted-spot defect",
+            title=f"T={maturity:g}",
+        )
+        axis.legend(fontsize=6.2, ncols=2)
+    _caption(
+        figure,
+        "R2 - fixed-budget martingale diagnostic",
+        _provenance(results, _section_seed(section))
+        + " Finite-dt expectation is exactly zero defect; intervals describe observed "
+        "finite-N sampling only.",
+    )
+    return figure
+
+
+def _plot_r3(results: Mapping[str, Any]) -> Figure:
+    section = results["R3"]
+    cells = _r3_cell_rows(section)
+    crossings = _r3_crossing_rows(section)
+    kappas = sorted({float(row["kappa2_hat"]) for row in cells})
+    powers = sorted({float(row["power"]) for row in cells})
+    slope = np.full((len(powers), len(kappas)), np.nan)
+    for row in cells:
+        slope[powers.index(float(row["power"])), kappas.index(float(row["kappa2_hat"]))] = (
+            _r2_value(row, "slope", "log_moment_slope")
+        )
+    figure, axis = plt.subplots(figsize=(11.0, 7.2))
+    finite = slope[np.isfinite(slope)]
+    limit = max(float(np.max(np.abs(finite))) if finite.size else 1.0, 1.0e-6)
+    image = axis.imshow(
+        slope,
+        origin="lower",
+        aspect="auto",
+        extent=(min(kappas) - 0.25, max(kappas) + 0.25, min(powers) - 0.05, max(powers) + 0.05),
+        cmap="RdBu_r",
+        norm=TwoSlopeNorm(vmin=-limit, vcenter=0.0, vmax=limit),
+    )
+    figure.colorbar(image, ax=axis, label="Slope of log moment vs log(1/dt)")
+    empirical = [row for row in crossings if row.get("crossing_power") is not None]
+    if empirical:
+        x = np.asarray([float(row["kappa2_hat"]) for row in empirical])
+        y = np.asarray([float(row["crossing_power"]) for row in empirical])
+        axis.plot(x, y, color="black", marker="o", linewidth=2.0, label="empirical crossing p*(k2)")
+        lower = np.asarray([_r2_value(row, "bootstrap_ci_lower", "ci_lower") for row in empirical])
+        upper = np.asarray([_r2_value(row, "bootstrap_ci_upper", "ci_upper") for row in empirical])
+        if np.all(np.isfinite(lower)) and np.all(np.isfinite(upper)):
+            axis.fill_between(x, lower, upper, color="black", alpha=0.15)
+    sufficient = [row for row in crossings if row.get("sufficient_crossing_power") is not None]
+    if sufficient:
+        axis.plot(
+            [float(row["kappa2_hat"]) for row in sufficient],
+            [float(row["sufficient_crossing_power"]) for row in sufficient],
+            color="#f4a261",
+            marker="s",
+            linestyle="--",
+            linewidth=2.0,
+            label="inverted sufficient curve",
+        )
+    axis.set(
+        xlabel="kappa2_hat",
+        ylabel="moment power p",
+        title="Empirical growth boundary and sufficient region",
+    )
+    axis.set_xticks(kappas)
+    axis.set_yticks(powers)
+    axis.legend(loc="best")
+    _caption(
+        figure,
+        "R3 - E4b empirical critical curve",
+        _provenance(results, _section_seed(section))
+        + " Slopes use dt<=1/252; bootstrap classifications are pointwise. The "
+        "sufficient curve is sufficient, not necessary. Unresolved tail cells="
+        f"{section['tail_diagnostics']['unresolved_cell_count']}; floor hits="
+        f"{section['floor_diagnostics']['floor_hits_total']}. Crossing curves remain "
+        "diagnostics, not accepted boundaries, whenever either flag is nonzero.",
+    )
+    return figure
+
+
+def _plot_r4(results: Mapping[str, Any]) -> Figure:
+    section = results["R4"]
+    records = _rows(section, "records")
+    names = sorted({str(row["parameter_set"]) for row in records})
+    figure, axes = plt.subplots(1, 2, figsize=(11.0, 6.8), squeeze=False)
+    for name in names:
+        group = sorted(
+            (row for row in records if row["parameter_set"] == name),
+            key=lambda row: row["dt_observation_mean"],
+        )
+        dt = np.asarray([row["dt_observation_mean"] for row in group])
+        axes[0, 0].plot(
+            dt, [row["rmse_correct_start"] for row in group], marker="o", label=f"{name}: observed"
+        )
+        axes[0, 0].plot(
+            dt,
+            [row["rmse_predicted_actual_sigma_bar"] for row in group],
+            linestyle="--",
+            label=f"{name}: formula",
+        )
+        x = 1.0 / np.sqrt(dt)
+        axes[0, 1].plot(
+            x, [row["forgetting_rate"] for row in group], marker="o", label=f"{name}: observed"
+        )
+        axes[0, 1].plot(
+            x,
+            [row["forgetting_predicted_asymptotic_log_decay"] for row in group],
+            linestyle="--",
+            label=f"{name}: asymptotic log-decay",
+        )
+    axes[0, 0].set(
+        xscale="log",
+        yscale="log",
+        xlabel="dt (years)",
+        ylabel="Filter RMSE",
+        title="RMSE level and dt^1/4 law",
+    )
+    axes[0, 1].set(
+        xlabel="1/sqrt(dt)", ylabel="Forgetting rate", title="Wrong-start forgetting rate"
+    )
+    for axis in axes[0]:
+        axis.legend(fontsize=7)
+    _caption(
+        figure,
+        "R4 - E6a filter scaling laws",
+        _provenance(results, section.get("seed"))
+        + " Dashed forgetting lines use the corrected asymptotic log-decay intercept; "
+        "regressions use dt<=1/252.",
+    )
+    return figure
+
+
+def _plot_r5(results: Mapping[str, Any]) -> Figure:
+    section = results["R5"]
+    derived = _rows(section, "derived_summaries", "derived", "summaries")
+    profile = _rows(section, "profile_summaries", "profiled", "profile_results")
+    figure, axes = plt.subplots(1, 2, figsize=(11.0, 6.8), squeeze=False)
+    for name in sorted({str(row["parameter_set"]) for row in derived}):
+        for quantity in sorted(
+            {str(row["quantity"]) for row in derived if row["parameter_set"] == name}
+        ):
+            group = sorted(
+                (
+                    row
+                    for row in derived
+                    if row["parameter_set"] == name and row["quantity"] == quantity
+                ),
+                key=lambda row: row["years"],
+            )
+            axes[0, 0].plot(
+                [row["years"] for row in group],
+                [row["rmse"] for row in group],
+                marker="o",
+                label=f"{name}: {quantity}",
+            )
+    axes[0, 0].set(
+        yscale="log", xlabel="Sample years", ylabel="RMSE", title="Derived-quantity recovery"
+    )
+    axes[0, 0].legend(fontsize=6.2, ncols=2)
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in profile:
+        grouped.setdefault(str(row["parameter_set"]), []).append(row)
+    labels = []
+    values = []
+    for name, group in sorted(grouped.items()):
+        finest_year = max(float(row["years"]) for row in group)
+        for row in group:
+            if float(row["years"]) == finest_year and row.get("parameter") in ("kappa1", "theta"):
+                labels.append(f"{name}\n{row['parameter']}")
+                values.append(float(row.get("rmse_improvement_fraction", float("nan"))))
+    axes[0, 1].bar(labels, values, color="#457b9d")
+    axes[0, 1].axhline(0.0, color="black", linewidth=0.8)
+    axes[0, 1].set(
+        ylabel="RMSE improvement fraction",
+        title="Oracle fixed-physical-kappa2 fit (longest sample)",
+    )
+    _caption(
+        figure,
+        "R5 - E7a derived identification and oracle profile",
+        _provenance(
+            results,
+            section.get("round1_seed_rule", "20260830 + replication"),
+        )
+        + " The oracle experiment fixes physical kappa2 at truth; it is not an "
+        "option-identification result. Archived unrestricted input: "
+        f"{results['R1']['round1_archive_tag']}; transformation/replay: current exact tag.",
+    )
+    return figure
+
+
+def write_round2_figures_pdf(
+    results: Mapping[str, Any],
+    path: Path,
+    *,
+    round1_results: Mapping[str, Any],
+) -> None:
+    """Reproduce the round-one figure document, then append round-two pages."""
+    output = Path(path)
+    if output.suffix.lower() != ".pdf":
+        raise ValueError("Round-two figure output must end in .pdf")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with PdfPages(output) as pdf:
+        metadata = pdf.infodict()
+        metadata["Title"] = str(results["title"])
+        metadata["Subject"] = "TGARCH discrete-versus-continuous study, rounds 1 and 2"
+        _write_round2_cover(results, pdf)
+
+        round1_reporting._write_cover_page(round1_results, pdf)
+        for record in round1_reporting._study_figure_records(round1_results):
+            figure = record.figure() if callable(record.figure) else record.figure
+            caption = round1_reporting._add_caption(figure, record)
+            pdf.attach_note(record.caption)
+            pdf.savefig(figure, bbox_inches="tight")
+            caption.remove()
+            plt.close(figure)
+
+        for figure in (
+            _plot_r1(results),
+            _plot_r2(results),
+            _plot_r3(results),
+            _plot_r4(results),
+            _plot_r5(results),
+        ):
+            pdf.savefig(figure, bbox_inches="tight")
+            plt.close(figure)
+
+
+__all__ = [
+    "write_round2_figures_pdf",
+    "write_round2_markdown",
+    "write_round2_results_json",
+]

--- a/volatility_book/ch_discrete_vol/round3.py
+++ b/volatility_book/ch_discrete_vol/round3.py
@@ -26,14 +26,20 @@ from .round3_traceability import (
 )
 
 BASE_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_NOTES_DIR = BASE_DIR / "notes"
 ROUND3_BRIEF = DEFAULT_NOTES_DIR / "SOL_BRIEF_discrete_vs_continuous_tgarch_study_1.md"
 TRACKED_NOTE = DEFAULT_NOTES_DIR / "tgarch_quadratic_drift_note.tex"
-DEFAULT_BACKGROUND_NOTE = (
-    Path(r"C:\Users\artur\OneDrive\My Papers\Volatility Book 2026\My Reference Papers")
-    / "Chapter on Discrete Volatility Estimation. Zurich. Aug 2026"
-    / "tgarch_quadratic_drift_note.tex"
-)
+ACCEPTANCE_MANIFEST = BASE_DIR / "acceptance_manifest.json"
+DEFAULT_BACKGROUND_NOTE = TRACKED_NOTE
+DEFAULT_OUTPUT_ROOT = REPOSITORY_ROOT / "outputs" / "volatility_book" / "ch_discrete_vol"
+DEFAULT_ROUND1_JSON = DEFAULT_OUTPUT_ROOT / "round1" / "results.json"
+DEFAULT_ROUND2_JSON = DEFAULT_OUTPUT_ROOT / "round2" / "round2_results.json"
+_ROUND3_OUTPUT_NAMES = {
+    StudyProfile.FULL: "round3",
+    StudyProfile.REFERENCE: "round3_reference",
+    StudyProfile.SMOKE: "round3_smoke",
+}
 
 
 def _sha256(path: Path) -> str:
@@ -66,7 +72,15 @@ def _git(repository: Path, *arguments: str) -> str:
 
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[2]
+    return REPOSITORY_ROOT
+
+
+def _default_output_dir(profile: StudyProfile) -> Path:
+    """Return the ignored, profile-specific Round-3 artifact directory."""
+
+    if not isinstance(profile, StudyProfile):
+        raise ValueError("profile must be a StudyProfile")
+    return DEFAULT_OUTPUT_ROOT / _ROUND3_OUTPUT_NAMES[profile]
 
 
 def _execution_provenance(
@@ -85,7 +99,11 @@ def _execution_provenance(
     if profile is StudyProfile.FULL and not tag:
         raise RuntimeError("Round 3 FULL must run from an exactly tagged commit")
 
-    executed_inputs = sorted(BASE_DIR.glob("*.py")) + [ROUND3_BRIEF, TRACKED_NOTE]
+    executed_inputs = sorted(BASE_DIR.glob("*.py")) + [
+        ROUND3_BRIEF,
+        TRACKED_NOTE,
+        ACCEPTANCE_MANIFEST,
+    ]
     ledger: list[dict[str, Any]] = []
     for path in executed_inputs:
         relative = path.resolve().relative_to(repository.resolve()).as_posix()
@@ -137,6 +155,12 @@ def _execution_provenance(
         "profile": profile.value,
         "package_versions": package_versions,
         "executed_inputs": ledger,
+        "acceptance_manifest": {
+            "path": ACCEPTANCE_MANIFEST.resolve()
+            .relative_to(repository.resolve())
+            .as_posix(),
+            "sha256": _sha256(ACCEPTANCE_MANIFEST),
+        },
         "background_note": {
             "absolute_path": str(background),
             "sha256": background_hash,
@@ -444,9 +468,24 @@ def _parse_args() -> argparse.Namespace:
         choices=[item.value for item in StudyProfile],
         default=StudyProfile.SMOKE.value,
     )
-    parser.add_argument("--output-dir", type=Path, default=DEFAULT_NOTES_DIR)
-    parser.add_argument("--round1-json", type=Path)
-    parser.add_argument("--round2-json", type=Path)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help=(
+            "Artifact directory. Defaults under outputs/volatility_book/ch_discrete_vol "
+            "to round3, round3_reference, or round3_smoke according to --profile."
+        ),
+    )
+    parser.add_argument(
+        "--round1-json",
+        type=Path,
+        help=f"Round-1 FULL archive (default: {DEFAULT_ROUND1_JSON}).",
+    )
+    parser.add_argument(
+        "--round2-json",
+        type=Path,
+        help=f"Round-2 FULL archive (default: {DEFAULT_ROUND2_JSON}).",
+    )
     parser.add_argument("--background-note", type=Path, default=DEFAULT_BACKGROUND_NOTE)
     return parser.parse_args()
 
@@ -455,15 +494,20 @@ def main() -> None:
     """Execute the command-line-selected round-three workload."""
 
     arguments = _parse_args()
-    output = Path(arguments.output_dir)
+    profile = StudyProfile(arguments.profile)
+    output = (
+        Path(arguments.output_dir)
+        if arguments.output_dir is not None
+        else _default_output_dir(profile)
+    )
     run_round3(
         output_dir=output,
-        profile=StudyProfile(arguments.profile),
+        profile=profile,
         round1_json=(
-            Path(arguments.round1_json) if arguments.round1_json else output / "results.json"
+            Path(arguments.round1_json) if arguments.round1_json else DEFAULT_ROUND1_JSON
         ),
         round2_json=(
-            Path(arguments.round2_json) if arguments.round2_json else output / "round2_results.json"
+            Path(arguments.round2_json) if arguments.round2_json else DEFAULT_ROUND2_JSON
         ),
         background_note=arguments.background_note,
     )

--- a/volatility_book/ch_discrete_vol/round3.py
+++ b/volatility_book/ch_discrete_vol/round3.py
@@ -1,0 +1,476 @@
+"""Round-three execution harness for the discrete-versus-continuous TGARCH study."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from .experiments import StudyProfile, parameter_sets
+from .round3_e8 import run_round3_e8
+from .round3_r7 import run_round3_r7
+from .round3_reporting import (
+    write_round3_figures_pdf,
+    write_round3_markdown,
+    write_round3_results_json,
+)
+from .round3_traceability import (
+    build_cited_numbers_manifest,
+    check_cited_numbers_manifest,
+    run_round3_r6,
+)
+
+BASE_DIR = Path(__file__).resolve().parent
+DEFAULT_NOTES_DIR = BASE_DIR / "notes"
+ROUND3_BRIEF = DEFAULT_NOTES_DIR / "SOL_BRIEF_discrete_vs_continuous_tgarch_study_1.md"
+TRACKED_NOTE = DEFAULT_NOTES_DIR / "tgarch_quadratic_drift_note.tex"
+DEFAULT_BACKGROUND_NOTE = (
+    Path(r"C:\Users\artur\OneDrive\My Papers\Volatility Book 2026\My Reference Papers")
+    / "Chapter on Discrete Volatility Estimation. Zurich. Aug 2026"
+    / "tgarch_quadratic_drift_note.tex"
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    source = Path(path).resolve()
+    with source.open("r", encoding="utf-8") as stream:
+        value = json.load(stream)
+    if not isinstance(value, dict):
+        raise ValueError(f"expected a JSON object in {source}")
+    value["_results_sha256"] = _sha256(source)
+    value["_results_absolute_path"] = str(source)
+    return value
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ["git", "-c", "safe.directory=*", "-C", str(repository), *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _execution_provenance(
+    *,
+    profile: StudyProfile,
+    background_note: Path,
+) -> dict[str, Any]:
+    repository = _repo_root()
+    status = _git(repository, "status", "--short", "--untracked-files=all")
+    try:
+        tag = _git(repository, "describe", "--tags", "--exact-match", "HEAD")
+    except subprocess.CalledProcessError:
+        tag = ""
+    if profile is StudyProfile.FULL and status:
+        raise RuntimeError("Round 3 FULL must run from a clean worktree:\n" + status)
+    if profile is StudyProfile.FULL and not tag:
+        raise RuntimeError("Round 3 FULL must run from an exactly tagged commit")
+
+    executed_inputs = sorted(BASE_DIR.glob("*.py")) + [ROUND3_BRIEF, TRACKED_NOTE]
+    ledger: list[dict[str, Any]] = []
+    for path in executed_inputs:
+        relative = path.resolve().relative_to(repository.resolve()).as_posix()
+        tracked = True
+        head_blob = ""
+        working_blob = ""
+        try:
+            _git(repository, "ls-files", "--error-unmatch", relative)
+            head_blob = _git(repository, "rev-parse", f"HEAD:{relative}")
+            working_blob = _git(repository, "hash-object", str(path))
+        except subprocess.CalledProcessError:
+            tracked = False
+        if profile is StudyProfile.FULL and not tracked:
+            raise RuntimeError(f"Executed round-three input is not tracked: {relative}")
+        if profile is StudyProfile.FULL and head_blob != working_blob:
+            raise RuntimeError(f"Executed round-three input differs from tagged HEAD: {relative}")
+        ledger.append(
+            {
+                "path": relative,
+                "sha256": _sha256(path),
+                "tracked": tracked,
+                "head_blob": head_blob or None,
+                "working_blob": working_blob or None,
+            }
+        )
+
+    background = Path(background_note).resolve()
+    if not background.is_file():
+        raise FileNotFoundError(f"background note does not exist: {background}")
+    background_hash = _sha256(background)
+    tracked_hash = _sha256(TRACKED_NOTE)
+    if background_hash != tracked_hash:
+        raise RuntimeError(
+            "External background note and the tracked study copy differ; validation would "
+            "not describe the exact tagged source"
+        )
+    package_versions: dict[str, str] = {}
+    for package in ("numpy", "scipy", "matplotlib", "numba", "stochvolmodels"):
+        try:
+            package_versions[package] = importlib.metadata.version(package)
+        except importlib.metadata.PackageNotFoundError:
+            package_versions[package] = "source-tree/uninstalled"
+    adjacent_pdf = background.with_suffix(".pdf")
+    return {
+        "script": Path(__file__).resolve().relative_to(repository.resolve()).as_posix(),
+        "repository_head": _git(repository, "rev-parse", "HEAD"),
+        "repository_tag": tag,
+        "repository_status": status,
+        "profile": profile.value,
+        "package_versions": package_versions,
+        "executed_inputs": ledger,
+        "background_note": {
+            "absolute_path": str(background),
+            "sha256": background_hash,
+            "tracked_copy": TRACKED_NOTE.resolve().relative_to(repository.resolve()).as_posix(),
+            "tracked_copy_sha256": tracked_hash,
+            "adjacent_pdf": str(adjacent_pdf),
+            "adjacent_pdf_sha256": _sha256(adjacent_pdf) if adjacent_pdf.is_file() else None,
+        },
+    }
+
+
+def _note_validation(provenance: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "source_sha256_before": provenance["background_note"]["sha256"],
+        "source_path": provenance["background_note"]["absolute_path"],
+        "adjacent_pdf_path": provenance["background_note"]["adjacent_pdf"],
+        "adjacent_pdf_sha256": provenance["background_note"]["adjacent_pdf_sha256"],
+        "adjacent_pdf_stale_revision_2": True,
+        "compiled_revision_3_successfully": True,
+        "compiled_pdf_pages": 11,
+        "visual_inspection_all_pages": True,
+        "compiler": "MiKTeX pdfTeX 1.40.29; two passes; cross-references resolved",
+        "layout_findings": [
+            "No clipping, overlap, missing glyphs, or unreadable tables on the 11 rendered pages.",
+            "One 9.78 pt overfull abstract line and two underfull footnote boxes are cosmetic.",
+        ],
+        "findings": [
+            {
+                "location": "TeX 540--544",
+                "severity": "mathematical typo",
+                "finding": (
+                    "The pre-validation drift-map proof dropped sqrt(Delta). It now uses "
+                    "E_Q[u]=sqrt(Delta)Lambda+O(Delta), equivalently "
+                    "sigma*sqrt(Delta)*E_Q[u]=sigma*Lambda*Delta+O(Delta^(3/2))."
+                ),
+            },
+            {
+                "location": "TeX 833--835",
+                "severity": "numerical contradiction",
+                "finding": (
+                    "Daily E3 errors are 5.63% and 8.69%; at dt=1/1008 they are 2.95% "
+                    "and 6.42%. The pre-validation 3--9% daily range and rough-halving "
+                    "claim were corrected."
+                ),
+            },
+            {
+                "location": "TeX 843--857",
+                "severity": "scope/identification",
+                "finding": (
+                    "R5 percentages are forty-year relative RMSEs and its cosine is a "
+                    "conditional local diagnostic. The note now frames R8 as an oracle "
+                    "upper bound, not achieved option-plus-d0 identification."
+                ),
+            },
+            {
+                "location": "TeX 878--885",
+                "severity": "scope",
+                "finding": (
+                    "The note now identifies 0.22/0.08 as finest-step results and limits "
+                    "the kappa2_hat>=2 zero-compatibility statement to dt<=1/1008."
+                ),
+            },
+            {
+                "location": "TeX 891--893",
+                "severity": "logical overstatement",
+                "finding": (
+                    "The corrected text states that a uniform superlinear moment bound is "
+                    "stronger than the continuous true-martingale property."
+                ),
+            },
+            {
+                "location": "TeX 46 and adjacent PDF",
+                "severity": "artifact mismatch",
+                "finding": (
+                    "The pre-validation source footnote said revision 2 and its adjacent "
+                    "PDF was stale. Both have been replaced by the validated revision-3 build."
+                ),
+            },
+        ],
+    }
+
+
+def _contradictions(
+    r6: dict[str, Any],
+    r7: dict[str, Any],
+    r8: dict[str, Any],
+    r9: dict[str, Any],
+) -> list[dict[str, str]]:
+    items = [
+        {
+            "item": "Pre-validation revision-3 E3 prose",
+            "finding": (
+                "The note's daily 3--9% range and rough-halving statement is contradicted "
+                "by its archive: daily is 5.63--8.69%, versus 2.95--6.42% at dt=1/1008."
+            ),
+        },
+        {
+            "item": "Drift-map proof line",
+            "finding": (
+                "The theorem was correct, but the pre-validation proof omitted sqrt(Delta) "
+                "in one identity. The corrected proof is dimensionally consistent."
+            ),
+        },
+        {
+            "item": "Pre-validation R5 option-plus-d0 interpretation",
+            "finding": (
+                "R5 fixed physical kappa2 only. The corrected note uses R8 as the honest "
+                "kappa2-and-d0 oracle upper bound and does not claim achieved option "
+                "identification."
+            ),
+        },
+        {
+            "item": "Pre-validation R2 scope",
+            "finding": (
+                "The original wording overgeneralized finest-step shortfalls and "
+                "zero-compatibility for kappa2_hat>=2. The corrected note states the grid scope."
+            ),
+        },
+        {
+            "item": "Pre-validation uniform moment claim",
+            "finding": (
+                "The corrected note states that a uniform 1+epsilon moment bound is strictly "
+                "stronger than the continuous true-martingale result."
+            ),
+        },
+    ]
+    if not r6["blocking_requirement_satisfied"]:
+        items.append(
+            {
+                "item": "R6 blocking traceability",
+                "finding": (
+                    "The full-budget clean-tag E1 gate failed; later round-3 work is non-closing."
+                ),
+            }
+        )
+    if not r7["checks"]["expected_descriptive_pattern_observed"]:
+        items.append(
+            {
+                "item": "R7 expected budget pattern",
+                "finding": (
+                    "The finest-step kappa2_hat=0.5 curve is nonmonotone and does not show "
+                    "positive net shrinkage. Both kappa2_hat=0 curves shrink at the endpoints, "
+                    "and every kappa2_hat=2 budget interval contains zero."
+                ),
+            }
+        )
+    dominance = r8["nested_profile_likelihood_dominance"]
+    if not dominance["all_rung_c_not_above_rung_b_within_tolerance"]:
+        items.append(
+            {
+                "item": "Archived R5 parent optimum",
+                "finding": (
+                    "One rung-(c) likelihood exceeds its archived rung-(b) parent because "
+                    "the archived local optimizer missed the parent-profile optimum."
+                ),
+            }
+        )
+    if not r9["note_claims_all_supported"]:
+        items.append(
+            {
+                "item": "R9 cited-number claims",
+                "finding": (
+                    "The machine check rejects at least one current note claim; raw numbers "
+                    "and pointers are retained without overwrite."
+                ),
+            }
+        )
+    return items
+
+
+def run_round3(
+    *,
+    output_dir: Path,
+    profile: StudyProfile,
+    round1_json: Path,
+    round2_json: Path,
+    background_note: Path = DEFAULT_BACKGROUND_NOTE,
+) -> dict[str, Any]:
+    """Execute R6 first, then R7/R8/R9, and write the round-three artifacts."""
+
+    if not isinstance(profile, StudyProfile):
+        raise ValueError("profile must be a StudyProfile")
+    started = time.perf_counter()
+    output = Path(output_dir).resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    provenance = _execution_provenance(profile=profile, background_note=Path(background_note))
+    round1 = _load_json(round1_json)
+    round2 = _load_json(round2_json)
+    suffix = "" if profile is StudyProfile.FULL else f"_{profile.value}"
+    samples_path = output / f"e3_stationary_samples_round3{suffix}.npz"
+
+    r6 = run_round3_r6(round1, profile=profile, samples_path=samples_path)
+    if profile is StudyProfile.FULL and not r6["blocking_requirement_satisfied"]:
+        failure_path = output / "round3_r6_failure.json"
+        write_round3_results_json(
+            {
+                "title": "Round 3 stopped at R6",
+                "profile": profile.value,
+                "R6": r6,
+                "provenance": provenance,
+            },
+            failure_path,
+        )
+        raise RuntimeError(f"R6 blocking gate failed; details written to {failure_path}")
+
+    params = parameter_sets()
+    print(f"[TGARCH round 3] R7 ({profile.value}): start", flush=True)
+    r7 = run_round3_r7(params["crypto"], profile.value, parameter_set="crypto")
+    print(f"[TGARCH round 3] R8 ({profile.value}): start", flush=True)
+    r8 = run_round3_e8(round1, round2, params, profile)
+
+    results: dict[str, Any] = {
+        "title": "Discrete versus continuous log-normal beta SV study — round 3",
+        "profile": profile.value,
+        "conventions": {
+            "volatility_and_rates": "annualized",
+            "time_and_dt": "years",
+            "returns": "log returns",
+            "kernel_loading_scaling": "square-root time-step scaling",
+        },
+        "R6": r6,
+        "R7": r7,
+        "R8": r8,
+        "R10": {
+            "status": "NOT RUN",
+            "reason": "The brief requires the explicit word 'go'; it was not supplied.",
+        },
+        "note_validation": _note_validation(provenance),
+        "standing_caveats": [
+            (
+                "All convergence statements are relative to the square-root step scaling "
+                "of the kernel loadings."
+            ),
+            ("Nothing transfers statistical inference between the discrete and continuous models."),
+        ],
+        "provenance": provenance,
+    }
+
+    manifest_path = output / f"cited_numbers{suffix}.json"
+    if profile is StudyProfile.FULL:
+        manifest = build_cited_numbers_manifest(
+            round1=round1,
+            round2=round2,
+            round3=results,
+            output_path=manifest_path,
+            archive_file_names={
+                "round1": Path(round1_json).name,
+                "round2": Path(round2_json).name,
+                "round3": "round3_results.json",
+            },
+        )
+        manifest_check = check_cited_numbers_manifest(
+            manifest,
+            round1=round1,
+            round2=round2,
+            round3=results,
+        )
+        summary = manifest["automatic_check_summary"]
+        results["R9"] = {
+            **summary,
+            **manifest_check,
+            "manifest_file": manifest_path.name,
+            "manifest_sha256": _sha256(manifest_path),
+            "unsupported_claim_ids": summary["unsupported_claim_ids"],
+        }
+    else:
+        skipped = {
+            "status": "NOT EVALUATED",
+            "reason": "R9 resolves the full-budget R6 schema and is executed only at FULL profile.",
+        }
+        write_round3_results_json(skipped, manifest_path)
+        results["R9"] = {
+            "all_pointers_resolved": False,
+            "note_claims_all_supported": False,
+            "citation_count": 0,
+            "claim_check_count": 0,
+            "unsupported_claim_ids": ["profile_not_full"],
+            "manifest_file": manifest_path.name,
+            "manifest_sha256": _sha256(manifest_path),
+            "status": "NOT EVALUATED",
+        }
+    results["contradictions"] = _contradictions(r6, r7, r8, results["R9"])
+    results["runtime_seconds"] = time.perf_counter() - started
+
+    json_path = output / ("round3_results.json" if not suffix else f"round3{suffix}_results.json")
+    markdown_path = output / ("round3_results.md" if not suffix else f"round3{suffix}_results.md")
+    figures_path = output / ("round3_figures.pdf" if not suffix else f"round3{suffix}_figures.pdf")
+    write_round3_results_json(results, json_path)
+    write_round3_figures_pdf(results, figures_path)
+    write_round3_markdown(
+        results,
+        markdown_path,
+        json_path=json_path,
+        manifest_path=manifest_path,
+        figures_path=figures_path,
+    )
+    print(f"[TGARCH round 3] artifacts written to {output}", flush=True)
+    return results
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile",
+        choices=[item.value for item in StudyProfile],
+        default=StudyProfile.SMOKE.value,
+    )
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_NOTES_DIR)
+    parser.add_argument("--round1-json", type=Path)
+    parser.add_argument("--round2-json", type=Path)
+    parser.add_argument("--background-note", type=Path, default=DEFAULT_BACKGROUND_NOTE)
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Execute the command-line-selected round-three workload."""
+
+    arguments = _parse_args()
+    output = Path(arguments.output_dir)
+    run_round3(
+        output_dir=output,
+        profile=StudyProfile(arguments.profile),
+        round1_json=(
+            Path(arguments.round1_json) if arguments.round1_json else output / "results.json"
+        ),
+        round2_json=(
+            Path(arguments.round2_json) if arguments.round2_json else output / "round2_results.json"
+        ),
+        background_note=arguments.background_note,
+    )
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = ["run_round3"]

--- a/volatility_book/ch_discrete_vol/round3_e8.py
+++ b/volatility_book/ch_discrete_vol/round3_e8.py
@@ -1,0 +1,843 @@
+"""Round-3 R8 honest oracle ladder for TGARCH drift identification.
+
+The experiment adds one constrained QMLE rung to the round-2 R5 profile:
+
+``(a)`` unrestricted, read from the immutable round-1 per-replication archive;
+``(b)`` physical ``kappa2`` fixed at truth, read from the round-2 R5 archive; and
+``(c)`` physical ``kappa2`` and ``d0 = kappa1 * theta`` fixed at truth, fitted here
+with ``kappa1 = d0 / theta``.
+
+Only rung (c) is re-estimated.  Each regenerated path first replays the archived
+likelihoods for rungs (a) and (b), and each selected source row receives a stable
+content hash.  The result is an oracle simulation diagnostic, not an option-data
+estimator.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import time
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+from scipy.optimize import OptimizeResult, minimize
+
+from volatility_book.ch_discrete_vol import experiments as round1
+from volatility_book.ch_discrete_vol import round2_e7
+from volatility_book.ch_discrete_vol.sim import Measure, TgarchParams, simulate_discrete_path
+
+_PARAMETER_NAMES = ("kappa1", "kappa2", "theta", "beta", "eps", "gamma1")
+_EXPECTED_YEARS = (5, 10, 20, 40)
+_RUNG_C_FREE_NAMES = ("theta", "beta", "eps", "gamma1")
+_NATURAL_BOUNDS = {
+    "kappa1": (0.1, 20.0),
+    "theta": (0.03, 2.5),
+    "beta": (-3.0, 3.0),
+    "eps": (0.05, 4.0),
+    "gamma1": (-2.0, 2.0),
+}
+_REPLAY_ATOL = 1.0e-7
+_REPLAY_RTOL = 1.0e-10
+_PROFILE_DOMINANCE_ATOL = 1.0e-3
+
+
+def _field(value: object, name: str) -> Any:
+    return round2_e7._field(value, name)
+
+
+def _json_ready(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _json_ready(item) for key, item in sorted(value.items())}
+    if isinstance(value, np.ndarray):
+        return [_json_ready(item) for item in value.tolist()]
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    if hasattr(value, "value") and isinstance(value.value, (str, int, float, bool)):
+        return value.value
+    return value
+
+
+def _json_sha256(value: Any) -> str:
+    payload = json.dumps(
+        _json_ready(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _optional_mapping(value: object, name: str) -> Mapping[str, Any]:
+    try:
+        candidate = _field(value, name)
+    except ValueError:
+        return {}
+    return candidate if isinstance(candidate, Mapping) else {}
+
+
+def _r5_results(round2_results: object) -> object:
+    if isinstance(round2_results, Mapping) and "R5" in round2_results:
+        return round2_results["R5"]
+    if hasattr(round2_results, "R5"):
+        return getattr(round2_results, "R5")
+    if isinstance(round2_results, Mapping) and "profile_estimates" in round2_results:
+        return round2_results
+    raise ValueError("round2_results must be the round-2 archive or its R5 mapping")
+
+
+def _validated_profile_estimate(row: Mapping[str, Any]) -> np.ndarray:
+    estimate = np.asarray(row.get("estimate"), dtype=np.float64)
+    if estimate.shape != (6,) or not np.all(np.isfinite(estimate)):
+        raise ValueError("each round-2 R5 profile estimate must contain six finite values")
+    if np.any(estimate[[0, 1, 2, 4]] <= 0.0):
+        raise ValueError("round-2 R5 kappa1, kappa2, theta, and eps must be positive")
+    return estimate
+
+
+def _round2_rows(
+    round2_results: object,
+    parameter_sets: Sequence[str],
+    replications: Sequence[int],
+) -> tuple[dict[tuple[str, int, int], Mapping[str, Any]], object]:
+    r5 = _r5_results(round2_results)
+    rows = _field(r5, "profile_estimates")
+    if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes)):
+        raise ValueError("round2_results R5 profile_estimates must be a sequence")
+
+    wanted_names = set(parameter_sets)
+    wanted_replications = set(replications)
+    indexed: dict[tuple[str, int, int], Mapping[str, Any]] = {}
+    for raw_row in rows:
+        if not isinstance(raw_row, Mapping):
+            raise ValueError("each round-2 R5 profile estimate must be a mapping")
+        name = str(raw_row.get("parameter_set"))
+        replication = int(raw_row.get("replication"))
+        if name not in wanted_names or replication not in wanted_replications:
+            continue
+        years = int(raw_row.get("years"))
+        if years not in _EXPECTED_YEARS:
+            continue
+        _validated_profile_estimate(raw_row)
+        key = (name, years, replication)
+        if key in indexed:
+            raise ValueError(f"duplicate round-2 R5 profile key: {key}")
+        indexed[key] = raw_row
+
+    expected = {
+        (name, years, replication)
+        for name in parameter_sets
+        for years in _EXPECTED_YEARS
+        for replication in replications
+    }
+    missing = sorted(expected.difference(indexed))
+    if missing:
+        raise ValueError(f"round-2 R5 is missing {len(missing)} selected profile rows")
+    return indexed, r5
+
+
+def _natural_truth(params: TgarchParams) -> np.ndarray:
+    return round2_e7._natural_truth(params)
+
+
+def _effective_theta_bounds(fixed_d0: float) -> tuple[float, float]:
+    kappa1_lower, kappa1_upper = _NATURAL_BOUNDS["kappa1"]
+    theta_lower, theta_upper = _NATURAL_BOUNDS["theta"]
+    lower = max(theta_lower, fixed_d0 / kappa1_upper)
+    upper = min(theta_upper, fixed_d0 / kappa1_lower)
+    if not (math.isfinite(lower) and math.isfinite(upper) and 0.0 < lower < upper):
+        raise ValueError(f"fixed d0={fixed_d0} leaves no feasible theta interval")
+    return lower, upper
+
+
+def _full_transformed(
+    free: np.ndarray,
+    *,
+    fixed_kappa2: float,
+    fixed_d0: float,
+) -> np.ndarray:
+    log_theta, beta, log_eps, gamma1 = free
+    return np.array(
+        (
+            math.log(fixed_d0) - log_theta,
+            math.log(fixed_kappa2),
+            log_theta,
+            beta,
+            log_eps,
+            gamma1,
+        ),
+        dtype=np.float64,
+    )
+
+
+def _free_start(natural: np.ndarray, theta_bounds: tuple[float, float]) -> np.ndarray:
+    theta = float(np.clip(natural[2], *theta_bounds))
+    beta = float(np.clip(natural[3], *_NATURAL_BOUNDS["beta"]))
+    eps = float(np.clip(natural[4], *_NATURAL_BOUNDS["eps"]))
+    gamma1 = float(np.clip(natural[5], *_NATURAL_BOUNDS["gamma1"]))
+    return np.array((math.log(theta), beta, math.log(eps), gamma1), dtype=np.float64)
+
+
+def _fit_fixed_physical_kappa2_and_d0(
+    log_returns: np.ndarray,
+    *,
+    dt: float,
+    r: float,
+    fixed_kappa2: float,
+    fixed_d0: float,
+    round2_start: np.ndarray,
+    unrestricted_start: np.ndarray,
+    truth_start: np.ndarray,
+) -> tuple[np.ndarray, OptimizeResult, float, str, int, tuple[float, float]]:
+    theta_bounds = _effective_theta_bounds(fixed_d0)
+    bounds = (
+        (math.log(theta_bounds[0]), math.log(theta_bounds[1])),
+        _NATURAL_BOUNDS["beta"],
+        (math.log(_NATURAL_BOUNDS["eps"][0]), math.log(_NATURAL_BOUNDS["eps"][1])),
+        _NATURAL_BOUNDS["gamma1"],
+    )
+
+    def objective(free: np.ndarray) -> float:
+        transformed = _full_transformed(
+            free,
+            fixed_kappa2=fixed_kappa2,
+            fixed_d0=fixed_d0,
+        )
+        values = round1._qmle_observations(transformed, log_returns, dt, r)
+        result = -float(np.mean(values))
+        return result if np.isfinite(result) else 1.0e12
+
+    candidates = (
+        ("round2_fixed_kappa2_projected", round2_start),
+        ("round1_unrestricted_projected", unrestricted_start),
+        ("truth_biased_projected", truth_start),
+    )
+    fitted_candidates: list[tuple[str, OptimizeResult, float]] = []
+    seen_starts: list[np.ndarray] = []
+    for label, natural_start in candidates:
+        transformed_start = _free_start(natural_start, theta_bounds)
+        if any(
+            np.allclose(transformed_start, seen, rtol=0.0, atol=1.0e-12) for seen in seen_starts
+        ):
+            continue
+        seen_starts.append(transformed_start)
+        fitted = minimize(
+            objective,
+            transformed_start,
+            method="L-BFGS-B",
+            bounds=bounds,
+            options={"maxiter": 350, "ftol": 1.0e-10, "gtol": 1.0e-6},
+        )
+        transformed = _full_transformed(
+            np.asarray(fitted.x, dtype=np.float64),
+            fixed_kappa2=fixed_kappa2,
+            fixed_d0=fixed_d0,
+        )
+        observations = round1._qmle_observations(transformed, log_returns, dt, r)
+        fitted_candidates.append((label, fitted, float(np.sum(observations))))
+
+    converged = [candidate for candidate in fitted_candidates if bool(candidate[1].success)]
+    eligible = converged if converged else fitted_candidates
+    label, fitted, log_likelihood = max(eligible, key=lambda candidate: candidate[2])
+    transformed = _full_transformed(
+        np.asarray(fitted.x, dtype=np.float64),
+        fixed_kappa2=fixed_kappa2,
+        fixed_d0=fixed_d0,
+    )
+    natural = round1._to_natural(transformed)
+    return natural, fitted, log_likelihood, label, len(fitted_candidates), theta_bounds
+
+
+def _natural_bound_hits(natural: np.ndarray) -> list[str]:
+    values = {
+        "kappa1": float(natural[0]),
+        "theta": float(natural[2]),
+        "beta": float(natural[3]),
+        "eps": float(natural[4]),
+        "gamma1": float(natural[5]),
+    }
+    hits: list[str] = []
+    for name, value in values.items():
+        lower, upper = _NATURAL_BOUNDS[name]
+        if np.isclose(value, lower, rtol=1.0e-6, atol=1.0e-8):
+            hits.append(f"{name}:lower")
+        if np.isclose(value, upper, rtol=1.0e-6, atol=1.0e-8):
+            hits.append(f"{name}:upper")
+    return hits
+
+
+def _free_coordinate_bound_hits(
+    natural: np.ndarray,
+    theta_bounds: tuple[float, float],
+) -> list[str]:
+    values_and_bounds = {
+        "theta": (float(natural[2]), theta_bounds),
+        "beta": (float(natural[3]), _NATURAL_BOUNDS["beta"]),
+        "eps": (float(natural[4]), _NATURAL_BOUNDS["eps"]),
+        "gamma1": (float(natural[5]), _NATURAL_BOUNDS["gamma1"]),
+    }
+    hits: list[str] = []
+    for name, (value, (lower, upper)) in values_and_bounds.items():
+        if np.isclose(value, lower, rtol=1.0e-6, atol=1.0e-8):
+            hits.append(f"{name}:effective_lower")
+        if np.isclose(value, upper, rtol=1.0e-6, atol=1.0e-8):
+            hits.append(f"{name}:effective_upper")
+    return hits
+
+
+def _replay_likelihood(
+    estimate: np.ndarray,
+    log_returns: np.ndarray,
+    *,
+    dt: float,
+    r: float,
+) -> float:
+    return float(
+        np.sum(
+            round1._qmle_observations(
+                round1._to_transformed(estimate),
+                log_returns,
+                dt,
+                r,
+            )
+        )
+    )
+
+
+def _replay_error(replayed: float, archived: float) -> tuple[float, float, bool]:
+    error = abs(replayed - archived)
+    tolerance = _REPLAY_ATOL + _REPLAY_RTOL * abs(archived)
+    return error, tolerance, error <= tolerance
+
+
+def _fit_profile(
+    selected_round1: Mapping[tuple[str, int, int], Mapping[str, Any]],
+    selected_round2: Mapping[tuple[str, int, int], Mapping[str, Any]],
+    params_by_name: Mapping[str, TgarchParams],
+    parameter_sets: Sequence[str],
+    replications: Sequence[int],
+    dt: float,
+) -> list[dict[str, Any]]:
+    estimates: list[dict[str, Any]] = []
+    maximum_years = float(max(_EXPECTED_YEARS))
+    for name in parameter_sets:
+        params = params_by_name[name]
+        truth = _natural_truth(params)
+        truth_start = round2_e7._optimizer_start(truth)
+        fixed_d0 = float(params.kappa1 * params.theta)
+        for replication in replications:
+            round1_group = [
+                selected_round1[(name, years, replication)] for years in _EXPECTED_YEARS
+            ]
+            seeds = {int(row["seed"]) for row in round1_group}
+            if len(seeds) != 1:
+                raise ValueError(
+                    f"round-1 E7 seeds differ across horizons for {name}, replication {replication}"
+                )
+            seed = seeds.pop()
+            path = simulate_discrete_path(
+                params=params,
+                measure=Measure.P,
+                dt=dt,
+                years=maximum_years,
+                seed=seed,
+            )
+            if not math.isclose(path.dt, dt, rel_tol=0.0, abs_tol=1.0e-15):
+                raise RuntimeError(f"regenerated path dt={path.dt} differs from E7 dt={dt}")
+            all_returns = np.diff(path.log_prices)
+
+            for years, round1_row in zip(_EXPECTED_YEARS, round1_group):
+                round2_row = selected_round2[(name, years, replication)]
+                if int(round2_row["seed"]) != seed:
+                    raise RuntimeError(
+                        f"round-2 R5 seed differs for {name}, {years}y, replication {replication}"
+                    )
+                archived_floor_hits = int(round1_row.get("floor_hits", 0))
+                if path.floor_hits != archived_floor_hits:
+                    raise RuntimeError(
+                        "regenerated path floor hits do not match round 1 for "
+                        f"{name}, {years}y, replication {replication}"
+                    )
+
+                count = int(round(years / dt))
+                log_returns = all_returns[:count]
+                unrestricted = round2_e7._validated_estimate(round1_row)
+                fixed_kappa2 = _validated_profile_estimate(round2_row)
+                if not math.isclose(
+                    float(fixed_kappa2[1]),
+                    params.kappa2,
+                    rel_tol=1.0e-12,
+                    abs_tol=1.0e-12,
+                ):
+                    raise RuntimeError(
+                        f"round-2 R5 kappa2 is not fixed at truth for {name}, {years}y, "
+                        f"replication {replication}"
+                    )
+
+                round1_likelihood = float(round1_row["log_likelihood"])
+                round1_replayed = _replay_likelihood(
+                    unrestricted,
+                    log_returns,
+                    dt=dt,
+                    r=params.r,
+                )
+                r1_error, r1_tolerance, r1_pass = _replay_error(
+                    round1_replayed,
+                    round1_likelihood,
+                )
+                if not r1_pass:
+                    raise RuntimeError(
+                        f"round-1 likelihood replay failed for {name}, {years}y, "
+                        f"replication {replication}: error={r1_error:.6g}, "
+                        f"tolerance={r1_tolerance:.6g}"
+                    )
+
+                round2_likelihood = float(round2_row["profile_log_likelihood"])
+                round2_replayed = _replay_likelihood(
+                    fixed_kappa2,
+                    log_returns,
+                    dt=dt,
+                    r=params.r,
+                )
+                r2_error, r2_tolerance, r2_pass = _replay_error(
+                    round2_replayed,
+                    round2_likelihood,
+                )
+                if not r2_pass:
+                    raise RuntimeError(
+                        f"round-2 likelihood replay failed for {name}, {years}y, "
+                        f"replication {replication}: error={r2_error:.6g}, "
+                        f"tolerance={r2_tolerance:.6g}"
+                    )
+
+                fitted, optimizer, profile_likelihood, start_label, starts_tried, theta_bounds = (
+                    _fit_fixed_physical_kappa2_and_d0(
+                        log_returns,
+                        dt=dt,
+                        r=params.r,
+                        fixed_kappa2=params.kappa2,
+                        fixed_d0=fixed_d0,
+                        round2_start=fixed_kappa2,
+                        unrestricted_start=unrestricted,
+                        truth_start=truth_start,
+                    )
+                )
+                free_hits = _free_coordinate_bound_hits(fitted, theta_bounds)
+                natural_hits = _natural_bound_hits(fitted)
+                d0_error = abs(float(fitted[0] * fitted[2]) - fixed_d0)
+                kappa2_error = abs(float(fitted[1]) - params.kappa2)
+                excess_over_round2 = profile_likelihood - round2_likelihood
+                excess_over_round1 = profile_likelihood - round1_likelihood
+                estimates.append(
+                    {
+                        "parameter_set": name,
+                        "years": years,
+                        "replication": replication,
+                        "seed": seed,
+                        "regime": "c_oracle_fixed_physical_kappa2_and_d0",
+                        "fixed_physical_kappa2": params.kappa2,
+                        "fixed_physical_d0": fixed_d0,
+                        "constraint": "kappa1 = d0 / theta",
+                        "free_parameters": list(_RUNG_C_FREE_NAMES),
+                        "effective_theta_bounds": list(theta_bounds),
+                        "estimate": fitted.tolist(),
+                        "converged": bool(optimizer.success),
+                        "optimizer_status": int(optimizer.status),
+                        "optimizer_message": str(optimizer.message),
+                        "optimizer_iterations": int(getattr(optimizer, "nit", 0)),
+                        "optimizer_function_evaluations": int(getattr(optimizer, "nfev", 0)),
+                        "selected_start": start_label,
+                        "starts_tried": starts_tried,
+                        "free_coordinate_bound_hits": free_hits,
+                        "natural_parameter_bound_hits": natural_hits,
+                        "profile_log_likelihood": profile_likelihood,
+                        "round2_fixed_kappa2_log_likelihood": round2_likelihood,
+                        "round1_unrestricted_log_likelihood": round1_likelihood,
+                        "loss_from_round2_fixed_kappa2": round2_likelihood - profile_likelihood,
+                        "loss_from_round1_unrestricted": round1_likelihood - profile_likelihood,
+                        "profile_above_round2_excess": excess_over_round2,
+                        "profile_not_above_round2": excess_over_round2 <= _PROFILE_DOMINANCE_ATOL,
+                        "profile_above_round1_excess": excess_over_round1,
+                        "profile_not_above_round1": excess_over_round1 <= _PROFILE_DOMINANCE_ATOL,
+                        "profile_dominance_tolerance": _PROFILE_DOMINANCE_ATOL,
+                        "round1_likelihood_replay_abs_error": r1_error,
+                        "round1_likelihood_replay_tolerance": r1_tolerance,
+                        "round1_likelihood_replay_pass": r1_pass,
+                        "round2_likelihood_replay_abs_error": r2_error,
+                        "round2_likelihood_replay_tolerance": r2_tolerance,
+                        "round2_likelihood_replay_pass": r2_pass,
+                        "fixed_d0_abs_error": d0_error,
+                        "fixed_kappa2_abs_error": kappa2_error,
+                        "round1_source_row_sha256": _json_sha256(round1_row),
+                        "round2_source_row_sha256": _json_sha256(round2_row),
+                        "floor_hits": path.floor_hits,
+                    }
+                )
+    return estimates
+
+
+def _error_summary(values: np.ndarray, truth: float) -> dict[str, float]:
+    errors = values - truth
+    return {
+        "mean_estimate": float(np.mean(values)),
+        "bias": float(np.mean(errors)),
+        "rmse": float(np.sqrt(np.mean(np.square(errors)))),
+    }
+
+
+def _rmse_ladder(
+    selected_round1: Mapping[tuple[str, int, int], Mapping[str, Any]],
+    selected_round2: Mapping[tuple[str, int, int], Mapping[str, Any]],
+    rung_c_estimates: Sequence[Mapping[str, Any]],
+    params_by_name: Mapping[str, TgarchParams],
+    parameter_sets: Sequence[str],
+    replications: Sequence[int],
+) -> list[dict[str, Any]]:
+    rung_c_index = {
+        (str(row["parameter_set"]), int(row["years"]), int(row["replication"])): row
+        for row in rung_c_estimates
+    }
+    summaries: list[dict[str, Any]] = []
+    for name in parameter_sets:
+        truth = _natural_truth(params_by_name[name])
+        for years in _EXPECTED_YEARS:
+            matrices = {
+                "a_unrestricted": np.vstack(
+                    [
+                        round2_e7._validated_estimate(selected_round1[(name, years, replication)])
+                        for replication in replications
+                    ]
+                ),
+                "b_oracle_fixed_physical_kappa2": np.vstack(
+                    [
+                        _validated_profile_estimate(selected_round2[(name, years, replication)])
+                        for replication in replications
+                    ]
+                ),
+                "c_oracle_fixed_physical_kappa2_and_d0": np.vstack(
+                    [
+                        np.asarray(
+                            rung_c_index[(name, years, replication)]["estimate"],
+                            dtype=np.float64,
+                        )
+                        for replication in replications
+                    ]
+                ),
+            }
+            for parameter_index in (0, 2):
+                parameter = _PARAMETER_NAMES[parameter_index]
+                regime_summaries = [
+                    {
+                        "regime": regime,
+                        **_error_summary(matrix[:, parameter_index], float(truth[parameter_index])),
+                    }
+                    for regime, matrix in matrices.items()
+                ]
+                rmse = {row["regime"]: float(row["rmse"]) for row in regime_summaries}
+                a = rmse["a_unrestricted"]
+                b = rmse["b_oracle_fixed_physical_kappa2"]
+                c = rmse["c_oracle_fixed_physical_kappa2_and_d0"]
+                summaries.append(
+                    {
+                        "parameter_set": name,
+                        "years": years,
+                        "parameter": parameter,
+                        "truth": float(truth[parameter_index]),
+                        "n_replications": len(replications),
+                        "regimes": regime_summaries,
+                        "rmse_ratio_b_to_a": b / a if a > 0.0 else None,
+                        "rmse_ratio_c_to_a": c / a if a > 0.0 else None,
+                        "rmse_ratio_c_to_b": c / b if b > 0.0 else None,
+                        "rmse_improvement_b_vs_a_fraction": 1.0 - b / a if a > 0.0 else None,
+                        "rmse_improvement_c_vs_a_fraction": 1.0 - c / a if a > 0.0 else None,
+                        "rmse_improvement_c_vs_b_fraction": 1.0 - c / b if b > 0.0 else None,
+                    }
+                )
+    return summaries
+
+
+def _profile_diagnostics(
+    estimates: Sequence[Mapping[str, Any]],
+    parameter_sets: Sequence[str],
+) -> list[dict[str, Any]]:
+    diagnostics: list[dict[str, Any]] = []
+    for name in parameter_sets:
+        for years in _EXPECTED_YEARS:
+            group = [
+                row for row in estimates if row["parameter_set"] == name and row["years"] == years
+            ]
+            free_hit_names = sorted(
+                {hit for row in group for hit in row["free_coordinate_bound_hits"]}
+            )
+            natural_hit_names = sorted(
+                {hit for row in group for hit in row["natural_parameter_bound_hits"]}
+            )
+            diagnostics.append(
+                {
+                    "parameter_set": name,
+                    "years": years,
+                    "n_replications": len(group),
+                    "convergence_fraction": float(np.mean([row["converged"] for row in group])),
+                    "any_free_coordinate_bound_fraction": float(
+                        np.mean([bool(row["free_coordinate_bound_hits"]) for row in group])
+                    ),
+                    "free_coordinate_bound_hit_counts": {
+                        hit: sum(hit in row["free_coordinate_bound_hits"] for row in group)
+                        for hit in free_hit_names
+                    },
+                    "any_natural_parameter_bound_fraction": float(
+                        np.mean([bool(row["natural_parameter_bound_hits"]) for row in group])
+                    ),
+                    "natural_parameter_bound_hit_counts": {
+                        hit: sum(hit in row["natural_parameter_bound_hits"] for row in group)
+                        for hit in natural_hit_names
+                    },
+                    "round1_likelihood_replay_all_pass": all(
+                        row["round1_likelihood_replay_pass"] for row in group
+                    ),
+                    "round2_likelihood_replay_all_pass": all(
+                        row["round2_likelihood_replay_pass"] for row in group
+                    ),
+                    "maximum_round1_likelihood_replay_abs_error": max(
+                        float(row["round1_likelihood_replay_abs_error"]) for row in group
+                    ),
+                    "maximum_round2_likelihood_replay_abs_error": max(
+                        float(row["round2_likelihood_replay_abs_error"]) for row in group
+                    ),
+                    "profile_above_round2_count": sum(
+                        not row["profile_not_above_round2"] for row in group
+                    ),
+                    "maximum_positive_profile_above_round2_excess": max(
+                        max(float(row["profile_above_round2_excess"]), 0.0) for row in group
+                    ),
+                    "profile_above_round1_count": sum(
+                        not row["profile_not_above_round1"] for row in group
+                    ),
+                    "maximum_positive_profile_above_round1_excess": max(
+                        max(float(row["profile_above_round1_excess"]), 0.0) for row in group
+                    ),
+                    "maximum_fixed_d0_abs_error": max(
+                        float(row["fixed_d0_abs_error"]) for row in group
+                    ),
+                    "maximum_fixed_kappa2_abs_error": max(
+                        float(row["fixed_kappa2_abs_error"]) for row in group
+                    ),
+                    "maximum_floor_hits": max(int(row["floor_hits"]) for row in group),
+                }
+            )
+    return diagnostics
+
+
+def _selected_rows_manifest_hash(
+    rows: Mapping[tuple[str, int, int], Mapping[str, Any]],
+) -> str:
+    manifest = [
+        {
+            "parameter_set": key[0],
+            "years": key[1],
+            "replication": key[2],
+            "row_sha256": _json_sha256(rows[key]),
+        }
+        for key in sorted(rows)
+    ]
+    return _json_sha256(manifest)
+
+
+def run_round3_e8(
+    round1_results: object,
+    round2_results: object,
+    params_by_name: Mapping[str, TgarchParams],
+    profile: round1.StudyProfile | str,
+) -> dict[str, Any]:
+    """Run the three-rung R8 oracle ladder on archived E7/R5 replications.
+
+    Parameters
+    ----------
+    round1_results
+        Loaded round-1 ``results.json`` mapping, or its equivalent result object.  The
+        unrestricted E7 estimates and their seeds are immutable inputs.
+    round2_results
+        Loaded round-2 ``round2_results.json`` mapping, or its R5 mapping.  Its
+        fixed-physical-``kappa2`` per-replication profiles are immutable rung-(b) inputs.
+    params_by_name
+        Physical simulation parameters keyed by the archived parameter-set names.
+    profile
+        ``smoke`` uses 2, ``reference`` 32, and ``full`` 200 complete replications per
+        parameter set and horizon.
+
+    Returns
+    -------
+    dict
+        JSON-ready per-replication rung-(c) estimates, the three-rung RMSE ladder for
+        ``kappa1`` and ``theta``, likelihood replays, convergence/bound diagnostics,
+        stable selected-input hashes, and the mandatory oracle interpretation caveat.
+    """
+
+    started = time.perf_counter()
+    resolved_profile = round2_e7._as_profile(profile)
+    selected_round1, parameter_sets, replications = round2_e7._round1_rows(
+        round1_results,
+        params_by_name,
+        resolved_profile,
+    )
+    selected_round2, r5 = _round2_rows(round2_results, parameter_sets, replications)
+
+    experiments = _field(round1_results, "experiments")
+    e7 = experiments["E7"]
+    dt = float(_field(e7, "dt"))
+    if not math.isfinite(dt) or dt <= 0.0:
+        raise ValueError("round-1 E7 dt must be finite and positive")
+
+    estimates = _fit_profile(
+        selected_round1,
+        selected_round2,
+        params_by_name,
+        parameter_sets,
+        replications,
+        dt,
+    )
+    ladder = _rmse_ladder(
+        selected_round1,
+        selected_round2,
+        estimates,
+        params_by_name,
+        parameter_sets,
+        replications,
+    )
+    diagnostics = _profile_diagnostics(estimates, parameter_sets)
+
+    r1_replay_errors = [float(row["round1_likelihood_replay_abs_error"]) for row in estimates]
+    r2_replay_errors = [float(row["round2_likelihood_replay_abs_error"]) for row in estimates]
+    round2_excesses = [float(row["profile_above_round2_excess"]) for row in estimates]
+    round1_excesses = [float(row["profile_above_round1_excess"]) for row in estimates]
+    round1_provenance = _optional_mapping(round1_results, "provenance")
+    round2_provenance = _optional_mapping(round2_results, "provenance")
+
+    return {
+        "claim": (
+            "An oracle upper bound on what an option-implied kappa2_hat plus the "
+            "cross-measure d0 restriction can add to the time series."
+        ),
+        "verdict": "MEASUREMENT ONLY - three-rung oracle identification experiment",
+        "profile": resolved_profile.value,
+        "dt": dt,
+        "sample_years": list(_EXPECTED_YEARS),
+        "parameter_sets": list(parameter_sets),
+        "replications_per_parameter_set_year": len(replications),
+        "selected_replications": list(replications),
+        "round1_seed_rule": _field(e7, "seed_rule"),
+        "path_regeneration": (
+            "One 40-year P path per parameter set and selected replication, regenerated "
+            "from the round-1 seed and sliced to 5/10/20/40-year horizons."
+        ),
+        "regime_definitions": {
+            "a_unrestricted": {
+                "restrictions": [],
+                "source": "round1.experiments.E7.estimates",
+                "action": "archived per-replication QMLE; not re-estimated in R8",
+                "producing_repository_head": round1_provenance.get("repository_head"),
+                "producing_repository_describe": round1_provenance.get("repository_describe"),
+            },
+            "b_oracle_fixed_physical_kappa2": {
+                "restrictions": ["physical kappa2 fixed at simulation truth"],
+                "source": "round2.R5.profile_estimates",
+                "action": "archived per-replication oracle profile; not re-estimated in R8",
+                "source_profile": _field(r5, "profile"),
+                "producing_repository_head": round2_provenance.get("repository_head"),
+                "producing_repository_tag": round2_provenance.get("repository_tag"),
+            },
+            "c_oracle_fixed_physical_kappa2_and_d0": {
+                "restrictions": [
+                    "physical kappa2 fixed at simulation truth",
+                    "physical d0=kappa1*theta fixed at simulation truth",
+                    "kappa1=d0/theta",
+                ],
+                "free_parameters": list(_RUNG_C_FREE_NAMES),
+                "source": "R8 fit on regenerated archived-seed paths",
+                "action": "estimated in this run from three projected starts",
+            },
+        },
+        "input_provenance": {
+            "selected_round1_row_count": len(selected_round1),
+            "selected_round2_row_count": len(selected_round2),
+            "selected_round1_rows_manifest_sha256": _selected_rows_manifest_hash(selected_round1),
+            "selected_round2_rows_manifest_sha256": _selected_rows_manifest_hash(selected_round2),
+            "per_replication_source_row_hashes_stored": True,
+        },
+        "rmse_ladder": ladder,
+        "profile_estimates": estimates,
+        "profile_diagnostics": diagnostics,
+        "likelihood_replay": {
+            "all_round1_unrestricted_passed": all(
+                row["round1_likelihood_replay_pass"] for row in estimates
+            ),
+            "all_round2_fixed_kappa2_passed": all(
+                row["round2_likelihood_replay_pass"] for row in estimates
+            ),
+            "absolute_tolerance": _REPLAY_ATOL,
+            "relative_tolerance": _REPLAY_RTOL,
+            "maximum_round1_absolute_error": max(r1_replay_errors, default=0.0),
+            "maximum_round2_absolute_error": max(r2_replay_errors, default=0.0),
+        },
+        "nested_profile_likelihood_dominance": {
+            "theoretical_relation": (
+                "At exact optima, rung (c) is nested within rung (b), which is nested "
+                "within rung (a), so each constrained likelihood cannot exceed its parent."
+            ),
+            "positive_excess_interpretation": (
+                "A positive excess beyond tolerance diagnoses a numerical optimizer miss "
+                "in the archived parent profile; it is not a failure of the nesting relation."
+            ),
+            "all_rung_c_not_above_rung_b_within_tolerance": all(
+                excess <= _PROFILE_DOMINANCE_ATOL for excess in round2_excesses
+            ),
+            "all_rung_c_not_above_rung_a_within_tolerance": all(
+                excess <= _PROFILE_DOMINANCE_ATOL for excess in round1_excesses
+            ),
+            "absolute_tolerance": _PROFILE_DOMINANCE_ATOL,
+            "rung_c_above_rung_b_failure_count": sum(
+                excess > _PROFILE_DOMINANCE_ATOL for excess in round2_excesses
+            ),
+            "rung_c_above_rung_a_failure_count": sum(
+                excess > _PROFILE_DOMINANCE_ATOL for excess in round1_excesses
+            ),
+            "maximum_positive_rung_c_above_rung_b_excess": max(
+                (max(excess, 0.0) for excess in round2_excesses),
+                default=0.0,
+            ),
+            "maximum_positive_rung_c_above_rung_a_excess": max(
+                (max(excess, 0.0) for excess in round1_excesses),
+                default=0.0,
+            ),
+        },
+        "constraint_validation": {
+            "maximum_fixed_d0_abs_error": max(
+                (float(row["fixed_d0_abs_error"]) for row in estimates),
+                default=0.0,
+            ),
+            "maximum_fixed_kappa2_abs_error": max(
+                (float(row["fixed_kappa2_abs_error"]) for row in estimates),
+                default=0.0,
+            ),
+        },
+        "oracle_upper_bound_caveat": (
+            "An oracle upper bound on what an option-implied kappa2_hat plus the "
+            "cross-measure d0 restriction can add to the time series. Do not frame it as "
+            "achieved identification from options. The real-data joint-estimation "
+            "experiment stays out of this study's scope."
+        ),
+        "standing_caveat": (
+            "All convergence statements are relative to the square-root step scaling of "
+            "the kernel loadings, and nothing transfers statistical inference between the "
+            "discrete and continuous models."
+        ),
+        "runtime_seconds": time.perf_counter() - started,
+    }
+
+
+__all__ = ["run_round3_e8"]

--- a/volatility_book/ch_discrete_vol/round3_r7.py
+++ b/volatility_book/ch_discrete_vol/round3_r7.py
@@ -1,0 +1,415 @@
+"""Round-3 R7 nested path-budget diagnostic for the discounted spot.
+
+The experiment deliberately studies a fixed-budget Monte Carlo estimand.  Every
+finite-step ``Q_LIMIT`` recursion used here satisfies the discounted-spot identity
+analytically; a negative empirical defect therefore diagnoses unseen rare-tail mass,
+not an arbitrage defect of the discretisation.  Path-count prefixes are nested within
+each time step and common base-normal streams are shared across ``kappa2_hat`` values.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .round2_e4 import (
+    BASE_SEED,
+    _bootstrap_logmeans,
+    _logmeanexp,
+    _pair_batch_logmeans,
+    _percentile_interval,
+    _tail_share,
+    _validate_grid_step,
+)
+from .sim import M1, S1, SIGMA_FLOOR, TgarchParams, derived_limit_params
+
+FloatArray = NDArray[np.float64]
+
+R7_DTS = (1.0 / 4032.0, 1.0 / 16128.0)
+R7_KAPPA_GRID = np.array((0.0, 0.5, 2.0), dtype=np.float64)
+R7_PATH_COUNTS = (2**16, 2**18, 2**20, 2**22)
+R7_MATURITY = 1.0
+
+
+class Round3R7Profile(str, Enum):
+    """Execution sizes for development and the exact brief."""
+
+    SMOKE = "smoke"
+    REFERENCE = "reference"
+    FULL = "full"
+
+
+@dataclass(frozen=True, slots=True)
+class Round3R7Config:
+    """Numerical workload for :func:`run_round3_r7`."""
+
+    profile: Round3R7Profile
+    path_counts: tuple[int, ...]
+    bootstrap_replications: int
+    bootstrap_batch_pairs: int
+    path_chunk: int
+    workers: int
+
+
+def _as_profile(profile: Round3R7Profile | str) -> Round3R7Profile:
+    if isinstance(profile, Round3R7Profile):
+        return profile
+    try:
+        return Round3R7Profile(str(profile).lower())
+    except ValueError as error:
+        choices = ", ".join(item.value for item in Round3R7Profile)
+        raise ValueError(f"profile must be one of {choices}") from error
+
+
+def _make_config(profile: Round3R7Profile | str) -> Round3R7Config:
+    profile_value = _as_profile(profile)
+    if profile_value is Round3R7Profile.FULL:
+        return Round3R7Config(
+            profile=profile_value,
+            path_counts=R7_PATH_COUNTS,
+            bootstrap_replications=400,
+            bootstrap_batch_pairs=128,
+            path_chunk=2**15,
+            workers=4,
+        )
+    if profile_value is Round3R7Profile.REFERENCE:
+        return Round3R7Config(
+            profile=profile_value,
+            path_counts=(2**14, 2**16, 2**18),
+            bootstrap_replications=200,
+            bootstrap_batch_pairs=64,
+            path_chunk=2**13,
+            workers=2,
+        )
+    return Round3R7Config(
+        profile=profile_value,
+        path_counts=(2**10, 2**12),
+        bootstrap_replications=80,
+        bootstrap_batch_pairs=16,
+        path_chunk=2**10,
+        workers=1,
+    )
+
+
+def _seed(*parts: int) -> int:
+    sequence = np.random.SeedSequence([BASE_SEED, *parts])
+    return int(sequence.generate_state(1, dtype=np.uint64)[0])
+
+
+def _antithetic_normals(rng: np.random.Generator, n_paths: int) -> FloatArray:
+    if n_paths % 2:
+        raise ValueError("n_paths must be even")
+    draws = rng.standard_normal(n_paths // 2)
+    result = np.empty(n_paths, dtype=np.float64)
+    result[0::2] = draws
+    result[1::2] = -draws
+    return result
+
+
+def _simulate_chunk(
+    params: TgarchParams,
+    dt: float,
+    start: int,
+    stop: int,
+) -> tuple[int, FloatArray, NDArray[np.int64], int]:
+    """Return one independently seeded terminal chunk for all R7 kappa values."""
+
+    n_paths = stop - start
+    if n_paths <= 0 or n_paths % 2:
+        raise ValueError("every R7 chunk must contain a positive number of antithetic pairs")
+    n_steps = _validate_grid_step(R7_MATURITY, dt)
+    dt_code = int(round(1.0 / dt))
+    derived_seed = _seed(700, dt_code, start)
+    rng = np.random.Generator(np.random.PCG64(derived_seed))
+    base = derived_limit_params(params)
+    sigma = np.full((R7_KAPPA_GRID.size, n_paths), params.sigma0, dtype=np.float64)
+    log_spot = np.full((R7_KAPPA_GRID.size, n_paths), math.log(params.spot0), dtype=np.float64)
+    floor_hits = np.zeros(R7_KAPPA_GRID.size, dtype=np.int64)
+    sqrt_dt = math.sqrt(dt)
+
+    with np.errstate(over="ignore", invalid="ignore"):
+        for step in range(1, n_steps + 1):
+            z = _antithetic_normals(rng, n_paths)
+            w = (np.abs(z) - M1) / S1
+            volatility_innovation = params.beta * z + params.eps * w
+            log_spot += (params.r - 0.5 * sigma * sigma) * dt + sigma * sqrt_dt * z[None, :]
+            drift = base.d0 + base.d1_hat * sigma - R7_KAPPA_GRID[:, None] * sigma * sigma
+            sigma_next = sigma + drift * dt + sigma * sqrt_dt * volatility_innovation[None, :]
+            hit = sigma_next < SIGMA_FLOOR
+            floor_hits += np.count_nonzero(hit, axis=1)
+            np.maximum(sigma_next, SIGMA_FLOOR, out=sigma_next)
+            sigma = sigma_next
+            if step % 256 == 0 and (
+                not np.isfinite(sigma).all() or not np.isfinite(log_spot).all()
+            ):
+                raise FloatingPointError(
+                    f"non-finite R7 state at dt={dt:.12g}, chunk={start}:{stop}, step={step}"
+                )
+
+    if not np.isfinite(sigma).all() or not np.isfinite(log_spot).all():
+        raise FloatingPointError(f"non-finite R7 terminal state at dt={dt:.12g}")
+    normalization = math.log(params.spot0) + params.r * R7_MATURITY
+    return start, log_spot - normalization, floor_hits, derived_seed
+
+
+def _simulate_dt(
+    params: TgarchParams,
+    dt: float,
+    config: Round3R7Config,
+) -> tuple[FloatArray, NDArray[np.int64], list[dict[str, int]], float]:
+    """Simulate the largest budget once; smaller budgets are strict prefixes."""
+
+    started = time.perf_counter()
+    maximum_paths = config.path_counts[-1]
+    terminal = np.empty((R7_KAPPA_GRID.size, maximum_paths), dtype=np.float64)
+    chunk_starts = list(range(0, maximum_paths, config.path_chunk))
+    floor_by_chunk = np.empty((len(chunk_starts), R7_KAPPA_GRID.size), dtype=np.int64)
+    seed_records: list[dict[str, int] | None] = [None] * len(chunk_starts)
+
+    def store(result: tuple[int, FloatArray, NDArray[np.int64], int]) -> None:
+        start, values, floor_hits, derived_seed = result
+        stop = start + values.shape[1]
+        terminal[:, start:stop] = values
+        chunk_index = start // config.path_chunk
+        floor_by_chunk[chunk_index] = floor_hits
+        seed_records[chunk_index] = {
+            "path_start": start,
+            "path_stop": stop,
+            "derived_seed": derived_seed,
+        }
+
+    if config.workers == 1:
+        for start in chunk_starts:
+            store(_simulate_chunk(params, dt, start, min(start + config.path_chunk, maximum_paths)))
+    else:
+        with ProcessPoolExecutor(max_workers=config.workers) as executor:
+            futures = [
+                executor.submit(
+                    _simulate_chunk,
+                    params,
+                    dt,
+                    start,
+                    min(start + config.path_chunk, maximum_paths),
+                )
+                for start in chunk_starts
+            ]
+            for future in as_completed(futures):
+                store(future.result())
+
+    if not np.isfinite(terminal).all():
+        raise FloatingPointError(f"R7 terminal archive is non-finite at dt={dt:.12g}")
+    cumulative_floor = np.cumsum(floor_by_chunk, axis=0)
+    floor_by_budget = np.empty((len(config.path_counts), R7_KAPPA_GRID.size), dtype=np.int64)
+    for index, n_paths in enumerate(config.path_counts):
+        if n_paths % config.path_chunk:
+            raise ValueError("each nested path budget must end on an R7 chunk boundary")
+        floor_by_budget[index] = cumulative_floor[n_paths // config.path_chunk - 1]
+    if any(record is None for record in seed_records):  # pragma: no cover - defensive
+        raise RuntimeError("missing R7 seed metadata")
+    return (
+        terminal,
+        floor_by_budget,
+        [record for record in seed_records if record is not None],
+        time.perf_counter() - started,
+    )
+
+
+def _summarize_dt(
+    terminal: FloatArray,
+    floor_by_budget: NDArray[np.int64],
+    *,
+    dt: float,
+    dt_index: int,
+    config: Round3R7Config,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    powers = np.array((1.0,), dtype=np.float64)
+    for budget_index, n_paths in enumerate(config.path_counts):
+        sample = terminal[:, :n_paths]
+        batch_logs = _pair_batch_logmeans(sample, powers, config.bootstrap_batch_pairs)[:, 0, :]
+        point_logs = _logmeanexp(batch_logs, axis=-1)
+        bootstrap_seed = _seed(710, dt_index, int(round(math.log2(n_paths))))
+        boot_logs = _bootstrap_logmeans(
+            batch_logs,
+            config.bootstrap_replications,
+            bootstrap_seed,
+        )
+        with np.errstate(over="ignore", invalid="ignore"):
+            boot_shortfalls = -np.expm1(boot_logs)
+        if not np.isfinite(boot_shortfalls).all():
+            raise FloatingPointError("R7 bootstrap produced a non-finite shortfall")
+        for kappa_index, kappa2_hat in enumerate(R7_KAPPA_GRID):
+            ci_low, ci_high = _percentile_interval(boot_shortfalls[:, kappa_index])
+            log_mean = float(point_logs[kappa_index])
+            records.append(
+                {
+                    "dt": dt,
+                    "n_steps": _validate_grid_step(R7_MATURITY, dt),
+                    "maturity": R7_MATURITY,
+                    "n_paths": n_paths,
+                    "log2_paths": int(round(math.log2(n_paths))),
+                    "kappa2_hat": float(kappa2_hat),
+                    "log_mean_discounted_spot": log_mean,
+                    "empirical_shortfall": float(-np.expm1(log_mean)),
+                    "bootstrap_ci_95": [ci_low, ci_high],
+                    "bootstrap_ci_contains_zero": ci_low <= 0.0 <= ci_high,
+                    "maximum_log_discounted_spot": float(np.max(sample[kappa_index])),
+                    "top_0.1pct_share": _tail_share(sample[kappa_index], 1.0),
+                    "floor_hits": int(floor_by_budget[budget_index, kappa_index]),
+                    "bootstrap_derived_seed": bootstrap_seed,
+                }
+            )
+    return records
+
+
+def _pattern_checks(records: list[dict[str, Any]], config: Round3R7Config) -> dict[str, Any]:
+    per_curve: list[dict[str, Any]] = []
+    log_counts = np.log2(np.asarray(config.path_counts, dtype=np.float64))
+    for dt in R7_DTS:
+        for kappa2_hat in R7_KAPPA_GRID:
+            curve = sorted(
+                (
+                    row
+                    for row in records
+                    if row["dt"] == dt and row["kappa2_hat"] == float(kappa2_hat)
+                ),
+                key=lambda row: row["n_paths"],
+            )
+            shortfalls = np.asarray([row["empirical_shortfall"] for row in curve])
+            slope = float(np.polyfit(log_counts, shortfalls, 1)[0])
+            final = curve[-1]
+            per_curve.append(
+                {
+                    "dt": dt,
+                    "kappa2_hat": float(kappa2_hat),
+                    "shortfall_slope_per_path_doubling": slope,
+                    "initial_shortfall": float(shortfalls[0]),
+                    "final_shortfall": float(shortfalls[-1]),
+                    "final_ci_contains_zero": bool(final["bootstrap_ci_contains_zero"]),
+                    "all_budget_intervals_contain_zero": bool(
+                        all(row["bootstrap_ci_contains_zero"] for row in curve)
+                    ),
+                    "positive_at_every_budget": bool(np.all(shortfalls > 0.0)),
+                    "net_shrinkage": bool(shortfalls[-1] < shortfalls[0]),
+                    "endpoint_shortfall_ratio": (
+                        float(shortfalls[-1] / shortfalls[0]) if shortfalls[0] != 0.0 else None
+                    ),
+                    "downward_increment_count": int(np.count_nonzero(np.diff(shortfalls) < 0.0)),
+                }
+            )
+    low_curvature = [row for row in per_curve if row["kappa2_hat"] in (0.0, 0.5)]
+    high_curvature = [row for row in per_curve if row["kappa2_hat"] == 2.0]
+    no_floor_hits = all(row["floor_hits"] == 0 for row in records)
+    expected_pattern = bool(
+        all(row["positive_at_every_budget"] and row["net_shrinkage"] for row in low_curvature)
+        and all(row["all_budget_intervals_contain_zero"] for row in high_curvature)
+        and no_floor_hits
+    )
+    return {
+        "per_curve": per_curve,
+        "low_curvature_positive_and_net_shrinking": all(
+            row["positive_at_every_budget"] and row["net_shrinkage"] for row in low_curvature
+        ),
+        "kappa2_equals_2_all_budget_intervals_contain_zero": all(
+            row["all_budget_intervals_contain_zero"] for row in high_curvature
+        ),
+        "no_sigma_floor_interventions": no_floor_hits,
+        "expected_descriptive_pattern_observed": expected_pattern,
+        "assessment_scope": (
+            "Descriptive summary only, not an acceptance gate or inferential test. "
+            "Low-curvature net shrinkage compares endpoints; the full curve, endpoint "
+            "ratio, fitted slope, and downward-increment count are reported. Noise at "
+            "kappa2_hat=2 requires every path-budget interval to contain zero."
+        ),
+    }
+
+
+def run_round3_r7(
+    params: TgarchParams,
+    profile: Round3R7Profile | str = Round3R7Profile.FULL,
+    *,
+    parameter_set: str = "crypto",
+) -> dict[str, Any]:
+    """Run the R7 nested path-count sensitivity experiment."""
+
+    started = time.perf_counter()
+    config = _make_config(profile)
+    if not parameter_set.strip():
+        raise ValueError("parameter_set must be a non-empty label")
+    records: list[dict[str, Any]] = []
+    per_dt: list[dict[str, Any]] = []
+    for dt_index, dt in enumerate(R7_DTS):
+        terminal, floor_by_budget, seed_records, runtime = _simulate_dt(params, dt, config)
+        records.extend(
+            _summarize_dt(
+                terminal,
+                floor_by_budget,
+                dt=dt,
+                dt_index=dt_index,
+                config=config,
+            )
+        )
+        per_dt.append(
+            {
+                "dt": dt,
+                "reciprocal_dt_code": int(round(1.0 / dt)),
+                "runtime_seconds": runtime,
+                "simulation_chunks": seed_records,
+            }
+        )
+        del terminal, floor_by_budget
+
+    checks = _pattern_checks(records, config)
+    return {
+        "name": "R7 nested path-budget discounted-spot diagnostic",
+        "profile": config.profile.value,
+        "parameter_set": parameter_set,
+        "parameters": asdict(params),
+        "config": {
+            **asdict(config),
+            "profile": config.profile.value,
+            "dt_grid": list(R7_DTS),
+            "maturity": R7_MATURITY,
+            "kappa2_hat_grid": R7_KAPPA_GRID.tolist(),
+            "nested_prefixes": True,
+            "common_random_numbers": "shared across kappa2_hat within each dt and prefix",
+            "chunk_dependence": (
+                "Prefix nesting is exact within this tagged configuration. Changing "
+                "path_chunk changes the independently derived streams after the first chunk."
+            ),
+        },
+        "seed_metadata": {
+            "base_seed": BASE_SEED,
+            "generator": "numpy.random.Generator(PCG64(derived_seed))",
+            "simulation_rule": ["BASE_SEED", 700, "round(1 / dt)", "path_start"],
+            "bootstrap_rule": ["BASE_SEED", 710, "dt_index", "log2(n_paths)"],
+            "per_dt": per_dt,
+        },
+        "records": records,
+        "checks": checks,
+        "interpretation": {
+            "estimand": "one minus the fixed-budget empirical discounted-spot mean",
+            "finite_step_identity": (
+                "Every Q_LIMIT step has conditional discounted expectation one exactly."
+            ),
+            "bootstrap_scope": (
+                "The pair-batch bootstrap is conditional on sampled paths and cannot assign "
+                "mass to rare paths absent from the largest nested prefix."
+            ),
+            "claim_limit": (
+                "Slow shrinkage is a finite-budget tail-sampling diagnostic; it is not an "
+                "estimate of a finite-step martingale defect or proof of strict-local mass loss."
+            ),
+        },
+        "runtime_seconds": time.perf_counter() - started,
+    }
+
+
+__all__ = ["Round3R7Profile", "run_round3_r7"]

--- a/volatility_book/ch_discrete_vol/round3_reporting.py
+++ b/volatility_book/ch_discrete_vol/round3_reporting.py
@@ -1,0 +1,551 @@
+"""Reporting for round three of the discrete-versus-continuous TGARCH study."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import math
+import textwrap
+from collections.abc import Mapping, Sequence
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.figure import Figure
+
+
+def _json_ready(value: Any) -> Any:
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {
+            field.name: _json_ready(getattr(value, field.name))
+            for field in dataclasses.fields(value)
+        }
+    if isinstance(value, Mapping):
+        return {str(key): _json_ready(item) for key, item in value.items()}
+    if isinstance(value, np.ndarray):
+        return [_json_ready(item) for item in value.tolist()]
+    if isinstance(value, np.generic):
+        return _json_ready(value.item())
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    return value
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return "NA"
+    if isinstance(value, bool):
+        return "PASS" if value else "FAIL"
+    if isinstance(value, (float, np.floating)):
+        number = float(value)
+        if not math.isfinite(number):
+            return "NA"
+        magnitude = abs(number)
+        if magnitude != 0.0 and (magnitude < 1.0e-4 or magnitude >= 1.0e5):
+            return f"{number:.4e}"
+        return f"{number:.6g}"
+    if isinstance(value, (list, tuple)):
+        return ", ".join(_fmt(item) for item in value)
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _table(rows: Sequence[Mapping[str, Any]], columns: Sequence[tuple[str, str]]) -> str:
+    if not rows:
+        return "_No records._\n"
+    header = "| " + " | ".join(label for label, _ in columns) + " |"
+    rule = "| " + " | ".join("---" for _ in columns) + " |"
+    body = ["| " + " | ".join(_fmt(row.get(field)) for _, field in columns) + " |" for row in rows]
+    return "\n".join((header, rule, *body)) + "\n"
+
+
+def _provenance_line(results: Mapping[str, Any], section: str, seed: str) -> str:
+    provenance = results["provenance"]
+    report_tag = provenance.get("reporting_repository_tag")
+    report_suffix = f"; report tag=`{report_tag}`" if report_tag else ""
+    return (
+        f"Provenance — section `{section}`; script=`{provenance['script']}`; seed={seed}; "
+        f"exact tag=`{provenance['repository_tag']}`; HEAD=`{provenance['repository_head']}`; "
+        f"input ledger=`round3_results.json#/provenance/executed_inputs`{report_suffix}."
+    )
+
+
+def write_round3_results_json(results: Mapping[str, Any], path: Path) -> None:
+    """Write a strict, deterministic round-three audit record."""
+
+    output = Path(path)
+    if output.suffix.lower() != ".json":
+        raise ValueError("Round-three JSON output must end in .json")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(_json_ready(results), indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _r6_summary_rows(section: Mapping[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            "parameter_set": row["parameter_set"],
+            "maturity": row["maturity"],
+            "clean_mean_bp": row["clean_mean_abs_error_bp"],
+            "archived_mean_bp": row["archived_mean_abs_error_bp"],
+            "max_z": row["maximum_abs_z_score"],
+            "passed": row["passed"],
+        }
+        for row in section["e1_stability"]["rows"]
+    ]
+
+
+def _r7_summary_rows(section: Mapping[str, Any]) -> list[dict[str, Any]]:
+    maximum_paths = max(int(row["n_paths"]) for row in section["records"])
+    return [
+        {
+            "dt": row["dt"],
+            "kappa2_hat": row["kappa2_hat"],
+            "shortfall": row["empirical_shortfall"],
+            "ci": row["bootstrap_ci_95"],
+            "zero": row["bootstrap_ci_contains_zero"],
+            "tail_share": row["top_0.1pct_share"],
+        }
+        for row in section["records"]
+        if int(row["n_paths"]) == maximum_paths
+    ]
+
+
+def _r8_summary_rows(section: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for row in section["rmse_ladder"]:
+        regimes = {item["regime"]: item for item in row["regimes"]}
+        rows.append(
+            {
+                "parameter_set": row["parameter_set"],
+                "years": row["years"],
+                "parameter": row["parameter"],
+                "a": regimes["a_unrestricted"]["rmse"],
+                "b": regimes["b_oracle_fixed_physical_kappa2"]["rmse"],
+                "c": regimes["c_oracle_fixed_physical_kappa2_and_d0"]["rmse"],
+                "c_vs_a": row["rmse_improvement_c_vs_a_fraction"],
+                "c_vs_b": row["rmse_improvement_c_vs_b_fraction"],
+            }
+        )
+    return rows
+
+
+def write_round3_markdown(
+    results: Mapping[str, Any],
+    path: Path,
+    *,
+    json_path: Path,
+    manifest_path: Path,
+    figures_path: Path,
+) -> None:
+    """Write the contradictions-first round-three analysis memo."""
+
+    r6 = results["R6"]
+    r7 = results["R7"]
+    r8 = results["R8"]
+    r9 = results["R9"]
+    note = results["note_validation"]
+    status_rows = [
+        {"item": "R6 traceability gate", "status": r6["blocking_requirement_satisfied"]},
+        {
+            "item": "R7 expected descriptive pattern",
+            "status": r7["checks"]["expected_descriptive_pattern_observed"],
+        },
+        {
+            "item": "R8 rung-c convergence",
+            "status": all(row["convergence_fraction"] == 1.0 for row in r8["profile_diagnostics"]),
+        },
+        {
+            "item": "R9 pointers resolved",
+            "status": r9["all_pointers_resolved"],
+        },
+        {
+            "item": "Corrected note claims supported by manifest",
+            "status": r9["note_claims_all_supported"],
+        },
+    ]
+    lines = [
+        f"# {results['title']}",
+        "",
+        "## Executive verdict",
+        "",
+        _table(status_rows, (("Item", "item"), ("Status", "status"))).rstrip(),
+        "",
+        (
+            "R6 is the blocking decision. R7 and R8 are measurements, and failure of an "
+            "expected empirical pattern is reported rather than repaired. R10 was not run "
+            "because the required explicit word `go` was not supplied."
+        ),
+        "",
+        "## Contradictions and validation corrections",
+        "",
+    ]
+    for item in results["contradictions"]:
+        lines.extend((f"- **{item['item']}** — {item['finding']}", ""))
+    lines.extend(
+        (
+            _provenance_line(results, "note validation", "not stochastic"),
+            "",
+            "## R6 — full-budget clean-tag traceability",
+            "",
+            (
+                "Blocking result: **"
+                f"{'PASS' if r6['blocking_requirement_satisfied'] else 'FAIL'}**. "
+                f"Maximum strike-level absolute z-score against the archived full run was "
+                f"{r6['e1_stability']['maximum_abs_z_score']:.4g} under the declared "
+                "three-combined-SE gate."
+            ),
+            "",
+            _table(
+                _r6_summary_rows(r6),
+                (
+                    ("Set", "parameter_set"),
+                    ("T", "maturity"),
+                    ("Clean mean abs err (bp)", "clean_mean_bp"),
+                    ("Archived mean abs err (bp)", "archived_mean_bp"),
+                    ("Max abs z", "max_z"),
+                    ("Gate", "passed"),
+                ),
+            ).rstrip(),
+            "",
+            (
+                f"The E3 stationary archive contains "
+                f"{len(r6['e3_stationary_samples']['records'])} arrays; NPZ SHA-256 "
+                f"`{r6['e3_stationary_samples']['sha256']}`. Future checks can now diff "
+                "the samples directly."
+            ),
+            "",
+            _provenance_line(results, "R6", "round-1 E1/E3 seeds; exact values in R6"),
+            "",
+            "## R7 — path-budget dimension of the shortfall",
+            "",
+            (
+                f"Expected descriptive pattern: **"
+                f"{'PASS' if r7['checks']['expected_descriptive_pattern_observed'] else 'FAIL'}**. "
+                "The table reports the largest nested prefix. Intervals are conditional on "
+                "observed antithetic pair batches and cannot supply mass from unseen paths."
+            ),
+            "",
+            _table(
+                _r7_summary_rows(r7),
+                (
+                    ("dt", "dt"),
+                    ("kappa2_hat", "kappa2_hat"),
+                    ("Shortfall", "shortfall"),
+                    ("95% bootstrap CI", "ci"),
+                    ("CI contains 0", "zero"),
+                    ("Top 0.1% share", "tail_share"),
+                ),
+            ).rstrip(),
+            "",
+            r7["interpretation"]["claim_limit"],
+            "",
+            _provenance_line(results, "R7", "base 20260823; full stream ledger in R7"),
+            "",
+            "## R8 — honest three-rung oracle ladder",
+            "",
+            r8["oracle_upper_bound_caveat"],
+            "",
+            _table(
+                _r8_summary_rows(r8),
+                (
+                    ("Set", "parameter_set"),
+                    ("Years", "years"),
+                    ("Parameter", "parameter"),
+                    ("(a) unrestricted", "a"),
+                    ("(b) fixed kappa2", "b"),
+                    ("(c) fixed kappa2+d0", "c"),
+                    ("c gain vs a", "c_vs_a"),
+                    ("c gain vs b", "c_vs_b"),
+                ),
+            ).rstrip(),
+            "",
+            (
+                "One archived rung-(b) local optimizer miss is retained as a numerical "
+                "finding; R8 does not overwrite its parent archive. All rung-(c) fits "
+                "converged and all likelihood replays were exact under the recorded tolerance."
+            ),
+            "",
+            _provenance_line(
+                results,
+                "R8",
+                str(r8.get("round1_seed_rule", "round-1 E7 seed ledger")),
+            ),
+            "",
+            "## R9 — cited-numbers manifest",
+            "",
+            (
+                f"The manifest contains {r9['citation_count']} value mappings and "
+                f"{r9['claim_check_count']} prose-claim checks. Pointer resolution: "
+                f"{'PASS' if r9['all_pointers_resolved'] else 'FAIL'}. Claims unsupported "
+                f"as currently written: {', '.join(r9['unsupported_claim_ids']) or 'none'}."
+            ),
+            "",
+            _provenance_line(results, "R9", "deterministic RFC 6901 resolution"),
+            "",
+            "## Validated write-up",
+            "",
+            (
+                (
+                    f"Pre-validation source SHA-256: `{note['source_sha256_before']}`; "
+                    f"corrected source SHA-256: `{note['source_sha256_after']}`. The corrected "
+                    f"PDF has {note['compiled_pdf_pages']} pages and every page was visually "
+                    "inspected."
+                )
+                if note.get("corrections_applied")
+                else (
+                    f"Source SHA-256: `{note['source_sha256_before']}`. The adjacent PDF was "
+                    "stale revision 2; revision-3 source compiled to "
+                    f"{note['compiled_pdf_pages']} pages and every page was visually inspected."
+                )
+            ),
+            "",
+        )
+    )
+    for finding in note["findings"]:
+        lines.extend((f"- **{finding['location']}** — {finding['finding']}", ""))
+    lines.extend(
+        (
+            "## Standing caveats",
+            "",
+            *[f"- {item}" for item in results["standing_caveats"]],
+            "",
+            "## Artifact ledger",
+            "",
+            f"- Full JSON audit record: `{Path(json_path).name}`; SHA-256 `{_sha256(json_path)}`.",
+            (
+                f"- Cited-numbers manifest: `{Path(manifest_path).name}`; SHA-256 "
+                f"`{_sha256(manifest_path)}`."
+            ),
+            f"- Figures PDF: `{Path(figures_path).name}`; SHA-256 `{_sha256(figures_path)}`.",
+            f"- Runtime: {_fmt(results['runtime_seconds'])} seconds.",
+            f"- Exact execution tag: `{results['provenance']['repository_tag']}`.",
+            "",
+        )
+    )
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _caption(figure: Figure, title: str, caption: str) -> None:
+    figure.suptitle(title, fontsize=14, weight="bold", y=0.985)
+    figure.text(
+        0.02,
+        0.012,
+        textwrap.fill(caption, width=135),
+        ha="left",
+        va="bottom",
+        fontsize=7.2,
+    )
+    figure.tight_layout(rect=(0.03, 0.12, 0.98, 0.94))
+
+
+def _cover(results: Mapping[str, Any]) -> Figure:
+    figure = plt.figure(figsize=(8.27, 11.69))
+    figure.text(
+        0.08,
+        0.92,
+        textwrap.fill(str(results["title"]), width=46),
+        fontsize=19,
+        weight="bold",
+        va="top",
+    )
+    figure.text(0.08, 0.83, f"Profile: {results['profile']}", fontsize=11, va="top")
+    contradictions = "\n\n".join(
+        f"{index}. {item['item']}: {item['finding']}"
+        for index, item in enumerate(results["contradictions"], start=1)
+    )
+    figure.text(
+        0.08,
+        0.77,
+        textwrap.fill("Contradictions first", width=85),
+        fontsize=12,
+        weight="bold",
+        color="#8b0000",
+        va="top",
+    )
+    figure.text(
+        0.08,
+        0.735,
+        "\n".join(textwrap.fill(paragraph, width=92) for paragraph in contradictions.split("\n\n")),
+        fontsize=8.6,
+        va="top",
+    )
+    figure.text(
+        0.08,
+        0.19,
+        textwrap.fill(
+            _provenance_line(results, "all", "section-specific ledgers in JSON"),
+            width=96,
+        ),
+        fontsize=8.2,
+        va="top",
+    )
+    figure.text(
+        0.08,
+        0.10,
+        "R10 importance sampling was not run: the explicit release word was absent.",
+        fontsize=9.2,
+        va="top",
+    )
+    return figure
+
+
+def _plot_r6(results: Mapping[str, Any]) -> Figure:
+    rows = results["R6"]["e1_stability"]["rows"]
+    labels: list[str] = []
+    values: list[float] = []
+    colors: list[str] = []
+    for row in rows:
+        labels.append(f"{row['parameter_set']}\nT={float(row['maturity']):.4g}")
+        values.append(float(row["maximum_abs_z_score"]))
+        colors.append("#2a9d8f" if row["passed"] else "#e76f51")
+    figure, axis = plt.subplots(figsize=(11.0, 7.0))
+    bars = axis.bar(labels, values, color=colors)
+    axis.axhline(3.0, color="black", linestyle="--", label="blocking threshold")
+    for bar, value in zip(bars, values, strict=True):
+        axis.text(
+            bar.get_x() + bar.get_width() / 2,
+            value,
+            f"{value:.3g}",
+            ha="center",
+            va="bottom",
+        )
+    axis.set(ylabel="Maximum strike-level |z|", title="Clean full-budget E1 versus archive")
+    axis.legend()
+    _caption(
+        figure,
+        "R6 — blocking clean-tag traceability gate",
+        _provenance_line(results, "R6", "round-1 E1 seeds")
+        + " Each bar is the maximum strike-level difference divided by the combined Monte "
+        "Carlo standard error within one parameter-set/maturity group.",
+    )
+    return figure
+
+
+def _plot_r7(results: Mapping[str, Any]) -> Figure:
+    section = results["R7"]
+    records = section["records"]
+    kappas = sorted({float(row["kappa2_hat"]) for row in records})
+    dts = sorted({float(row["dt"]) for row in records}, reverse=True)
+    figure, axes = plt.subplots(len(kappas), 1, figsize=(10.8, 10.5), sharex=True)
+    if len(kappas) == 1:
+        axes = np.asarray([axes])
+    colors = ("#264653", "#e76f51")
+    for axis, kappa in zip(axes, kappas, strict=True):
+        for color, dt in zip(colors, dts, strict=True):
+            group = sorted(
+                (
+                    row
+                    for row in records
+                    if float(row["kappa2_hat"]) == kappa and float(row["dt"]) == dt
+                ),
+                key=lambda row: int(row["n_paths"]),
+            )
+            x = np.asarray([row["log2_paths"] for row in group], dtype=float)
+            y = np.asarray([row["empirical_shortfall"] for row in group], dtype=float)
+            lower = np.asarray([row["bootstrap_ci_95"][0] for row in group], dtype=float)
+            upper = np.asarray([row["bootstrap_ci_95"][1] for row in group], dtype=float)
+            axis.plot(x, y, marker="o", color=color, label=f"dt=1/{round(1 / dt)}")
+            axis.fill_between(x, lower, upper, color=color, alpha=0.14)
+        axis.axhline(0.0, color="black", linewidth=0.8)
+        axis.set(ylabel="Shortfall", title=f"kappa2_hat = {kappa:g}")
+        axis.legend(loc="best", fontsize=8)
+    axes[-1].set_xlabel("log2(paths); smaller budgets are exact prefixes")
+    _caption(
+        figure,
+        "R7 — discounted-spot shortfall against path budget",
+        _provenance_line(results, "R7", "base 20260823; nested per-dt prefix streams")
+        + " Every finite-step mean equals one analytically. Bands are ordinary antithetic "
+        "pair-batch bootstrap intervals conditional on observed paths.",
+    )
+    return figure
+
+
+def _plot_r8(results: Mapping[str, Any]) -> Figure:
+    rows = _r8_summary_rows(results["R8"])
+    figure, axes = plt.subplots(2, 2, figsize=(11.0, 8.3), sharex=True)
+    regimes = (
+        ("a", "unrestricted", "#6c757d", "o"),
+        ("b", "fixed kappa2", "#457b9d", "s"),
+        ("c", "fixed kappa2+d0", "#e76f51", "^"),
+    )
+    for row_index, parameter_set in enumerate(("crypto", "equity")):
+        for column_index, parameter in enumerate(("kappa1", "theta")):
+            axis = axes[row_index, column_index]
+            group = sorted(
+                (
+                    row
+                    for row in rows
+                    if row["parameter_set"] == parameter_set and row["parameter"] == parameter
+                ),
+                key=lambda row: row["years"],
+            )
+            for field, label, color, marker in regimes:
+                axis.plot(
+                    [row["years"] for row in group],
+                    [row[field] for row in group],
+                    marker=marker,
+                    color=color,
+                    label=label,
+                )
+            axis.set(yscale="log", title=f"{parameter_set}: {parameter}", ylabel="RMSE")
+            axis.grid(alpha=0.2)
+            if row_index == 1:
+                axis.set_xlabel("Sample years")
+            if row_index == 0 and column_index == 0:
+                axis.legend(fontsize=8)
+    _caption(
+        figure,
+        "R8 — oracle RMSE ladder",
+        _provenance_line(results, "R8", str(results["R8"].get("round1_seed_rule", "E7 ledger")))
+        + " Rung (c) is an oracle upper bound on what option-implied kappa2_hat plus the "
+        "cross-measure d0 restriction can add; it is not achieved option identification.",
+    )
+    return figure
+
+
+def write_round3_figures_pdf(results: Mapping[str, Any], path: Path) -> None:
+    """Write the single round-three figures PDF."""
+
+    output = Path(path)
+    if output.suffix.lower() != ".pdf":
+        raise ValueError("Round-three figure output must end in .pdf")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with PdfPages(output) as pdf:
+        metadata = pdf.infodict()
+        metadata["Title"] = str(results["title"])
+        metadata["Subject"] = "TGARCH discrete-versus-continuous study, round 3"
+        for figure in (_cover(results), _plot_r6(results), _plot_r7(results), _plot_r8(results)):
+            pdf.savefig(figure, bbox_inches="tight")
+            plt.close(figure)
+
+
+__all__ = [
+    "write_round3_figures_pdf",
+    "write_round3_markdown",
+    "write_round3_results_json",
+]

--- a/volatility_book/ch_discrete_vol/round3_traceability.py
+++ b/volatility_book/ch_discrete_vol/round3_traceability.py
@@ -1,0 +1,1124 @@
+"""Round-3 R6 traceability run and R9 cited-number manifest.
+
+This repository-only module deliberately leaves the established study harness
+unchanged.  R6 reuses its full-budget E1 and E3 implementations, adds a
+strike-level combined-Monte-Carlo-error comparison for E1, and persists the
+deterministic E3 stationary draws.  R9 resolves every revision-3 numerical
+claim back to one or more RFC 6901 JSON pointers and records both exact raw
+values and the rounded or range-valued prose claim.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import subprocess
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from scipy.stats import ks_2samp
+
+from volatility_book.ch_discrete_vol.experiments import (
+    StudyProfile,
+    make_study_config,
+    parameter_sets,
+    run_e1,
+    run_e3,
+)
+from volatility_book.ch_discrete_vol.sim import (
+    LimitParams,
+    Measure,
+    derived_limit_params,
+    simulate_stationary_sigma,
+)
+
+R6_E1_Z_LIMIT = 3.0
+E3_SAMPLE_INTERVAL = 1.0 / 252.0
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _array_sha256(values: np.ndarray) -> str:
+    array = np.ascontiguousarray(np.asarray(values, dtype="<f8"))
+    return hashlib.sha256(array.tobytes(order="C")).hexdigest()
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ["git", "-c", "safe.directory=*", "-C", str(repository), *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _repository_revision(*, require_exact_clean_tag: bool) -> dict[str, str]:
+    repository = Path(__file__).resolve().parents[2]
+    head = _git(repository, "rev-parse", "HEAD")
+    status = _git(repository, "status", "--short", "--untracked-files=all")
+    try:
+        tag = _git(repository, "describe", "--tags", "--exact-match", "HEAD")
+    except subprocess.CalledProcessError:
+        tag = ""
+    if require_exact_clean_tag and status:
+        raise RuntimeError("R6 full run requires a clean worktree")
+    if require_exact_clean_tag and not tag:
+        raise RuntimeError("R6 full run requires HEAD to have an exact tag")
+    return {"repository_head": head, "repository_tag": tag, "repository_status": status}
+
+
+def _finest_e1_records(data: Mapping[str, Any]) -> dict[tuple[str, float], Mapping[str, Any]]:
+    records = data["records"]
+    groups: dict[tuple[str, float], list[Mapping[str, Any]]] = {}
+    for row in records:
+        key = (str(row["parameter_set"]), float(row["maturity"]))
+        groups.setdefault(key, []).append(row)
+    return {key: min(rows, key=lambda row: float(row["dt"])) for key, rows in groups.items()}
+
+
+def compare_full_budget_e1(
+    archived_e1: Mapping[str, Any],
+    clean_e1: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Compare finest-step E1 strike errors using combined Monte Carlo error."""
+    archived = _finest_e1_records(archived_e1)
+    clean = _finest_e1_records(clean_e1)
+    missing_in_clean = sorted(set(archived) - set(clean))
+    extra_in_clean = sorted(set(clean) - set(archived))
+    common_keys = sorted(set(archived) & set(clean))
+    if not common_keys:
+        raise RuntimeError("archived and clean E1 runs have no common groups")
+    rows: list[dict[str, Any]] = []
+    for key in common_keys:
+        old = archived[key]
+        new = clean[key]
+        old_strikes = np.asarray(old["strikes"], dtype=float)
+        new_strikes = np.asarray(new["strikes"], dtype=float)
+        if not np.array_equal(old_strikes, new_strikes):
+            raise RuntimeError(f"E1 strike grids differ for {key}")
+        old_error = np.asarray(old["mc_ivols"], dtype=float) - np.asarray(
+            old["affine_ivols"], dtype=float
+        )
+        new_error = np.asarray(new["mc_ivols"], dtype=float) - np.asarray(
+            new["affine_ivols"], dtype=float
+        )
+        old_se = np.asarray(old["mc_ivol_se"], dtype=float)
+        new_se = np.asarray(new["mc_ivol_se"], dtype=float)
+        combined_se = np.hypot(old_se, new_se)
+        difference = new_error - old_error
+        z_score = np.divide(
+            difference,
+            combined_se,
+            out=np.full_like(difference, np.inf),
+            where=combined_se > 0.0,
+        )
+        both_exact = (combined_se == 0.0) & (difference == 0.0)
+        z_score[both_exact] = 0.0
+        strike_rows = [
+            {
+                "strike": float(strike),
+                "archived_error_bp": float(1.0e4 * old_value),
+                "clean_error_bp": float(1.0e4 * new_value),
+                "archived_mc_se_bp": float(1.0e4 * old_se_value),
+                "clean_mc_se_bp": float(1.0e4 * new_se_value),
+                "combined_mc_se_bp": float(1.0e4 * combined_value),
+                "z_score": float(z_value),
+                "within_3_combined_se": bool(abs(z_value) <= R6_E1_Z_LIMIT),
+            }
+            for (
+                strike,
+                old_value,
+                new_value,
+                old_se_value,
+                new_se_value,
+                combined_value,
+                z_value,
+            ) in zip(
+                old_strikes,
+                old_error,
+                new_error,
+                old_se,
+                new_se,
+                combined_se,
+                z_score,
+                strict=True,
+            )
+        ]
+        maximum_z = float(np.max(np.abs(z_score)))
+        rows.append(
+            {
+                "parameter_set": key[0],
+                "maturity": key[1],
+                "dt": float(new["dt"]),
+                "archived_n_paths": int(old["n_paths"]),
+                "clean_n_paths": int(new["n_paths"]),
+                "archived_mean_abs_error_bp": float(np.mean(np.abs(old_error)) * 1.0e4),
+                "clean_mean_abs_error_bp": float(np.mean(np.abs(new_error)) * 1.0e4),
+                "archived_max_abs_error_bp": float(np.max(np.abs(old_error)) * 1.0e4),
+                "clean_max_abs_error_bp": float(np.max(np.abs(new_error)) * 1.0e4),
+                "maximum_abs_z_score": maximum_z,
+                "passed": bool(maximum_z <= R6_E1_Z_LIMIT),
+                "strike_rows": strike_rows,
+            }
+        )
+    return {
+        "criterion": "maximum strike-level absolute difference / combined MC SE <= 3",
+        "z_limit": R6_E1_Z_LIMIT,
+        "groups_complete": not missing_in_clean and not extra_in_clean,
+        "missing_in_clean": [
+            {"parameter_set": key[0], "maturity": key[1]} for key in missing_in_clean
+        ],
+        "extra_in_clean": [{"parameter_set": key[0], "maturity": key[1]} for key in extra_in_clean],
+        "rows": rows,
+        "maximum_abs_z_score": max(float(row["maximum_abs_z_score"]) for row in rows),
+        "acceptance_pass": bool(rows) and all(bool(row["passed"]) for row in rows),
+    }
+
+
+def _limit_from_e3_row(params: Any, row: Mapping[str, Any]) -> LimitParams:
+    base = derived_limit_params(params)
+    return LimitParams.from_drift_coefficients(
+        d0=base.d0,
+        d1_hat=base.d1_hat,
+        kappa2_hat=float(row["kappa2_hat"]),
+        lambda0_bar=base.lambda0_bar,
+        lambda1_bar=base.lambda1_bar,
+        vartheta=base.vartheta,
+    )
+
+
+def _sample_key(row: Mapping[str, Any]) -> str:
+    dt_code = format(float(row["dt"]), ".17g").replace(".", "p").replace("-", "m")
+    return f"{row['parameter_set']}__{row['variant']}__dt_{dt_code}"
+
+
+def persist_e3_stationary_samples(
+    e3: Mapping[str, Any],
+    *,
+    samples_path: Path,
+) -> dict[str, Any]:
+    """Recreate and save the deterministic samples underlying E3 diagnostics."""
+    params_by_name = parameter_sets()
+    arrays: dict[str, np.ndarray] = {}
+    records: list[dict[str, Any]] = []
+    for row in e3["records"]:
+        params = params_by_name[str(row["parameter_set"])]
+        limit = _limit_from_e3_row(params, row)
+        simulated = simulate_stationary_sigma(
+            params=params,
+            measure=Measure.Q_LIMIT,
+            dt=float(row["dt"]),
+            burn_years=float(row["burn_years"]),
+            sample_years=float(row["sample_years"]),
+            sample_interval=E3_SAMPLE_INTERVAL,
+            seed=int(row["seed"]),
+            limit_params=limit,
+        )
+        samples = np.asarray(simulated.samples, dtype=np.float64)
+        key = _sample_key(row)
+        if key in arrays:
+            raise RuntimeError(f"duplicate E3 sample key: {key}")
+        if samples.size != int(row["n_samples"]):
+            raise RuntimeError(f"E3 sample count does not reproduce for {key}")
+        if simulated.floor_hits != int(row["floor_hits"]):
+            raise RuntimeError(f"E3 floor-hit count does not reproduce for {key}")
+        probabilities = np.asarray(row["probabilities"], dtype=float)
+        expected_quantiles = np.asarray(row["sample_quantiles"], dtype=float)
+        reproduced_quantiles = np.quantile(samples, probabilities)
+        if not np.array_equal(reproduced_quantiles, expected_quantiles):
+            maximum_error = float(np.max(np.abs(reproduced_quantiles - expected_quantiles)))
+            if maximum_error > 5.0e-14:
+                raise RuntimeError(f"E3 sample quantiles do not reproduce for {key}")
+        arrays[key] = samples
+        records.append(
+            {
+                "array_key": key,
+                "parameter_set": row["parameter_set"],
+                "variant": row["variant"],
+                "dt": float(row["dt"]),
+                "seed": int(row["seed"]),
+                "burn_years": float(row["burn_years"]),
+                "sample_years": float(row["sample_years"]),
+                "sample_interval": E3_SAMPLE_INTERVAL,
+                "n_samples": int(samples.size),
+                "floor_hits": int(simulated.floor_hits),
+                "mean": float(np.mean(samples)),
+                "standard_deviation": float(np.std(samples, ddof=1)),
+                "minimum": float(np.min(samples)),
+                "maximum": float(np.max(samples)),
+                "array_sha256_float64_little_endian": _array_sha256(samples),
+            }
+        )
+    destination = Path(samples_path).resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(destination.name + ".tmp.npz")
+    np.savez_compressed(temporary, **{key: arrays[key] for key in sorted(arrays)})
+    temporary.replace(destination)
+    return {
+        "path": destination.name,
+        "absolute_path_at_execution": str(destination),
+        "format": "NumPy compressed NPZ; each array is float64",
+        "sha256": _sha256(destination),
+        "sample_interval": E3_SAMPLE_INTERVAL,
+        "records": records,
+        "all_quantiles_reproduced": True,
+    }
+
+
+def compare_stationary_sample_archives(
+    reference_path: Path,
+    candidate_path: Path,
+) -> dict[str, Any]:
+    """Diff two R6 E3 sample archives, including a two-sample KS diagnostic."""
+    rows: list[dict[str, Any]] = []
+    with (
+        np.load(reference_path, allow_pickle=False) as reference,
+        np.load(candidate_path, allow_pickle=False) as candidate,
+    ):
+        reference_keys = set(reference.files)
+        candidate_keys = set(candidate.files)
+        if reference_keys != candidate_keys:
+            return {
+                "keys_match": False,
+                "missing_in_candidate": sorted(reference_keys - candidate_keys),
+                "extra_in_candidate": sorted(candidate_keys - reference_keys),
+                "rows": [],
+                "all_exact": False,
+            }
+        for key in sorted(reference_keys):
+            old = np.asarray(reference[key], dtype=float)
+            new = np.asarray(candidate[key], dtype=float)
+            same_shape = old.shape == new.shape
+            exact = same_shape and np.array_equal(old, new)
+            paired_difference = new - old if same_shape else np.array([], dtype=float)
+            ks = ks_2samp(old, new, alternative="two-sided", method="auto")
+            rows.append(
+                {
+                    "array_key": key,
+                    "reference_n": int(old.size),
+                    "candidate_n": int(new.size),
+                    "same_shape": same_shape,
+                    "exact": exact,
+                    "reference_sha256": _array_sha256(old),
+                    "candidate_sha256": _array_sha256(new),
+                    "paired_mean_difference": (
+                        float(np.mean(paired_difference)) if same_shape else None
+                    ),
+                    "paired_rmse": (
+                        float(np.sqrt(np.mean(np.square(paired_difference))))
+                        if same_shape
+                        else None
+                    ),
+                    "paired_max_abs_difference": (
+                        float(np.max(np.abs(paired_difference))) if same_shape else None
+                    ),
+                    "ks_statistic": float(ks.statistic),
+                    "ks_pvalue": float(ks.pvalue),
+                }
+            )
+    return {
+        "keys_match": True,
+        "missing_in_candidate": [],
+        "extra_in_candidate": [],
+        "rows": rows,
+        "all_exact": bool(rows) and all(bool(row["exact"]) for row in rows),
+    }
+
+
+def run_round3_r6(
+    archived_round1: Mapping[str, Any],
+    *,
+    profile: StudyProfile,
+    samples_path: Path,
+) -> dict[str, Any]:
+    """Run R6 at the selected workload; only FULL closes the blocking obligation."""
+    if not isinstance(profile, StudyProfile):
+        raise ValueError("profile must be a StudyProfile")
+    started = time.perf_counter()
+    revision = _repository_revision(require_exact_clean_tag=profile is StudyProfile.FULL)
+    config = make_study_config(profile)
+    params = parameter_sets()
+    print(f"[TGARCH round 3] R6 E1 ({profile.value}): start", flush=True)
+    e1 = run_e1(params, config)
+    e1_stability = compare_full_budget_e1(archived_round1["experiments"]["E1"], e1)
+    print(f"[TGARCH round 3] R6 E3 ({profile.value}): start", flush=True)
+    e3 = run_e3(params, config)
+    samples = persist_e3_stationary_samples(e3, samples_path=samples_path)
+    full_budget = profile is StudyProfile.FULL
+    return {
+        "claim": (
+            "full-budget clean-tag E1 agrees with the archived run within combined Monte "
+            "Carlo error, and E3 stationary samples are retained for direct future diffs"
+        ),
+        "profile": profile.value,
+        "is_full_round1_budget": full_budget,
+        "e1_full_budget": e1,
+        "e1_stability": e1_stability,
+        "e3_clean_run": e3,
+        "e3_stationary_samples": samples,
+        "acceptance_pass": bool(e1_stability["acceptance_pass"] and e3["acceptance_pass"]),
+        "blocking_requirement_satisfied": bool(
+            full_budget
+            and e1_stability["groups_complete"]
+            and e1_stability["acceptance_pass"]
+            and e3["acceptance_pass"]
+        ),
+        "acceptance_criterion": (
+            "At FULL profile, every finest-step E1 strike must be within three combined MC "
+            "standard errors of the archived value; the clean E3 acceptance gate must pass; "
+            "and all underlying stationary samples must be archived."
+        ),
+        "provenance": {
+            **revision,
+            "seed_E1": int(e1["seed"]),
+            "seed_E3": int(e3["seed"]),
+            "archived_round1_repository_describe": archived_round1["provenance"][
+                "repository_describe"
+            ],
+            "archived_round1_results_sha256": archived_round1.get("_results_sha256"),
+        },
+        "runtime_seconds": time.perf_counter() - started,
+    }
+
+
+def _pointer_get(document: Any, pointer: str) -> Any:
+    if pointer == "":
+        return document
+    if not pointer.startswith("/"):
+        raise ValueError(f"invalid RFC 6901 pointer: {pointer}")
+    value = document
+    for encoded in pointer[1:].split("/"):
+        token = encoded.replace("~1", "/").replace("~0", "~")
+        if isinstance(value, Mapping):
+            value = value[token]
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            value = value[int(token)]
+        else:
+            raise KeyError(f"pointer traverses a scalar at {token!r}: {pointer}")
+    return value
+
+
+def _find_index(rows: Sequence[Mapping[str, Any]], **conditions: Any) -> int:
+    matches: list[int] = []
+    for index, row in enumerate(rows):
+        matched = True
+        for key, expected in conditions.items():
+            actual = row.get(key)
+            if isinstance(expected, float):
+                matched &= isinstance(actual, (int, float)) and math.isclose(
+                    float(actual), expected, rel_tol=1.0e-12, abs_tol=1.0e-15
+                )
+            else:
+                matched &= actual == expected
+        if matched:
+            matches.append(index)
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one row for {conditions}, found {len(matches)}")
+    return matches[0]
+
+
+def _archive_tag(name: str, document: Mapping[str, Any]) -> str:
+    provenance = document.get("provenance", {})
+    if name == "round1":
+        return str(provenance.get("repository_describe", "unavailable"))
+    return str(
+        provenance.get("repository_tag", provenance.get("repository_describe", "unavailable"))
+    )
+
+
+def _source(
+    archive: str,
+    pointer: str,
+    archives: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "archive": archive,
+        "json_pointer": pointer,
+        "producing_tag": _archive_tag(archive, archives[archive]),
+    }
+
+
+def _evaluate_sources(
+    sources: Sequence[Mapping[str, Any]],
+    archives: Mapping[str, Mapping[str, Any]],
+    transform: str,
+) -> Any:
+    values = [
+        _pointer_get(archives[str(item["archive"])], str(item["json_pointer"])) for item in sources
+    ]
+    if transform == "identity":
+        if len(values) != 1:
+            raise ValueError("identity transform requires one source")
+        return values[0]
+    if transform == "absolute":
+        if len(values) != 1:
+            raise ValueError("absolute transform requires one source")
+        return abs(float(values[0]))
+    if transform == "scale_100":
+        if len(values) != 1:
+            raise ValueError("scale_100 transform requires one source")
+        return 100.0 * float(values[0])
+    if transform == "ratio_percent":
+        if len(values) != 2:
+            raise ValueError("ratio_percent transform requires numerator and denominator")
+        return 100.0 * float(values[0]) / abs(float(values[1]))
+    raise ValueError(f"unsupported cited-number transform: {transform}")
+
+
+def _claim_supported(values: Sequence[Any], specification: Mapping[str, Any]) -> bool:
+    kind = specification["kind"]
+    numeric = [float(value) for value in values]
+    if kind == "rounded_range":
+        rounded = [round(value, int(specification.get("digits", 0))) for value in numeric]
+        return min(rounded) == specification["lower"] and max(rounded) == specification["upper"]
+    if kind == "rounded_value":
+        return all(
+            round(value, int(specification.get("digits", 0))) == specification["value"]
+            for value in numeric
+        )
+    if kind == "approximately":
+        return all(
+            abs(value - float(specification["value"])) <= float(specification["tolerance"])
+            for value in numeric
+        )
+    if kind == "all_less_than":
+        return all(value < float(specification["value"]) for value in numeric)
+    if kind == "all_greater_than":
+        return all(value > float(specification["value"]) for value in numeric)
+    if kind == "all_within_fraction_of_one":
+        return all(abs(value - 1.0) <= float(specification["fraction"]) for value in numeric)
+    if kind == "all_equal":
+        return all(value == specification["value"] for value in values)
+    raise ValueError(f"unsupported note-claim check: {kind}")
+
+
+def _make_citation(
+    *,
+    identifier: str,
+    claim_id: str,
+    claim_text: str,
+    claim_form: str,
+    sources: Sequence[Mapping[str, Any]],
+    archives: Mapping[str, Mapping[str, Any]],
+    units: str,
+    transform: str = "identity",
+) -> dict[str, Any]:
+    value = _evaluate_sources(sources, archives, transform)
+    return {
+        "id": identifier,
+        "claim_id": claim_id,
+        "claim_text": claim_text,
+        "claim_form": claim_form,
+        "units": units,
+        "transform": transform,
+        "sources": list(sources),
+        "raw_value": value,
+    }
+
+
+def _build_citations(archives: Mapping[str, Mapping[str, Any]]) -> list[dict[str, Any]]:
+    round1 = archives["round1"]
+    round2 = archives["round2"]
+    round3 = archives["round3"]
+    r6 = round3["R6"]
+    citations: list[dict[str, Any]] = []
+
+    def add(**arguments: Any) -> None:
+        citations.append(_make_citation(archives=archives, **arguments))
+
+    e1_summaries = r6["e1_full_budget"]["summaries"]
+    for parameter_set, maturity, claim_id, claim_text in (
+        ("equity", 1.0 / 12.0, "e1_equity_mean", "4--5 bp equity mean"),
+        ("equity", 1.0 / 4.0, "e1_equity_mean", "4--5 bp equity mean"),
+        ("crypto", 1.0 / 12.0, "e1_crypto_mean", "23--26 bp crypto mean"),
+        ("crypto", 1.0 / 4.0, "e1_crypto_mean", "23--26 bp crypto mean"),
+    ):
+        index = _find_index(e1_summaries, parameter_set=parameter_set, maturity=maturity)
+        add(
+            identifier=f"E1.{parameter_set}.T{maturity:.8g}.mean_abs_error_bp",
+            claim_id=claim_id,
+            claim_text=claim_text,
+            claim_form="integer-rounded range",
+            sources=[
+                _source(
+                    "round3",
+                    f"/R6/e1_full_budget/summaries/{index}/finest_mean_abs_error_bp",
+                    archives,
+                )
+            ],
+            units="implied-volatility bp",
+        )
+    crypto_month = _find_index(e1_summaries, parameter_set="crypto", maturity=1.0 / 12.0)
+    add(
+        identifier="E1.crypto.T0.083333333.max_abs_error_bp",
+        claim_id="e1_crypto_wing_max",
+        claim_text="58 bp one-month crypto wing maximum",
+        claim_form="integer-rounded value",
+        sources=[
+            _source(
+                "round3",
+                f"/R6/e1_full_budget/summaries/{crypto_month}/finest_max_abs_error_bp",
+                archives,
+            )
+        ],
+        units="implied-volatility bp",
+    )
+
+    e2_rates = round1["experiments"]["E2"]["rates"]
+    for parameter_set in ("crypto", "equity"):
+        index = _find_index(e2_rates, parameter_set=parameter_set)
+        add(
+            identifier=f"E2.{parameter_set}.fitted_rate",
+            claim_id="e2_rates",
+            claim_text="fitted rates about 0.48",
+            claim_form="approximate common value",
+            sources=[_source("round1", f"/experiments/E2/rates/{index}/fitted_rate", archives)],
+            units="log-log slope",
+        )
+
+    e3_records = r6["e3_clean_run"]["records"]
+    for parameter_set in ("crypto", "equity"):
+        for dt, suffix in ((1.0 / 252.0, "daily"), (1.0 / 1008.0, "fine")):
+            index = _find_index(e3_records, parameter_set=parameter_set, variant="baseline", dt=dt)
+            add(
+                identifier=f"E3.{parameter_set}.{suffix}.relative_sup_density_percent",
+                claim_id=f"e3_{suffix}",
+                claim_text=(
+                    "5.63% and 8.69% at daily steps"
+                    if suffix == "daily"
+                    else "2.95% and 6.42% at dt=1/1008"
+                ),
+                claim_form="attributed integer-rounded range",
+                sources=[
+                    _source(
+                        "round3",
+                        f"/R6/e3_clean_run/records/{index}/relative_sup_density_error",
+                        archives,
+                    )
+                ],
+                units="percent",
+                transform="scale_100",
+            )
+
+    e5_records = round1["experiments"]["E5"]["records"]
+    for dt, label in (
+        (1.0 / 52.0, "weekly"),
+        (1.0 / 252.0, "daily"),
+        (1.0 / 1008.0, "fine"),
+    ):
+        index = _find_index(e5_records, dt=dt)
+        add(
+            identifier=f"E5.{label}.kesten_alpha",
+            claim_id="e5_kesten_indices",
+            claim_text="Kesten indices 2.68, 2.76, and 2.80",
+            claim_form="ordered values rounded to two decimals",
+            sources=[_source("round1", f"/experiments/E5/records/{index}/kesten_alpha", archives)],
+            units="survival-tail exponent",
+        )
+    add(
+        identifier="E5.continuous.inverse_gamma_alpha",
+        claim_id="e5_limit_index",
+        claim_text="continuous limit index 2.85",
+        claim_form="value rounded to two decimals",
+        sources=[
+            _source(
+                "round1",
+                "/experiments/E5/records/0/continuous_inverse_gamma_alpha",
+                archives,
+            )
+        ],
+        units="survival-tail exponent",
+    )
+
+    r2_rows = round2["R2"]["q_limit"]
+    finest_dt = min(
+        float(row["dt"])
+        for row in r2_rows
+        if math.isclose(float(row["maturity"]), 1.0) and int(row["n_paths"]) == 2**20
+    )
+    for kappa2_hat, claim_id, text in (
+        (0.0, "r2_shortfall_k0", "one-year shortfall 0.22 at kappa2_hat=0"),
+        (0.5, "r2_shortfall_k05", "one-year shortfall 0.08 at kappa2_hat=0.5"),
+        (2.0, "r2_shortfall_k2", "shortfall indistinguishable from zero at kappa2_hat>=2"),
+    ):
+        index = _find_index(
+            r2_rows,
+            maturity=1.0,
+            n_paths=2**20,
+            dt=finest_dt,
+            kappa2_hat=kappa2_hat,
+        )
+        add(
+            identifier=f"R2.kappa2_{kappa2_hat:g}.finest.empirical_shortfall",
+            claim_id=claim_id,
+            claim_text=text,
+            claim_form="absolute shortfall rounded to two decimals",
+            sources=[
+                _source(
+                    "round2",
+                    f"/R2/q_limit/{index}/empirical_fixed_budget_defect",
+                    archives,
+                )
+            ],
+            units="discounted-spot expectation",
+            transform="absolute",
+        )
+        if kappa2_hat == 2.0:
+            add(
+                identifier="R2.kappa2_2.finest.bootstrap_ci_contains_zero",
+                claim_id="r2_shortfall_k2_ci",
+                claim_text="shortfall indistinguishable from zero at kappa2_hat>=2",
+                claim_form="bootstrap confidence-interval decision",
+                sources=[
+                    _source(
+                        "round2",
+                        f"/R2/q_limit/{index}/bootstrap_ci_contains_zero",
+                        archives,
+                    )
+                ],
+                units="boolean",
+            )
+
+    r4_regressions = round2["R4"]["regressions"]
+    for parameter_set in ("crypto", "equity"):
+        index = _find_index(r4_regressions, parameter_set=parameter_set)
+        base = f"/R4/regressions/{index}"
+        for suffix, pointer, claim_id, text, units in (
+            (
+                "rmse_exponent",
+                f"{base}/rmse/exponent",
+                "r4_exponents",
+                "filter-error exponents 0.249 and 0.234",
+                "log-log slope",
+            ),
+            (
+                "gain_slope_ratio",
+                f"{base}/forgetting/slope_ratio",
+                "r4_slope_match",
+                "gain slope matches within one tenth of one percent",
+                "ratio",
+            ),
+            (
+                "rmse_actual_level_ratio",
+                f"{base}/rmse/actual_sigma_bar_level_ratio",
+                "r4_rmse_level_match",
+                "RMSE level matches within ten percent using realized average volatility",
+                "ratio",
+            ),
+            (
+                "jensen_intercept_ratio",
+                f"{base}/forgetting/asymptotic_log_decay_intercept_ratio",
+                "r4_intercept_match",
+                "Jensen-corrected log-decay intercept matches within nine percent",
+                "ratio",
+            ),
+        ):
+            add(
+                identifier=f"R4.{parameter_set}.{suffix}",
+                claim_id=claim_id,
+                claim_text=text,
+                claim_form="raw ratio or rounded value",
+                sources=[_source("round2", pointer, archives)],
+                units=units,
+            )
+
+    e7_identification = round1["experiments"]["E7"]["identification"]
+    for parameter_set in ("crypto", "equity"):
+        index = _find_index(e7_identification, parameter_set=parameter_set, years=40)
+        for field in ("gamma1_identified_at_2", "median_abs_gamma1_tstat"):
+            add(
+                identifier=f"R5.{parameter_set}.40y.{field}",
+                claim_id="r5_gamma1_unidentified",
+                claim_text="gamma1 unidentified at forty years",
+                claim_form="decision and supporting median absolute t-statistic",
+                sources=[
+                    _source(
+                        "round1",
+                        f"/experiments/E7/identification/{index}/{field}",
+                        archives,
+                    )
+                ],
+                units="boolean" if field.endswith("_2") else "absolute t-statistic",
+            )
+
+    e7_summaries = round1["experiments"]["E7"]["summaries"]
+    for parameter_set in ("crypto", "equity"):
+        index = _find_index(e7_summaries, parameter_set=parameter_set, parameter="kappa2", years=40)
+        add(
+            identifier=f"R5.{parameter_set}.40y.kappa2.relative_rmse_percent",
+            claim_id="r5_kappa2_relative_rmse",
+            claim_text="kappa2 RMSE is 56--100% of truth",
+            claim_form="integer-rounded derived range",
+            sources=[
+                _source("round1", f"/experiments/E7/summaries/{index}/rmse", archives),
+                _source("round1", f"/experiments/E7/summaries/{index}/truth", archives),
+            ],
+            units="percent of truth",
+            transform="ratio_percent",
+        )
+
+    derived_summaries = round2["R5"]["derived_summaries"]
+    for quantity, claim_id, text in (
+        ("vartheta", "r5_vartheta_relative_rmse", "vartheta RMSE about 4%"),
+        ("kappa_lin", "r5_kappa_lin_relative_rmse", "kappa_lin RMSE about 13%"),
+        ("d0", "r5_d0_relative_rmse", "d0 RMSE 19--25%"),
+    ):
+        for parameter_set in ("crypto", "equity"):
+            index = _find_index(
+                derived_summaries,
+                parameter_set=parameter_set,
+                quantity=quantity,
+                years=40,
+            )
+            add(
+                identifier=f"R5.{parameter_set}.40y.{quantity}.relative_rmse_percent",
+                claim_id=claim_id,
+                claim_text=text,
+                claim_form="integer-rounded value or range",
+                sources=[
+                    _source("round2", f"/R5/derived_summaries/{index}/rmse", archives),
+                    _source("round2", f"/R5/derived_summaries/{index}/truth", archives),
+                ],
+                units="percent of truth",
+                transform="ratio_percent",
+            )
+    add(
+        identifier="R5.minimum_speed_ridge_cosine",
+        claim_id="r5_cosines",
+        claim_text="speed/ridge eigendirection cosines above 0.97",
+        claim_form="lower bound",
+        sources=[
+            _source(
+                "round2",
+                "/R5/ridge_hypothesis_diagnostics/minimum_small_eigenvector_speed_abs_cosine",
+                archives,
+            )
+        ],
+        units="absolute cosine",
+    )
+    return citations
+
+
+CLAIM_SPECIFICATIONS: dict[str, dict[str, Any]] = {
+    "e1_equity_mean": {"kind": "rounded_range", "lower": 4, "upper": 5, "digits": 0},
+    "e1_crypto_mean": {"kind": "rounded_range", "lower": 23, "upper": 26, "digits": 0},
+    "e1_crypto_wing_max": {"kind": "rounded_value", "value": 58, "digits": 0},
+    "e2_rates": {"kind": "approximately", "value": 0.48, "tolerance": 0.01},
+    "e3_daily": {"kind": "rounded_range", "lower": 5.63, "upper": 8.69, "digits": 2},
+    "e3_fine": {"kind": "rounded_range", "lower": 2.95, "upper": 6.42, "digits": 2},
+    "e5_kesten_indices": {"kind": "all_equal", "value": True},
+    "e5_limit_index": {"kind": "rounded_value", "value": 2.85, "digits": 2},
+    "r2_shortfall_k0": {"kind": "rounded_value", "value": 0.22, "digits": 2},
+    "r2_shortfall_k05": {"kind": "rounded_value", "value": 0.08, "digits": 2},
+    "r2_shortfall_k2": {"kind": "rounded_value", "value": 0.0, "digits": 2},
+    "r2_shortfall_k2_ci": {"kind": "all_equal", "value": True},
+    "r4_exponents": {"kind": "all_equal", "value": True},
+    "r4_slope_match": {"kind": "all_within_fraction_of_one", "fraction": 0.001},
+    "r4_rmse_level_match": {"kind": "all_within_fraction_of_one", "fraction": 0.10},
+    "r4_intercept_match": {"kind": "all_within_fraction_of_one", "fraction": 0.091},
+    "r5_gamma1_unidentified": {"kind": "all_equal", "value": True},
+    "r5_kappa2_relative_rmse": {
+        "kind": "rounded_range",
+        "lower": 56,
+        "upper": 100,
+        "digits": 0,
+    },
+    "r5_vartheta_relative_rmse": {"kind": "rounded_value", "value": 4, "digits": 0},
+    "r5_kappa_lin_relative_rmse": {"kind": "rounded_value", "value": 13, "digits": 0},
+    "r5_d0_relative_rmse": {
+        "kind": "rounded_range",
+        "lower": 19,
+        "upper": 25,
+        "digits": 0,
+    },
+    "r5_cosines": {"kind": "all_greater_than", "value": 0.97},
+}
+
+
+def _claim_checks(citations: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for citation in citations:
+        grouped.setdefault(str(citation["claim_id"]), []).append(citation)
+    checks: list[dict[str, Any]] = []
+    for claim_id, specification in CLAIM_SPECIFICATIONS.items():
+        rows = grouped.get(claim_id, [])
+        if claim_id == "e5_kesten_indices":
+            observed = [round(float(row["raw_value"]), 2) for row in rows]
+            expected = [2.68, 2.76, 2.80]
+            supported = observed == expected
+        elif claim_id == "r4_exponents":
+            observed = [round(float(row["raw_value"]), 3) for row in rows]
+            expected = [0.249, 0.234]
+            supported = observed == expected
+        elif claim_id == "r5_gamma1_unidentified":
+            decisions = [
+                row["raw_value"] for row in rows if row["id"].endswith("gamma1_identified_at_2")
+            ]
+            t_statistics = [
+                float(row["raw_value"])
+                for row in rows
+                if row["id"].endswith("median_abs_gamma1_tstat")
+            ]
+            observed = {"identified": decisions, "median_abs_tstat": t_statistics}
+            expected = {"identified": [False, False], "median_abs_tstat_below": 2.0}
+            supported = decisions == [False, False] and all(value < 2.0 for value in t_statistics)
+        else:
+            observed = [row["raw_value"] for row in rows]
+            expected = specification
+            supported = bool(rows) and _claim_supported(observed, specification)
+        checks.append(
+            {
+                "claim_id": claim_id,
+                "claim_text": rows[0]["claim_text"] if rows else "missing citation rows",
+                "observed": observed,
+                "expected_representation": expected,
+                "supported": bool(supported),
+            }
+        )
+
+    daily = grouped.get("e3_daily", [])
+    fine = grouped.get("e3_fine", [])
+    if daily and fine:
+        daily_values = {str(row["id"]).split(".")[1]: float(row["raw_value"]) for row in daily}
+        fine_values = {str(row["id"]).split(".")[1]: float(row["raw_value"]) for row in fine}
+        combined_values = (*daily_values.values(), *fine_values.values())
+        ratios = {name: fine_values[name] / daily_values[name] for name in sorted(daily_values)}
+        checks.append(
+            {
+                "claim_id": "e3_fine_decline",
+                "claim_text": "the errors fall to 2.95% and 6.42% at dt=1/1008",
+                "observed": ratios,
+                "expected_representation": "fine-step error is lower for both parameter sets",
+                "supported": all(0.0 < value < 1.0 for value in ratios.values()),
+            }
+        )
+        checks.append(
+            {
+                "claim_id": "e3_attribution_audit",
+                "claim_text": "daily and dt=1/1008 values are attributed separately",
+                "observed": {
+                    "daily_integer_rounded_range": [
+                        min(round(value) for value in daily_values.values()),
+                        max(round(value) for value in daily_values.values()),
+                    ],
+                    "dt_1_over_1008_integer_rounded_range": [
+                        min(round(value) for value in fine_values.values()),
+                        max(round(value) for value in fine_values.values()),
+                    ],
+                    "combined_integer_rounded_range": [
+                        min(round(value) for value in combined_values),
+                        max(round(value) for value in combined_values),
+                    ],
+                },
+                "expected_representation": {
+                    "daily_two_decimal_range": [5.63, 8.69],
+                    "dt_1_over_1008_two_decimal_range": [2.95, 6.42],
+                },
+                "supported": (
+                    sorted(round(value, 2) for value in daily_values.values()) == [5.63, 8.69]
+                    and sorted(round(value, 2) for value in fine_values.values()) == [2.95, 6.42]
+                ),
+                "finding": (
+                    "The corrected note reports the daily and dt=1/1008 values separately "
+                    "and makes no common halving claim."
+                ),
+            }
+        )
+    return checks
+
+
+def build_cited_numbers_manifest(
+    *,
+    round1: Mapping[str, Any],
+    round2: Mapping[str, Any],
+    round3: Mapping[str, Any],
+    output_path: Path | None = None,
+    archive_file_names: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build and optionally write the R9 manifest from the three study archives."""
+    archives = {"round1": round1, "round2": round2, "round3": round3}
+    citations = _build_citations(archives)
+    checks = _claim_checks(citations)
+    names = {
+        "round1": "results.json",
+        "round2": "round2_results.json",
+        "round3": "round3_results.json",
+        **dict(archive_file_names or {}),
+    }
+    manifest = {
+        "schema_version": 1,
+        "note_revision": 3,
+        "purpose": (
+            "Map every revision-3 note-cited value to its producing archive pointer and "
+            "tag, preserving exact raw values separately from prose rounding."
+        ),
+        "source_archives": {
+            name: {
+                "file": names[name],
+                "producing_tag": _archive_tag(name, document),
+            }
+            for name, document in archives.items()
+        },
+        "cited_numbers": citations,
+        "note_claim_checks": checks,
+        "automatic_check_summary": {
+            "all_pointers_resolved": True,
+            "citation_count": len(citations),
+            "claim_check_count": len(checks),
+            "supported_claim_count": sum(bool(check["supported"]) for check in checks),
+            "unsupported_claim_ids": [
+                check["claim_id"] for check in checks if not bool(check["supported"])
+            ],
+            "note_claims_all_supported": all(bool(check["supported"]) for check in checks),
+        },
+        "future_diff_contract": {
+            "raw_value_change": (
+                "Any exact raw-value change is reported for review; it is not silently "
+                "treated as an excursion beyond Monte Carlo noise."
+            ),
+            "note_claim_excursion": (
+                "A claim excursion occurs when current raw values cease to support the "
+                "stored rounded/range claim specification."
+            ),
+            "E1_noise_gate": (
+                "Use /R6/e1_stability/rows/*/passed: it implements the declared maximum "
+                "strike-level three-combined-SE gate."
+            ),
+            "E3_sample_diff": (
+                "Use compare_stationary_sample_archives on the NPZ artifacts before "
+                "interpreting a changed density diagnostic."
+            ),
+        },
+    }
+    if output_path is not None:
+        destination = Path(output_path).resolve()
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n",
+            encoding="utf-8",
+        )
+    return manifest
+
+
+def run_round3_r9(
+    *,
+    round1: Mapping[str, Any],
+    round2: Mapping[str, Any],
+    round3: Mapping[str, Any],
+    output_path: Path,
+    archive_file_names: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Write ``cited_numbers.json`` and return the compact top-level R9 section."""
+    destination = Path(output_path).resolve()
+    manifest = build_cited_numbers_manifest(
+        round1=round1,
+        round2=round2,
+        round3=round3,
+        output_path=destination,
+        archive_file_names=archive_file_names,
+    )
+    summary = manifest["automatic_check_summary"]
+    return {
+        "claim": (
+            "every revision-3 note-cited number maps to archive JSON pointer(s) and its "
+            "producing tag, with exact raw values separated from prose rounding"
+        ),
+        "manifest_file": destination.name,
+        "manifest_absolute_path_at_execution": str(destination),
+        "manifest_sha256": _sha256(destination),
+        "schema_version": manifest["schema_version"],
+        "citation_count": summary["citation_count"],
+        "claim_check_count": summary["claim_check_count"],
+        "all_pointers_resolved": summary["all_pointers_resolved"],
+        "note_claims_all_supported": summary["note_claims_all_supported"],
+        "unsupported_claim_ids": summary["unsupported_claim_ids"],
+        "note_claim_checks": manifest["note_claim_checks"],
+        "acceptance_pass": bool(summary["all_pointers_resolved"] and summary["citation_count"] > 0),
+        "interpretation": (
+            "R9 traceability acceptance concerns pointer completeness. Unsupported prose "
+            "claims remain explicit findings and do not invalidate the manifest itself."
+        ),
+    }
+
+
+def check_cited_numbers_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    round1: Mapping[str, Any],
+    round2: Mapping[str, Any],
+    round3: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Diff current archives against a saved manifest and rerun prose-claim checks."""
+    archives = {"round1": round1, "round2": round2, "round3": round3}
+    current_rows: list[dict[str, Any]] = []
+    pointer_errors: list[dict[str, str]] = []
+    for baseline in manifest["cited_numbers"]:
+        try:
+            current = _evaluate_sources(baseline["sources"], archives, str(baseline["transform"]))
+        except (KeyError, IndexError, TypeError, ValueError) as error:
+            pointer_errors.append({"id": baseline["id"], "error": str(error)})
+            continue
+        expected = baseline["raw_value"]
+        if isinstance(current, (int, float)) and isinstance(expected, (int, float)):
+            raw_changed = not math.isclose(
+                float(current), float(expected), rel_tol=0.0, abs_tol=0.0
+            )
+        else:
+            raw_changed = current != expected
+        row = dict(baseline)
+        row["raw_value"] = current
+        current_rows.append(
+            {
+                "id": baseline["id"],
+                "baseline_raw_value": expected,
+                "current_raw_value": current,
+                "raw_changed": raw_changed,
+            }
+        )
+    current_checks = _claim_checks(
+        [
+            {
+                **baseline,
+                "raw_value": next(
+                    row["current_raw_value"] for row in current_rows if row["id"] == baseline["id"]
+                ),
+            }
+            for baseline in manifest["cited_numbers"]
+            if any(row["id"] == baseline["id"] for row in current_rows)
+        ]
+    )
+    raw_changes = [row for row in current_rows if row["raw_changed"]]
+    unsupported = [check for check in current_checks if not bool(check["supported"])]
+    return {
+        "all_pointers_resolved": not pointer_errors,
+        "pointer_errors": pointer_errors,
+        "raw_change_count": len(raw_changes),
+        "raw_changes": raw_changes,
+        "claim_excursion_count": len(unsupported),
+        "unsupported_claims": unsupported,
+        "current_claim_checks": current_checks,
+        "archive_stability_pass": not pointer_errors and not raw_changes,
+        "note_claims_all_supported": not unsupported,
+    }
+
+
+__all__ = [
+    "build_cited_numbers_manifest",
+    "check_cited_numbers_manifest",
+    "compare_full_budget_e1",
+    "compare_stationary_sample_archives",
+    "persist_e3_stationary_samples",
+    "run_round3_r6",
+    "run_round3_r9",
+]

--- a/volatility_book/ch_discrete_vol/run_study.py
+++ b/volatility_book/ch_discrete_vol/run_study.py
@@ -1,0 +1,117 @@
+"""Command-line runner for the discrete-versus-continuous TGARCH study.
+
+Model inputs use annualized volatilities and rates, with time and ``dt`` in
+years.  The simulator records log returns.  This runner writes ``results.md``,
+``figures.pdf``, and ``results.json`` to one selected output directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+from enum import Enum
+from pathlib import Path
+
+from volatility_book.ch_discrete_vol.experiments import (
+    StudyProfile,
+    StudyResults,
+    run_all_experiments,
+)
+from volatility_book.ch_discrete_vol.reporting import (
+    write_figures_pdf,
+    write_results_json,
+    write_results_markdown,
+)
+
+DEFAULT_OUTPUT_DIR = Path(__file__).resolve().parent / "output"
+
+
+class LocalTests(str, Enum):
+    """Runnable local study profiles."""
+
+    SMOKE = "smoke"
+    REFERENCE = "reference"
+    FULL = "full"
+
+
+def _study_profile(value: str | StudyProfile) -> StudyProfile:
+    if isinstance(value, StudyProfile):
+        return value
+    try:
+        return StudyProfile(value)
+    except ValueError as error:
+        choices = ", ".join(str(profile.value) for profile in StudyProfile)
+        raise ValueError(f"Unknown study profile '{value}'; choose one of: {choices}") from error
+
+
+def run_study(
+    *,
+    output_dir: Path,
+    profile: StudyProfile,
+) -> StudyResults:
+    """Run all experiments and write the three reproducible study artifacts."""
+    resolved_output_dir = Path(output_dir).expanduser().resolve()
+    resolved_output_dir.mkdir(parents=True, exist_ok=True)
+    resolved_profile = _study_profile(profile)
+    results = run_all_experiments(
+        output_dir=resolved_output_dir,
+        profile=resolved_profile,
+    )
+    write_results_markdown(
+        results=results,
+        path=resolved_output_dir / "results.md",
+    )
+    write_figures_pdf(
+        results=results,
+        path=resolved_output_dir / "figures.pdf",
+    )
+    write_results_json(
+        results=results,
+        path=resolved_output_dir / "results.json",
+    )
+    return results
+
+
+def run_local_test(
+    local_test: LocalTests,
+    *,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+) -> StudyResults:
+    """Run one named local profile through the same production entry point."""
+    if not isinstance(local_test, LocalTests):
+        raise ValueError("local_test must be a LocalTests member")
+    return run_study(
+        output_dir=output_dir,
+        profile=_study_profile(local_test.value),
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the discrete-versus-continuous TGARCH simulation study.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Artifact directory (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+    parser.add_argument(
+        "--profile",
+        choices=[str(profile.value) for profile in StudyProfile],
+        default=LocalTests.SMOKE.value,
+        help="Study workload profile.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run the command-line selected study profile."""
+    arguments = _parse_args()
+    run_local_test(
+        local_test=LocalTests(arguments.profile),
+        output_dir=arguments.output_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/volatility_book/ch_discrete_vol/run_study.py
+++ b/volatility_book/ch_discrete_vol/run_study.py
@@ -22,7 +22,9 @@ from volatility_book.ch_discrete_vol.reporting import (
     write_results_markdown,
 )
 
-DEFAULT_OUTPUT_DIR = Path(__file__).resolve().parent / "output"
+DEFAULT_OUTPUT_ROOT = (
+    Path(__file__).resolve().parents[2] / "outputs" / "volatility_book" / "ch_discrete_vol"
+)
 
 
 class LocalTests(str, Enum):
@@ -33,6 +35,14 @@ class LocalTests(str, Enum):
     FULL = "full"
 
 
+DEFAULT_OUTPUT_DIRS = {
+    StudyProfile.SMOKE: DEFAULT_OUTPUT_ROOT / "round1_smoke",
+    StudyProfile.REFERENCE: DEFAULT_OUTPUT_ROOT / "round1_reference",
+    StudyProfile.FULL: DEFAULT_OUTPUT_ROOT / "round1",
+}
+DEFAULT_OUTPUT_DIR = DEFAULT_OUTPUT_DIRS[StudyProfile.SMOKE]
+
+
 def _study_profile(value: str | StudyProfile) -> StudyProfile:
     if isinstance(value, StudyProfile):
         return value
@@ -41,6 +51,11 @@ def _study_profile(value: str | StudyProfile) -> StudyProfile:
     except ValueError as error:
         choices = ", ".join(str(profile.value) for profile in StudyProfile)
         raise ValueError(f"Unknown study profile '{value}'; choose one of: {choices}") from error
+
+
+def _default_output_dir(profile: StudyProfile) -> Path:
+    """Return the ignored Round-1 artifact directory for one workload profile."""
+    return DEFAULT_OUTPUT_DIRS[_study_profile(profile)]
 
 
 def run_study(
@@ -74,15 +89,14 @@ def run_study(
 def run_local_test(
     local_test: LocalTests,
     *,
-    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    output_dir: Path | None = None,
 ) -> StudyResults:
     """Run one named local profile through the same production entry point."""
     if not isinstance(local_test, LocalTests):
         raise ValueError("local_test must be a LocalTests member")
-    return run_study(
-        output_dir=output_dir,
-        profile=_study_profile(local_test.value),
-    )
+    profile = _study_profile(local_test.value)
+    selected_output_dir = _default_output_dir(profile) if output_dir is None else output_dir
+    return run_study(output_dir=selected_output_dir, profile=profile)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -92,8 +106,10 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--output-dir",
         type=Path,
-        default=DEFAULT_OUTPUT_DIR,
-        help=f"Artifact directory (default: {DEFAULT_OUTPUT_DIR}).",
+        help=(
+            "Artifact directory (default: profile-specific directory under "
+            f"{DEFAULT_OUTPUT_ROOT})."
+        ),
     )
     parser.add_argument(
         "--profile",

--- a/volatility_book/ch_discrete_vol/sim.py
+++ b/volatility_book/ch_discrete_vol/sim.py
@@ -6,12 +6,10 @@ log return.  The discrete model uses one Gaussian return innovation ``z`` and th
 absolute-value innovation ``w = (abs(z) - M1) / S1``.  The two-shock limit-path helper instead
 uses genuinely independent Gaussian shocks for the return and residual volatility channels.
 
-The exact-Q simulator implements the finite-step Gaussian law from the working note, including
-the exact state-dependent mean and variance.  It does not replace them by their small-step
-expansions.  Euler updates are floored at ``SIGMA_FLOOR`` only after an update; every result
-records the number of floor hits so the localization can be audited.  Terminal simulations use
-``numpy.random.Generator(PCG64(seed))`` and antithetic standard-normal pairs while retaining only
-terminal state and, when requested under P, the accumulated P-to-Q log likelihood ratio.
+The package TGARCH model owns terminal simulation, including the exact finite-step Gaussian law,
+antithetic random ordering, volatility floor, and optional P-to-Q log likelihood ratio.  This
+module provides a compatibility view over that terminal result and retains the chapter-specific
+scalar, stored-path, filtering, and analytical-check helpers.
 """
 
 from __future__ import annotations
@@ -19,11 +17,18 @@ from __future__ import annotations
 import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
-from enum import Enum
 from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
+from stochvolmodels.data.model_paths import ModelPaths
+from stochvolmodels.models.tgarch import (
+    TgarchLimitParams as LimitParams,
+    TgarchMeasure as Measure,
+    TgarchModel,
+    TgarchParams,
+    derive_tgarch_limit_params as derived_limit_params,
+)
 
 M1 = math.sqrt(2.0 / math.pi)
 S1 = math.sqrt(1.0 - 2.0 / math.pi)
@@ -34,18 +39,6 @@ _SQRT_TWO_PI = math.sqrt(2.0 * math.pi)
 _DEFAULT_CHUNK_STEPS = 8
 
 FloatArray = NDArray[np.float64]
-
-
-class Measure(str, Enum):
-    """Simulation law.
-
-    ``P`` and ``Q_EXACT`` retain the physical recursion maps and change the innovation law.
-    ``Q_LIMIT`` uses a standard innovation and the hatted limiting drift.
-    """
-
-    P = "P"
-    Q_EXACT = "Q_EXACT"
-    Q_LIMIT = "Q_LIMIT"
 
 
 def _finite_float(value: float, name: str) -> float:
@@ -117,287 +110,72 @@ def _readonly_vector(
 
 
 @dataclass(frozen=True, slots=True)
-class TgarchParams:
-    """Physical recursion and pricing-kernel parameters.
-
-    ``beta`` is signed, ``eps`` is residual volatility of volatility, and ``spot0`` is the
-    initial price level.  ``gamma0 + gamma1 * sigma`` is the conditional Sharpe ratio while
-    ``eta0 + eta1 * sigma`` is the finite-step variance-preference loading before multiplication
-    by ``sqrt(dt)``.
-    """
-
-    theta: float
-    kappa1: float
-    kappa2: float
-    beta: float
-    eps: float
-    sigma0: float
-    r: float = 0.0
-    gamma0: float = 0.0
-    gamma1: float = 0.0
-    eta0: float = 0.0
-    eta1: float = 0.0
-    spot0: float = 1.0
-
-    def __post_init__(self) -> None:
-        for name in ("theta", "kappa1", "eps", "sigma0", "spot0"):
-            object.__setattr__(self, name, _positive_float(getattr(self, name), name))
-        object.__setattr__(
-            self,
-            "kappa2",
-            _positive_float(self.kappa2, "kappa2", allow_zero=True),
-        )
-        for name in ("beta", "r", "gamma0", "gamma1", "eta0", "eta1"):
-            object.__setattr__(self, name, _finite_float(getattr(self, name), name))
-
-    @property
-    def vartheta(self) -> float:
-        """Total volatility of volatility ``sqrt(beta**2 + eps**2)``."""
-
-        return math.hypot(self.beta, self.eps)
-
-    @property
-    def d0(self) -> float:
-        return self.kappa1 * self.theta
-
-    @property
-    def d1(self) -> float:
-        return self.kappa2 * self.theta - self.kappa1
-
-    @property
-    def d2(self) -> float:
-        return -self.kappa2
-
-    @property
-    def s0(self) -> float:
-        """Alias for ``spot0`` used in some option-pricing notation."""
-
-        return self.spot0
-
-    @property
-    def epsilon(self) -> float:
-        """Alias for the residual volatility-of-volatility parameter ``eps``."""
-
-        return self.eps
-
-    def gamma(self, sigma: float | FloatArray) -> float | FloatArray:
-        return self.gamma0 + self.gamma1 * sigma
-
-    def eta(self, sigma: float | FloatArray) -> float | FloatArray:
-        return self.eta0 + self.eta1 * sigma
-
-    def drift(self, sigma: float | FloatArray) -> float | FloatArray:
-        return (self.kappa1 + self.kappa2 * sigma) * (self.theta - sigma)
-
-
-@dataclass(frozen=True, slots=True)
-class LimitParams:
-    """Validated hatted parameters and equivalent drift coefficients under limit Q."""
-
-    kappa1_hat: float
-    kappa2_hat: float
-    theta_hat: float
-    d0: float
-    d1_hat: float
-    lambda0_bar: float
-    lambda1_bar: float
-    vartheta: float
-
-    def __post_init__(self) -> None:
-        for name in ("kappa1_hat", "theta_hat", "d0", "vartheta"):
-            object.__setattr__(self, name, _positive_float(getattr(self, name), name))
-        object.__setattr__(
-            self,
-            "kappa2_hat",
-            _positive_float(self.kappa2_hat, "kappa2_hat", allow_zero=True),
-        )
-        for name in ("d1_hat", "lambda0_bar", "lambda1_bar"):
-            object.__setattr__(self, name, _finite_float(getattr(self, name), name))
-
-        implied_d0 = self.kappa1_hat * self.theta_hat
-        implied_d1 = self.kappa2_hat * self.theta_hat - self.kappa1_hat
-        d0_scale = max(1.0, abs(self.d0), abs(implied_d0))
-        d1_scale = max(1.0, abs(self.d1_hat), abs(implied_d1))
-        if abs(implied_d0 - self.d0) > 5.0e-11 * d0_scale:
-            raise ValueError("inconsistent limit parameters: d0 != kappa1_hat * theta_hat")
-        if abs(implied_d1 - self.d1_hat) > 5.0e-11 * d1_scale:
-            raise ValueError(
-                "inconsistent limit parameters: d1_hat != kappa2_hat * theta_hat - kappa1_hat"
-            )
-
-    @classmethod
-    def from_drift_coefficients(
-        cls,
-        *,
-        d0: float,
-        d1_hat: float,
-        kappa2_hat: float,
-        lambda0_bar: float,
-        lambda1_bar: float,
-        vartheta: float,
-    ) -> LimitParams:
-        """Construct the hatted factorization from its polynomial coefficients.
-
-        The zero-``kappa2_hat`` boundary is supported when ``d1_hat < 0``; it reduces to the
-        linear drift ``d0 - kappa1_hat * sigma``.
-        """
-
-        d0_value = _positive_float(d0, "d0")
-        d1_value = _finite_float(d1_hat, "d1_hat")
-        kappa2_value = _positive_float(kappa2_hat, "kappa2_hat", allow_zero=True)
-        if kappa2_value == 0.0:
-            if d1_value >= 0.0:
-                raise ValueError("kappa2_hat=0 requires d1_hat<0 for a mean-reverting limit")
-            kappa1_hat = -d1_value
-            theta_hat = d0_value / kappa1_hat
-        else:
-            discriminant = math.sqrt(d1_value * d1_value + 4.0 * kappa2_value * d0_value)
-            if d1_value >= 0.0:
-                theta_hat = (d1_value + discriminant) / (2.0 * kappa2_value)
-            else:
-                # Algebraically identical root without cancellation for a large negative d1.
-                theta_hat = 2.0 * d0_value / (discriminant - d1_value)
-            kappa1_hat = d0_value / theta_hat
-        return cls(
-            kappa1_hat=kappa1_hat,
-            kappa2_hat=kappa2_value,
-            theta_hat=theta_hat,
-            d0=d0_value,
-            d1_hat=d1_value,
-            lambda0_bar=lambda0_bar,
-            lambda1_bar=lambda1_bar,
-            vartheta=vartheta,
-        )
-
-    @property
-    def d2_hat(self) -> float:
-        return -self.kappa2_hat
-
-    def drift(self, sigma: float | FloatArray) -> float | FloatArray:
-        return self.d0 + self.d1_hat * sigma - self.kappa2_hat * sigma * sigma
-
-
-def derived_limit_params(params: TgarchParams) -> LimitParams:
-    """Apply the note's exact drift-coefficient map and Corollary-14 factorization."""
-
-    if not isinstance(params, TgarchParams):
-        raise ValueError("params must be a TgarchParams instance")
-    lambda0_bar = params.gamma1
-    lambda1_bar = -(M1 / S1) * params.eta1
-    lambda_intercept = -params.beta * params.gamma0 + params.eps * M1 * params.eta0 / S1
-    lambda_slope = -params.beta * params.gamma1 + params.eps * M1 * params.eta1 / S1
-    d1_hat = params.d1 + lambda_intercept
-    kappa2_hat = params.kappa2 - lambda_slope
-    if kappa2_hat < 0.0:
-        raise ValueError(
-            "derived kappa2_hat is negative; the requested Q limit is outside the "
-            f"well-posed parameter region (kappa2_hat={kappa2_hat:.12g})"
-        )
-    return LimitParams.from_drift_coefficients(
-        d0=params.d0,
-        d1_hat=d1_hat,
-        kappa2_hat=kappa2_hat,
-        lambda0_bar=lambda0_bar,
-        lambda1_bar=lambda1_bar,
-        vartheta=params.vartheta,
-    )
-
-
-@dataclass(frozen=True, slots=True)
 class SimulationResult:
-    """Terminal state from a streamed antithetic simulation."""
+    """Backward-compatible chapter view over package-owned TGARCH terminal paths."""
 
-    measure: Measure
-    maturity: float
-    dt: float
-    n_steps: int
-    terminal_spot: FloatArray
-    terminal_log_spot: FloatArray
-    terminal_sigma: FloatArray
-    floor_hits: int
-    spot_overflow_count: int = 0
-    log_weights: FloatArray | None = None
-    effective_sample_size: float | None = None
-    ess_fraction: float | None = None
-    low_ess: bool = False
+    paths: ModelPaths
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "measure", _as_measure(self.measure))
-        object.__setattr__(self, "maturity", _positive_float(self.maturity, "maturity"))
-        object.__setattr__(self, "dt", _positive_float(self.dt, "dt"))
-        object.__setattr__(self, "n_steps", _positive_int(self.n_steps, "n_steps"))
-        log_spot = _readonly_vector(self.terminal_log_spot, "terminal_log_spot")
-        n_paths = log_spot.size
-        if n_paths == 0:
-            raise ValueError("terminal arrays cannot be empty")
-        spot = _readonly_vector(
-            self.terminal_spot,
-            "terminal_spot",
-            length=n_paths,
-            allow_positive_infinity=True,
-        )
-        sigma = _readonly_vector(self.terminal_sigma, "terminal_sigma", length=n_paths)
-        if (spot < 0.0).any():
-            raise ValueError("terminal_spot must be non-negative")
-        if (sigma < SIGMA_FLOOR).any():
-            raise ValueError("terminal_sigma is below SIGMA_FLOOR")
-        object.__setattr__(self, "terminal_spot", spot)
-        object.__setattr__(self, "terminal_log_spot", log_spot)
-        object.__setattr__(self, "terminal_sigma", sigma)
-        object.__setattr__(
-            self, "floor_hits", _positive_int(self.floor_hits, "floor_hits", minimum=0)
-        )
-        object.__setattr__(
-            self,
-            "spot_overflow_count",
-            _positive_int(self.spot_overflow_count, "spot_overflow_count", minimum=0),
-        )
-        actual_overflows = int(np.isposinf(spot).sum())
-        if actual_overflows != self.spot_overflow_count:
-            raise ValueError("spot_overflow_count does not match terminal_spot")
-        if not math.isclose(self.dt * self.n_steps, self.maturity, rel_tol=2.0e-13, abs_tol=1e-15):
-            raise ValueError("dt * n_steps must equal maturity")
+        if not isinstance(self.paths, ModelPaths):
+            raise ValueError("paths must be a ModelPaths instance")
 
-        if self.log_weights is None:
-            if self.effective_sample_size is not None or self.ess_fraction is not None:
-                raise ValueError("ESS fields require log_weights")
-            if self.low_ess:
-                raise ValueError("low_ess cannot be true without log_weights")
-        else:
-            weights = _readonly_vector(self.log_weights, "log_weights", length=n_paths)
-            object.__setattr__(self, "log_weights", weights)
-            ess = _positive_float(self.effective_sample_size, "effective_sample_size")
-            fraction = _positive_float(self.ess_fraction, "ess_fraction")
-            if ess > n_paths * (1.0 + 1.0e-12):
-                raise ValueError("effective_sample_size cannot exceed n_paths")
-            if not math.isclose(fraction, ess / n_paths, rel_tol=2.0e-12, abs_tol=1e-15):
-                raise ValueError("ess_fraction must equal effective_sample_size / n_paths")
-            if self.low_ess != (fraction < 0.2):
-                raise ValueError("low_ess must flag ess_fraction < 0.2")
-            object.__setattr__(self, "effective_sample_size", ess)
-            object.__setattr__(self, "ess_fraction", fraction)
+    @property
+    def measure(self) -> Measure:
+        return Measure(self.paths.sampling_measure)
+
+    @property
+    def maturity(self) -> float:
+        return float(self.paths.observation_times[-1])
+
+    @property
+    def dt(self) -> float:
+        return float(self.paths.provenance["realized_dt"])
+
+    @property
+    def n_steps(self) -> int:
+        return int(self.paths.provenance["n_steps"])
+
+    @property
+    def terminal_spot(self) -> FloatArray:
+        return self.paths.assets[:, -1, 0]
+
+    @property
+    def terminal_log_spot(self) -> FloatArray:
+        return self.paths.states["log_spot"][:, -1]
+
+    @property
+    def terminal_sigma(self) -> FloatArray:
+        return self.paths.states["sigma"][:, -1]
+
+    @property
+    def floor_hits(self) -> int:
+        return int(self.paths.diagnostics["floor_hits"])
+
+    @property
+    def spot_overflow_count(self) -> int:
+        return int(self.paths.diagnostics["spot_overflow_count"])
+
+    @property
+    def log_weights(self) -> FloatArray | None:
+        return self.paths.log_likelihood_ratios
+
+    @property
+    def effective_sample_size(self) -> float | None:
+        value = self.paths.diagnostics["effective_sample_size"]
+        return None if value is None else float(value)
+
+    @property
+    def ess_fraction(self) -> float | None:
+        value = self.paths.diagnostics["ess_fraction"]
+        return None if value is None else float(value)
+
+    @property
+    def low_ess(self) -> bool:
+        return bool(self.paths.diagnostics["low_ess"])
 
     @property
     def n_paths(self) -> int:
-        return int(self.terminal_sigma.size)
-
-    def likelihood_weights(self, *, normalize_to_mean_one: bool = False) -> FloatArray:
-        """Exponentiate stored log weights stably.
-
-        Normalization to sample mean one is useful for diagnostics and ESS plots but changes the
-        raw likelihood-ratio estimator into a self-normalized estimator.
-        """
-
-        if self.log_weights is None:
-            raise ValueError("this result does not contain P-to-Q log weights")
-        shift = float(np.max(self.log_weights))
-        weights = np.exp(self.log_weights - shift)
-        if normalize_to_mean_one:
-            weights /= np.mean(weights)
-        else:
-            weights *= math.exp(shift)
-        weights.setflags(write=False)
-        return weights
+        return int(self.paths.assets.shape[0])
 
 
 @dataclass(frozen=True, slots=True)
@@ -534,24 +312,6 @@ def _resolve_limit_params(
     return result
 
 
-def _exact_q_law(
-    sigma: FloatArray,
-    dt: float,
-    params: TgarchParams,
-) -> tuple[FloatArray, FloatArray]:
-    sqrt_dt = math.sqrt(dt)
-    denominator = 1.0 - 2.0 * sqrt_dt * params.eta(sigma)
-    if np.any(denominator <= 0.0) or not np.isfinite(denominator).all():
-        worst = float(np.min(denominator))
-        raise ValueError(
-            "the exact-Q kernel is inadmissible: 1 - 2*sqrt(dt)*eta(sigma) "
-            f"must be positive on every path (minimum={worst:.12g})"
-        )
-    variance = 1.0 / denominator
-    mean = -sqrt_dt * params.gamma(sigma) - 0.5 * sigma * sqrt_dt * (variance - 1.0)
-    return np.asarray(mean, dtype=np.float64), np.asarray(variance, dtype=np.float64)
-
-
 def _exact_q_law_scalar(sigma: float, dt: float, params: TgarchParams) -> tuple[float, float]:
     sqrt_dt = math.sqrt(dt)
     denominator = 1.0 - 2.0 * sqrt_dt * float(params.eta(sigma))
@@ -565,35 +325,6 @@ def _exact_q_law_scalar(sigma: float, dt: float, params: TgarchParams) -> tuple[
     return mean, variance
 
 
-def _antithetic_normal_block(
-    rng: np.random.Generator,
-    *,
-    block_steps: int,
-    n_paths: int,
-) -> FloatArray:
-    pair_count = n_paths // 2
-    has_singleton = n_paths % 2
-    independent_count = pair_count + has_singleton
-    draws = rng.standard_normal((block_steps, independent_count), dtype=np.float64)
-    result = np.empty((block_steps, n_paths), dtype=np.float64)
-    if pair_count:
-        result[:, :pair_count] = draws[:, :pair_count]
-        result[:, pair_count : 2 * pair_count] = -draws[:, :pair_count]
-    if has_singleton:
-        result[:, -1] = draws[:, -1]
-    return result
-
-
-def _effective_sample_size(log_weights: FloatArray) -> float:
-    shift = float(np.max(log_weights))
-    scaled = np.exp(log_weights - shift)
-    numerator = float(np.sum(scaled)) ** 2
-    denominator = float(np.dot(scaled, scaled))
-    if denominator == 0.0 or not math.isfinite(numerator):
-        raise FloatingPointError("could not compute a finite effective sample size")
-    return numerator / denominator
-
-
 def simulate_terminal(
     params: TgarchParams,
     measure: Measure | str,
@@ -605,109 +336,23 @@ def simulate_terminal(
     track_log_weights: bool = False,
     chunk_steps: int = _DEFAULT_CHUNK_STEPS,
 ) -> SimulationResult:
-    """Stream a terminal simulation with antithetic PCG64 base normals.
+    """Adapt the package-owned terminal TGARCH simulation to the chapter result view.
 
-    ``max_dt`` is an upper bound: the function takes ``ceil(maturity / max_dt)`` equal steps so
-    that the final time is exactly ``maturity``.  P-to-Q likelihood ratios are available only on
-    P paths because they are the Radon--Nikodym weights used by the reweighting experiment.
+    The signature and legacy result attributes are retained for the chapter study.  Numerical
+    dynamics, random ordering, likelihood ratios, and diagnostics are owned by
+    :class:`stochvolmodels.models.tgarch.TgarchModel`.
     """
-
-    if not isinstance(params, TgarchParams):
-        raise ValueError("params must be a TgarchParams instance")
-    measure_value = _as_measure(measure)
-    maturity_value = _positive_float(maturity, "maturity")
-    n_paths_value = _positive_int(n_paths, "n_paths")
-    seed_value = _validated_seed(seed)
-    chunk_value = _positive_int(chunk_steps, "chunk_steps")
-    if not isinstance(track_log_weights, (bool, np.bool_)):
-        raise ValueError("track_log_weights must be bool")
-    if track_log_weights and measure_value is not Measure.P:
-        raise ValueError("P-to-Q log weights can only be accumulated on P simulations")
-    n_steps, dt = _step_grid(maturity_value, max_dt)
-    limit = _resolve_limit_params(params, measure_value, limit_params)
-
-    rng = np.random.Generator(np.random.PCG64(seed_value))
-    sigma = np.full(n_paths_value, params.sigma0, dtype=np.float64)
-    log_spot = np.full(n_paths_value, math.log(params.spot0), dtype=np.float64)
-    log_weights = np.zeros(n_paths_value, dtype=np.float64) if track_log_weights else None
-    sqrt_dt = math.sqrt(dt)
-    floor_hits = 0
-
-    for block_start in range(0, n_steps, chunk_value):
-        block_size = min(chunk_value, n_steps - block_start)
-        base_block = _antithetic_normal_block(
-            rng,
-            block_steps=block_size,
-            n_paths=n_paths_value,
-        )
-        for block_index in range(block_size):
-            base_z = base_block[block_index]
-            if measure_value is Measure.Q_EXACT:
-                q_mean, q_variance = _exact_q_law(sigma, dt, params)
-                z = q_mean + np.sqrt(q_variance) * base_z
-                log_drift = params.r + params.gamma(sigma) * sigma - 0.5 * sigma * sigma
-                sigma_drift = params.drift(sigma)
-            elif measure_value is Measure.P:
-                z = base_z
-                log_drift = params.r + params.gamma(sigma) * sigma - 0.5 * sigma * sigma
-                sigma_drift = params.drift(sigma)
-                if log_weights is not None:
-                    q_mean, q_variance = _exact_q_law(sigma, dt, params)
-                    log_weights += -0.5 * np.log(q_variance) - 0.5 * (
-                        (z - q_mean) * (z - q_mean) / q_variance - z * z
-                    )
-            else:
-                if limit is None:  # pragma: no cover - guarded by _resolve_limit_params
-                    raise RuntimeError("missing Q-limit parameters")
-                z = base_z
-                log_drift = params.r - 0.5 * sigma * sigma
-                sigma_drift = limit.drift(sigma)
-
-            log_spot += log_drift * dt + sigma * sqrt_dt * z
-            w = (np.abs(z) - M1) / S1
-            sigma_next = (
-                sigma + sigma_drift * dt + sigma * sqrt_dt * (params.beta * z + params.eps * w)
-            )
-            hit = sigma_next < SIGMA_FLOOR
-            floor_hits += int(np.count_nonzero(hit))
-            np.maximum(sigma_next, SIGMA_FLOOR, out=sigma_next)
-            sigma = sigma_next
-
-        if not np.isfinite(sigma).all() or not np.isfinite(log_spot).all():
-            step = block_start + block_size
-            raise FloatingPointError(f"non-finite state encountered after simulation step {step}")
-        if log_weights is not None and not np.isfinite(log_weights).all():
-            step = block_start + block_size
-            raise FloatingPointError(
-                f"non-finite log weight encountered after simulation step {step}"
-            )
-
-    with np.errstate(over="ignore", under="ignore"):
-        terminal_spot = np.exp(log_spot)
-    overflow_count = int(np.isposinf(terminal_spot).sum())
-    ess: float | None = None
-    ess_fraction: float | None = None
-    low_ess = False
-    if log_weights is not None:
-        ess = _effective_sample_size(log_weights)
-        ess_fraction = ess / n_paths_value
-        low_ess = ess_fraction < 0.2
-
-    return SimulationResult(
-        measure=measure_value,
-        maturity=maturity_value,
-        dt=dt,
-        n_steps=n_steps,
-        terminal_spot=terminal_spot,
-        terminal_log_spot=log_spot,
-        terminal_sigma=sigma,
-        floor_hits=floor_hits,
-        spot_overflow_count=overflow_count,
-        log_weights=log_weights,
-        effective_sample_size=ess,
-        ess_fraction=ess_fraction,
-        low_ess=low_ess,
+    paths = TgarchModel(params).simulate_paths(
+        measure=measure,
+        maturity=maturity,
+        max_dt=max_dt,
+        n_paths=n_paths,
+        seed=seed,
+        limit_params=limit_params,
+        track_log_weights=track_log_weights,
+        chunk_steps=chunk_steps,
     )
+    return SimulationResult(paths=paths)
 
 
 def _scalar_discrete_update(
@@ -1091,7 +736,9 @@ def validate_one_step_moments(
     sigma_value = params.sigma0 if sigma is None else _positive_float(sigma, "sigma")
     measure_value = _as_measure(measure)
     rng = np.random.Generator(np.random.PCG64(seed_value))
-    base = _antithetic_normal_block(rng, block_steps=1, n_paths=n_paths_value)[0]
+    pair_count = n_paths_value // 2
+    independent = rng.standard_normal(pair_count, dtype=np.float64)
+    base = np.concatenate((independent, -independent))
     if measure_value is Measure.Q_EXACT:
         mean, variance = _exact_q_law_scalar(sigma_value, dt_value, params)
         z = mean + math.sqrt(variance) * base

--- a/volatility_book/ch_discrete_vol/sim.py
+++ b/volatility_book/ch_discrete_vol/sim.py
@@ -1,0 +1,1377 @@
+"""Simulation utilities for the discrete threshold-volatility study.
+
+All rates and volatilities are annualized and all times are measured in years.  Prices are
+represented internally by log prices.  Consequently every return handled by this module is a
+log return.  The discrete model uses one Gaussian return innovation ``z`` and the standardized
+absolute-value innovation ``w = (abs(z) - M1) / S1``.  The two-shock limit-path helper instead
+uses genuinely independent Gaussian shocks for the return and residual volatility channels.
+
+The exact-Q simulator implements the finite-step Gaussian law from the working note, including
+the exact state-dependent mean and variance.  It does not replace them by their small-step
+expansions.  Euler updates are floored at ``SIGMA_FLOOR`` only after an update; every result
+records the number of floor hits so the localization can be audited.  Terminal simulations use
+``numpy.random.Generator(PCG64(seed))`` and antithetic standard-normal pairs while retaining only
+terminal state and, when requested under P, the accumulated P-to-Q log likelihood ratio.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+M1 = math.sqrt(2.0 / math.pi)
+S1 = math.sqrt(1.0 - 2.0 / math.pi)
+SIGMA_FLOOR = 1.0e-6
+
+_SQRT_TWO = math.sqrt(2.0)
+_SQRT_TWO_PI = math.sqrt(2.0 * math.pi)
+_DEFAULT_CHUNK_STEPS = 8
+
+FloatArray = NDArray[np.float64]
+
+
+class Measure(str, Enum):
+    """Simulation law.
+
+    ``P`` and ``Q_EXACT`` retain the physical recursion maps and change the innovation law.
+    ``Q_LIMIT`` uses a standard innovation and the hatted limiting drift.
+    """
+
+    P = "P"
+    Q_EXACT = "Q_EXACT"
+    Q_LIMIT = "Q_LIMIT"
+
+
+def _finite_float(value: float, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a finite real number, not bool")
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite real number") from exc
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite, got {value!r}")
+    return result
+
+
+def _positive_float(value: float, name: str, *, allow_zero: bool = False) -> float:
+    result = _finite_float(value, name)
+    if allow_zero:
+        if result < 0.0:
+            raise ValueError(f"{name} must be non-negative, got {result}")
+    elif result <= 0.0:
+        raise ValueError(f"{name} must be strictly positive, got {result}")
+    return result
+
+
+def _positive_int(value: int, name: str, *, minimum: int = 1) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f"{name} must be an integer")
+    result = int(value)
+    if result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}, got {result}")
+    return result
+
+
+def _validated_seed(seed: int) -> int:
+    if isinstance(seed, (bool, np.bool_)) or not isinstance(seed, (int, np.integer)):
+        raise ValueError("seed must be a non-negative integer")
+    result = int(seed)
+    if result < 0:
+        raise ValueError(f"seed must be non-negative, got {result}")
+    return result
+
+
+def _as_measure(measure: Measure | str) -> Measure:
+    try:
+        return Measure(measure)
+    except (TypeError, ValueError) as exc:
+        allowed = ", ".join(item.value for item in Measure)
+        raise ValueError(f"measure must be one of {{{allowed}}}, got {measure!r}") from exc
+
+
+def _readonly_vector(
+    value: NDArray[np.floating[Any]],
+    name: str,
+    *,
+    length: int | None = None,
+    allow_positive_infinity: bool = False,
+) -> FloatArray:
+    result = np.asarray(value, dtype=np.float64)
+    if result.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional, got shape {result.shape}")
+    if length is not None and result.size != length:
+        raise ValueError(f"{name} must have length {length}, got {result.size}")
+    if np.isnan(result).any() or np.isneginf(result).any():
+        raise ValueError(f"{name} contains NaN or negative infinity")
+    if not allow_positive_infinity and np.isposinf(result).any():
+        raise ValueError(f"{name} contains positive infinity")
+    result.setflags(write=False)
+    return result
+
+
+@dataclass(frozen=True, slots=True)
+class TgarchParams:
+    """Physical recursion and pricing-kernel parameters.
+
+    ``beta`` is signed, ``eps`` is residual volatility of volatility, and ``spot0`` is the
+    initial price level.  ``gamma0 + gamma1 * sigma`` is the conditional Sharpe ratio while
+    ``eta0 + eta1 * sigma`` is the finite-step variance-preference loading before multiplication
+    by ``sqrt(dt)``.
+    """
+
+    theta: float
+    kappa1: float
+    kappa2: float
+    beta: float
+    eps: float
+    sigma0: float
+    r: float = 0.0
+    gamma0: float = 0.0
+    gamma1: float = 0.0
+    eta0: float = 0.0
+    eta1: float = 0.0
+    spot0: float = 1.0
+
+    def __post_init__(self) -> None:
+        for name in ("theta", "kappa1", "eps", "sigma0", "spot0"):
+            object.__setattr__(self, name, _positive_float(getattr(self, name), name))
+        object.__setattr__(
+            self,
+            "kappa2",
+            _positive_float(self.kappa2, "kappa2", allow_zero=True),
+        )
+        for name in ("beta", "r", "gamma0", "gamma1", "eta0", "eta1"):
+            object.__setattr__(self, name, _finite_float(getattr(self, name), name))
+
+    @property
+    def vartheta(self) -> float:
+        """Total volatility of volatility ``sqrt(beta**2 + eps**2)``."""
+
+        return math.hypot(self.beta, self.eps)
+
+    @property
+    def d0(self) -> float:
+        return self.kappa1 * self.theta
+
+    @property
+    def d1(self) -> float:
+        return self.kappa2 * self.theta - self.kappa1
+
+    @property
+    def d2(self) -> float:
+        return -self.kappa2
+
+    @property
+    def s0(self) -> float:
+        """Alias for ``spot0`` used in some option-pricing notation."""
+
+        return self.spot0
+
+    @property
+    def epsilon(self) -> float:
+        """Alias for the residual volatility-of-volatility parameter ``eps``."""
+
+        return self.eps
+
+    def gamma(self, sigma: float | FloatArray) -> float | FloatArray:
+        return self.gamma0 + self.gamma1 * sigma
+
+    def eta(self, sigma: float | FloatArray) -> float | FloatArray:
+        return self.eta0 + self.eta1 * sigma
+
+    def drift(self, sigma: float | FloatArray) -> float | FloatArray:
+        return (self.kappa1 + self.kappa2 * sigma) * (self.theta - sigma)
+
+
+@dataclass(frozen=True, slots=True)
+class LimitParams:
+    """Validated hatted parameters and equivalent drift coefficients under limit Q."""
+
+    kappa1_hat: float
+    kappa2_hat: float
+    theta_hat: float
+    d0: float
+    d1_hat: float
+    lambda0_bar: float
+    lambda1_bar: float
+    vartheta: float
+
+    def __post_init__(self) -> None:
+        for name in ("kappa1_hat", "theta_hat", "d0", "vartheta"):
+            object.__setattr__(self, name, _positive_float(getattr(self, name), name))
+        object.__setattr__(
+            self,
+            "kappa2_hat",
+            _positive_float(self.kappa2_hat, "kappa2_hat", allow_zero=True),
+        )
+        for name in ("d1_hat", "lambda0_bar", "lambda1_bar"):
+            object.__setattr__(self, name, _finite_float(getattr(self, name), name))
+
+        implied_d0 = self.kappa1_hat * self.theta_hat
+        implied_d1 = self.kappa2_hat * self.theta_hat - self.kappa1_hat
+        d0_scale = max(1.0, abs(self.d0), abs(implied_d0))
+        d1_scale = max(1.0, abs(self.d1_hat), abs(implied_d1))
+        if abs(implied_d0 - self.d0) > 5.0e-11 * d0_scale:
+            raise ValueError("inconsistent limit parameters: d0 != kappa1_hat * theta_hat")
+        if abs(implied_d1 - self.d1_hat) > 5.0e-11 * d1_scale:
+            raise ValueError(
+                "inconsistent limit parameters: d1_hat != kappa2_hat * theta_hat - kappa1_hat"
+            )
+
+    @classmethod
+    def from_drift_coefficients(
+        cls,
+        *,
+        d0: float,
+        d1_hat: float,
+        kappa2_hat: float,
+        lambda0_bar: float,
+        lambda1_bar: float,
+        vartheta: float,
+    ) -> LimitParams:
+        """Construct the hatted factorization from its polynomial coefficients.
+
+        The zero-``kappa2_hat`` boundary is supported when ``d1_hat < 0``; it reduces to the
+        linear drift ``d0 - kappa1_hat * sigma``.
+        """
+
+        d0_value = _positive_float(d0, "d0")
+        d1_value = _finite_float(d1_hat, "d1_hat")
+        kappa2_value = _positive_float(kappa2_hat, "kappa2_hat", allow_zero=True)
+        if kappa2_value == 0.0:
+            if d1_value >= 0.0:
+                raise ValueError("kappa2_hat=0 requires d1_hat<0 for a mean-reverting limit")
+            kappa1_hat = -d1_value
+            theta_hat = d0_value / kappa1_hat
+        else:
+            discriminant = math.sqrt(d1_value * d1_value + 4.0 * kappa2_value * d0_value)
+            if d1_value >= 0.0:
+                theta_hat = (d1_value + discriminant) / (2.0 * kappa2_value)
+            else:
+                # Algebraically identical root without cancellation for a large negative d1.
+                theta_hat = 2.0 * d0_value / (discriminant - d1_value)
+            kappa1_hat = d0_value / theta_hat
+        return cls(
+            kappa1_hat=kappa1_hat,
+            kappa2_hat=kappa2_value,
+            theta_hat=theta_hat,
+            d0=d0_value,
+            d1_hat=d1_value,
+            lambda0_bar=lambda0_bar,
+            lambda1_bar=lambda1_bar,
+            vartheta=vartheta,
+        )
+
+    @property
+    def d2_hat(self) -> float:
+        return -self.kappa2_hat
+
+    def drift(self, sigma: float | FloatArray) -> float | FloatArray:
+        return self.d0 + self.d1_hat * sigma - self.kappa2_hat * sigma * sigma
+
+
+def derived_limit_params(params: TgarchParams) -> LimitParams:
+    """Apply the note's exact drift-coefficient map and Corollary-14 factorization."""
+
+    if not isinstance(params, TgarchParams):
+        raise ValueError("params must be a TgarchParams instance")
+    lambda0_bar = params.gamma1
+    lambda1_bar = -(M1 / S1) * params.eta1
+    lambda_intercept = -params.beta * params.gamma0 + params.eps * M1 * params.eta0 / S1
+    lambda_slope = -params.beta * params.gamma1 + params.eps * M1 * params.eta1 / S1
+    d1_hat = params.d1 + lambda_intercept
+    kappa2_hat = params.kappa2 - lambda_slope
+    if kappa2_hat < 0.0:
+        raise ValueError(
+            "derived kappa2_hat is negative; the requested Q limit is outside the "
+            f"well-posed parameter region (kappa2_hat={kappa2_hat:.12g})"
+        )
+    return LimitParams.from_drift_coefficients(
+        d0=params.d0,
+        d1_hat=d1_hat,
+        kappa2_hat=kappa2_hat,
+        lambda0_bar=lambda0_bar,
+        lambda1_bar=lambda1_bar,
+        vartheta=params.vartheta,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class SimulationResult:
+    """Terminal state from a streamed antithetic simulation."""
+
+    measure: Measure
+    maturity: float
+    dt: float
+    n_steps: int
+    terminal_spot: FloatArray
+    terminal_log_spot: FloatArray
+    terminal_sigma: FloatArray
+    floor_hits: int
+    spot_overflow_count: int = 0
+    log_weights: FloatArray | None = None
+    effective_sample_size: float | None = None
+    ess_fraction: float | None = None
+    low_ess: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "measure", _as_measure(self.measure))
+        object.__setattr__(self, "maturity", _positive_float(self.maturity, "maturity"))
+        object.__setattr__(self, "dt", _positive_float(self.dt, "dt"))
+        object.__setattr__(self, "n_steps", _positive_int(self.n_steps, "n_steps"))
+        log_spot = _readonly_vector(self.terminal_log_spot, "terminal_log_spot")
+        n_paths = log_spot.size
+        if n_paths == 0:
+            raise ValueError("terminal arrays cannot be empty")
+        spot = _readonly_vector(
+            self.terminal_spot,
+            "terminal_spot",
+            length=n_paths,
+            allow_positive_infinity=True,
+        )
+        sigma = _readonly_vector(self.terminal_sigma, "terminal_sigma", length=n_paths)
+        if (spot < 0.0).any():
+            raise ValueError("terminal_spot must be non-negative")
+        if (sigma < SIGMA_FLOOR).any():
+            raise ValueError("terminal_sigma is below SIGMA_FLOOR")
+        object.__setattr__(self, "terminal_spot", spot)
+        object.__setattr__(self, "terminal_log_spot", log_spot)
+        object.__setattr__(self, "terminal_sigma", sigma)
+        object.__setattr__(
+            self, "floor_hits", _positive_int(self.floor_hits, "floor_hits", minimum=0)
+        )
+        object.__setattr__(
+            self,
+            "spot_overflow_count",
+            _positive_int(self.spot_overflow_count, "spot_overflow_count", minimum=0),
+        )
+        actual_overflows = int(np.isposinf(spot).sum())
+        if actual_overflows != self.spot_overflow_count:
+            raise ValueError("spot_overflow_count does not match terminal_spot")
+        if not math.isclose(self.dt * self.n_steps, self.maturity, rel_tol=2.0e-13, abs_tol=1e-15):
+            raise ValueError("dt * n_steps must equal maturity")
+
+        if self.log_weights is None:
+            if self.effective_sample_size is not None or self.ess_fraction is not None:
+                raise ValueError("ESS fields require log_weights")
+            if self.low_ess:
+                raise ValueError("low_ess cannot be true without log_weights")
+        else:
+            weights = _readonly_vector(self.log_weights, "log_weights", length=n_paths)
+            object.__setattr__(self, "log_weights", weights)
+            ess = _positive_float(self.effective_sample_size, "effective_sample_size")
+            fraction = _positive_float(self.ess_fraction, "ess_fraction")
+            if ess > n_paths * (1.0 + 1.0e-12):
+                raise ValueError("effective_sample_size cannot exceed n_paths")
+            if not math.isclose(fraction, ess / n_paths, rel_tol=2.0e-12, abs_tol=1e-15):
+                raise ValueError("ess_fraction must equal effective_sample_size / n_paths")
+            if self.low_ess != (fraction < 0.2):
+                raise ValueError("low_ess must flag ess_fraction < 0.2")
+            object.__setattr__(self, "effective_sample_size", ess)
+            object.__setattr__(self, "ess_fraction", fraction)
+
+    @property
+    def n_paths(self) -> int:
+        return int(self.terminal_sigma.size)
+
+    def likelihood_weights(self, *, normalize_to_mean_one: bool = False) -> FloatArray:
+        """Exponentiate stored log weights stably.
+
+        Normalization to sample mean one is useful for diagnostics and ESS plots but changes the
+        raw likelihood-ratio estimator into a self-normalized estimator.
+        """
+
+        if self.log_weights is None:
+            raise ValueError("this result does not contain P-to-Q log weights")
+        shift = float(np.max(self.log_weights))
+        weights = np.exp(self.log_weights - shift)
+        if normalize_to_mean_one:
+            weights /= np.mean(weights)
+        else:
+            weights *= math.exp(shift)
+        weights.setflags(write=False)
+        return weights
+
+
+@dataclass(frozen=True, slots=True)
+class StationarySimulationResult:
+    """Subsampled volatility observations from one long recursion."""
+
+    samples: FloatArray
+    measure: Measure
+    dt: float
+    burn_steps: int
+    sample_steps: int
+    sample_interval: float
+    sample_interval_steps: int
+    floor_hits: int
+
+    def __post_init__(self) -> None:
+        samples = _readonly_vector(self.samples, "samples")
+        if samples.size == 0:
+            raise ValueError("samples cannot be empty")
+        if (samples < SIGMA_FLOOR).any():
+            raise ValueError("samples contain a volatility below SIGMA_FLOOR")
+        object.__setattr__(self, "samples", samples)
+        object.__setattr__(self, "measure", _as_measure(self.measure))
+        object.__setattr__(self, "dt", _positive_float(self.dt, "dt"))
+        object.__setattr__(
+            self, "burn_steps", _positive_int(self.burn_steps, "burn_steps", minimum=0)
+        )
+        object.__setattr__(self, "sample_steps", _positive_int(self.sample_steps, "sample_steps"))
+        object.__setattr__(
+            self,
+            "sample_interval",
+            _positive_float(self.sample_interval, "sample_interval"),
+        )
+        object.__setattr__(
+            self,
+            "sample_interval_steps",
+            _positive_int(self.sample_interval_steps, "sample_interval_steps"),
+        )
+        object.__setattr__(
+            self, "floor_hits", _positive_int(self.floor_hits, "floor_hits", minimum=0)
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PathSimulationResult:
+    """Stored single path for filtering diagnostics."""
+
+    times: FloatArray
+    log_prices: FloatArray
+    sigmas: FloatArray
+    floor_hits: int
+    measure: Measure
+    dt: float
+    two_shock: bool
+
+    def __post_init__(self) -> None:
+        times = _readonly_vector(self.times, "times")
+        if times.size < 2:
+            raise ValueError("a path must contain at least two time points")
+        log_prices = _readonly_vector(self.log_prices, "log_prices", length=times.size)
+        sigmas = _readonly_vector(self.sigmas, "sigmas", length=times.size)
+        if times[0] != 0.0 or np.any(np.diff(times) <= 0.0):
+            raise ValueError("times must start at zero and be strictly increasing")
+        if (sigmas < SIGMA_FLOOR).any():
+            raise ValueError("sigmas contain a volatility below SIGMA_FLOOR")
+        object.__setattr__(self, "times", times)
+        object.__setattr__(self, "log_prices", log_prices)
+        object.__setattr__(self, "sigmas", sigmas)
+        object.__setattr__(
+            self, "floor_hits", _positive_int(self.floor_hits, "floor_hits", minimum=0)
+        )
+        object.__setattr__(self, "measure", _as_measure(self.measure))
+        object.__setattr__(self, "dt", _positive_float(self.dt, "dt"))
+        if not isinstance(self.two_shock, (bool, np.bool_)):
+            raise ValueError("two_shock must be bool")
+        object.__setattr__(self, "two_shock", bool(self.two_shock))
+
+
+@dataclass(frozen=True, slots=True)
+class OneStepMoments:
+    """First two moments of ``(z, beta*z + eps*w)``."""
+
+    mean_z: float
+    mean_volatility_innovation: float
+    variance_z: float
+    variance_volatility_innovation: float
+    covariance: float
+
+    def __post_init__(self) -> None:
+        for name in (
+            "mean_z",
+            "mean_volatility_innovation",
+            "variance_z",
+            "variance_volatility_innovation",
+            "covariance",
+        ):
+            object.__setattr__(self, name, _finite_float(getattr(self, name), name))
+        if self.variance_z < 0.0 or self.variance_volatility_innovation < 0.0:
+            raise ValueError("variances must be non-negative")
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "mean_z": self.mean_z,
+            "mean_volatility_innovation": self.mean_volatility_innovation,
+            "variance_z": self.variance_z,
+            "variance_volatility_innovation": self.variance_volatility_innovation,
+            "covariance": self.covariance,
+        }
+
+
+def _step_grid(horizon: float, max_dt: float) -> tuple[int, float]:
+    horizon_value = _positive_float(horizon, "horizon")
+    max_dt_value = _positive_float(max_dt, "max_dt")
+    n_steps = max(1, int(math.ceil(horizon_value / max_dt_value - 2.0e-14)))
+    return n_steps, horizon_value / n_steps
+
+
+def _resolve_limit_params(
+    params: TgarchParams,
+    measure: Measure,
+    limit_params: LimitParams | None,
+) -> LimitParams | None:
+    if limit_params is not None and not isinstance(limit_params, LimitParams):
+        raise ValueError("limit_params must be a LimitParams instance or None")
+    if measure is not Measure.Q_LIMIT:
+        return limit_params
+    result = derived_limit_params(params) if limit_params is None else limit_params
+    d0_scale = max(1.0, abs(params.d0), abs(result.d0))
+    vol_scale = max(1.0, params.vartheta, result.vartheta)
+    if abs(result.d0 - params.d0) > 5.0e-11 * d0_scale:
+        raise ValueError("limit_params violates the cross-measure d0 restriction")
+    if abs(result.vartheta - params.vartheta) > 5.0e-11 * vol_scale:
+        raise ValueError("limit_params.vartheta must match the physical diffusion scale")
+    return result
+
+
+def _exact_q_law(
+    sigma: FloatArray,
+    dt: float,
+    params: TgarchParams,
+) -> tuple[FloatArray, FloatArray]:
+    sqrt_dt = math.sqrt(dt)
+    denominator = 1.0 - 2.0 * sqrt_dt * params.eta(sigma)
+    if np.any(denominator <= 0.0) or not np.isfinite(denominator).all():
+        worst = float(np.min(denominator))
+        raise ValueError(
+            "the exact-Q kernel is inadmissible: 1 - 2*sqrt(dt)*eta(sigma) "
+            f"must be positive on every path (minimum={worst:.12g})"
+        )
+    variance = 1.0 / denominator
+    mean = -sqrt_dt * params.gamma(sigma) - 0.5 * sigma * sqrt_dt * (variance - 1.0)
+    return np.asarray(mean, dtype=np.float64), np.asarray(variance, dtype=np.float64)
+
+
+def _exact_q_law_scalar(sigma: float, dt: float, params: TgarchParams) -> tuple[float, float]:
+    sqrt_dt = math.sqrt(dt)
+    denominator = 1.0 - 2.0 * sqrt_dt * float(params.eta(sigma))
+    if denominator <= 0.0 or not math.isfinite(denominator):
+        raise ValueError(
+            "the exact-Q kernel is inadmissible: 1 - 2*sqrt(dt)*eta(sigma) "
+            f"must be positive (value={denominator:.12g})"
+        )
+    variance = 1.0 / denominator
+    mean = -sqrt_dt * float(params.gamma(sigma)) - 0.5 * sigma * sqrt_dt * (variance - 1.0)
+    return mean, variance
+
+
+def _antithetic_normal_block(
+    rng: np.random.Generator,
+    *,
+    block_steps: int,
+    n_paths: int,
+) -> FloatArray:
+    pair_count = n_paths // 2
+    has_singleton = n_paths % 2
+    independent_count = pair_count + has_singleton
+    draws = rng.standard_normal((block_steps, independent_count), dtype=np.float64)
+    result = np.empty((block_steps, n_paths), dtype=np.float64)
+    if pair_count:
+        result[:, :pair_count] = draws[:, :pair_count]
+        result[:, pair_count : 2 * pair_count] = -draws[:, :pair_count]
+    if has_singleton:
+        result[:, -1] = draws[:, -1]
+    return result
+
+
+def _effective_sample_size(log_weights: FloatArray) -> float:
+    shift = float(np.max(log_weights))
+    scaled = np.exp(log_weights - shift)
+    numerator = float(np.sum(scaled)) ** 2
+    denominator = float(np.dot(scaled, scaled))
+    if denominator == 0.0 or not math.isfinite(numerator):
+        raise FloatingPointError("could not compute a finite effective sample size")
+    return numerator / denominator
+
+
+def simulate_terminal(
+    params: TgarchParams,
+    measure: Measure | str,
+    maturity: float,
+    max_dt: float,
+    n_paths: int,
+    seed: int,
+    limit_params: LimitParams | None = None,
+    track_log_weights: bool = False,
+    chunk_steps: int = _DEFAULT_CHUNK_STEPS,
+) -> SimulationResult:
+    """Stream a terminal simulation with antithetic PCG64 base normals.
+
+    ``max_dt`` is an upper bound: the function takes ``ceil(maturity / max_dt)`` equal steps so
+    that the final time is exactly ``maturity``.  P-to-Q likelihood ratios are available only on
+    P paths because they are the Radon--Nikodym weights used by the reweighting experiment.
+    """
+
+    if not isinstance(params, TgarchParams):
+        raise ValueError("params must be a TgarchParams instance")
+    measure_value = _as_measure(measure)
+    maturity_value = _positive_float(maturity, "maturity")
+    n_paths_value = _positive_int(n_paths, "n_paths")
+    seed_value = _validated_seed(seed)
+    chunk_value = _positive_int(chunk_steps, "chunk_steps")
+    if not isinstance(track_log_weights, (bool, np.bool_)):
+        raise ValueError("track_log_weights must be bool")
+    if track_log_weights and measure_value is not Measure.P:
+        raise ValueError("P-to-Q log weights can only be accumulated on P simulations")
+    n_steps, dt = _step_grid(maturity_value, max_dt)
+    limit = _resolve_limit_params(params, measure_value, limit_params)
+
+    rng = np.random.Generator(np.random.PCG64(seed_value))
+    sigma = np.full(n_paths_value, params.sigma0, dtype=np.float64)
+    log_spot = np.full(n_paths_value, math.log(params.spot0), dtype=np.float64)
+    log_weights = np.zeros(n_paths_value, dtype=np.float64) if track_log_weights else None
+    sqrt_dt = math.sqrt(dt)
+    floor_hits = 0
+
+    for block_start in range(0, n_steps, chunk_value):
+        block_size = min(chunk_value, n_steps - block_start)
+        base_block = _antithetic_normal_block(
+            rng,
+            block_steps=block_size,
+            n_paths=n_paths_value,
+        )
+        for block_index in range(block_size):
+            base_z = base_block[block_index]
+            if measure_value is Measure.Q_EXACT:
+                q_mean, q_variance = _exact_q_law(sigma, dt, params)
+                z = q_mean + np.sqrt(q_variance) * base_z
+                log_drift = params.r + params.gamma(sigma) * sigma - 0.5 * sigma * sigma
+                sigma_drift = params.drift(sigma)
+            elif measure_value is Measure.P:
+                z = base_z
+                log_drift = params.r + params.gamma(sigma) * sigma - 0.5 * sigma * sigma
+                sigma_drift = params.drift(sigma)
+                if log_weights is not None:
+                    q_mean, q_variance = _exact_q_law(sigma, dt, params)
+                    log_weights += -0.5 * np.log(q_variance) - 0.5 * (
+                        (z - q_mean) * (z - q_mean) / q_variance - z * z
+                    )
+            else:
+                if limit is None:  # pragma: no cover - guarded by _resolve_limit_params
+                    raise RuntimeError("missing Q-limit parameters")
+                z = base_z
+                log_drift = params.r - 0.5 * sigma * sigma
+                sigma_drift = limit.drift(sigma)
+
+            log_spot += log_drift * dt + sigma * sqrt_dt * z
+            w = (np.abs(z) - M1) / S1
+            sigma_next = (
+                sigma + sigma_drift * dt + sigma * sqrt_dt * (params.beta * z + params.eps * w)
+            )
+            hit = sigma_next < SIGMA_FLOOR
+            floor_hits += int(np.count_nonzero(hit))
+            np.maximum(sigma_next, SIGMA_FLOOR, out=sigma_next)
+            sigma = sigma_next
+
+        if not np.isfinite(sigma).all() or not np.isfinite(log_spot).all():
+            step = block_start + block_size
+            raise FloatingPointError(f"non-finite state encountered after simulation step {step}")
+        if log_weights is not None and not np.isfinite(log_weights).all():
+            step = block_start + block_size
+            raise FloatingPointError(
+                f"non-finite log weight encountered after simulation step {step}"
+            )
+
+    with np.errstate(over="ignore", under="ignore"):
+        terminal_spot = np.exp(log_spot)
+    overflow_count = int(np.isposinf(terminal_spot).sum())
+    ess: float | None = None
+    ess_fraction: float | None = None
+    low_ess = False
+    if log_weights is not None:
+        ess = _effective_sample_size(log_weights)
+        ess_fraction = ess / n_paths_value
+        low_ess = ess_fraction < 0.2
+
+    return SimulationResult(
+        measure=measure_value,
+        maturity=maturity_value,
+        dt=dt,
+        n_steps=n_steps,
+        terminal_spot=terminal_spot,
+        terminal_log_spot=log_spot,
+        terminal_sigma=sigma,
+        floor_hits=floor_hits,
+        spot_overflow_count=overflow_count,
+        log_weights=log_weights,
+        effective_sample_size=ess,
+        ess_fraction=ess_fraction,
+        low_ess=low_ess,
+    )
+
+
+def _scalar_discrete_update(
+    *,
+    sigma: float,
+    log_price: float,
+    params: TgarchParams,
+    measure: Measure,
+    dt: float,
+    standard_normal: float,
+    limit_params: LimitParams | None,
+) -> tuple[float, float, bool]:
+    sqrt_dt = math.sqrt(dt)
+    if measure is Measure.Q_EXACT:
+        mean, variance = _exact_q_law_scalar(sigma, dt, params)
+        z = mean + math.sqrt(variance) * standard_normal
+        log_drift = params.r + float(params.gamma(sigma)) * sigma - 0.5 * sigma * sigma
+        sigma_drift = float(params.drift(sigma))
+    elif measure is Measure.P:
+        z = standard_normal
+        log_drift = params.r + float(params.gamma(sigma)) * sigma - 0.5 * sigma * sigma
+        sigma_drift = float(params.drift(sigma))
+    else:
+        if limit_params is None:  # pragma: no cover - guarded by caller
+            raise RuntimeError("missing Q-limit parameters")
+        z = standard_normal
+        log_drift = params.r - 0.5 * sigma * sigma
+        sigma_drift = float(limit_params.drift(sigma))
+    next_log_price = log_price + log_drift * dt + sigma * sqrt_dt * z
+    w = (abs(z) - M1) / S1
+    next_sigma = sigma + sigma_drift * dt + sigma * sqrt_dt * (params.beta * z + params.eps * w)
+    floor_hit = next_sigma < SIGMA_FLOOR
+    return next_log_price, max(next_sigma, SIGMA_FLOOR), floor_hit
+
+
+def simulate_stationary_sigma(
+    params: TgarchParams,
+    measure: Measure | str,
+    dt: float,
+    burn_years: float,
+    sample_years: float,
+    sample_interval: float,
+    seed: int,
+    limit_params: LimitParams | None = None,
+) -> StationarySimulationResult:
+    """Simulate a long recursion and subsample at ``sample_interval`` years.
+
+    The requested interval must be an integer multiple of ``dt`` (an interval no larger than
+    ``dt`` retains every step).
+    """
+
+    if not isinstance(params, TgarchParams):
+        raise ValueError("params must be a TgarchParams instance")
+    measure_value = _as_measure(measure)
+    dt_value = _positive_float(dt, "dt")
+    burn_value = _positive_float(burn_years, "burn_years", allow_zero=True)
+    sample_value = _positive_float(sample_years, "sample_years")
+    interval_value = _positive_float(sample_interval, "sample_interval")
+    interval_ratio = interval_value / dt_value
+    interval_steps = max(1, int(round(interval_ratio)))
+    if interval_ratio > 1.0 and not math.isclose(
+        interval_ratio,
+        interval_steps,
+        rel_tol=2.0e-11,
+        abs_tol=2.0e-11,
+    ):
+        raise ValueError("sample_interval must be an integer multiple of dt")
+    seed_value = _validated_seed(seed)
+    burn_steps = int(math.ceil(burn_value / dt_value - 2.0e-14)) if burn_value else 0
+    sample_steps = max(1, int(math.ceil(sample_value / dt_value - 2.0e-14)))
+    n_samples = sample_steps // interval_steps
+    if n_samples == 0:
+        raise ValueError("sample_interval exceeds the number of post-burn simulation steps")
+    limit = _resolve_limit_params(params, measure_value, limit_params)
+    rng = np.random.Generator(np.random.PCG64(seed_value))
+    sigma = params.sigma0
+    sqrt_dt = math.sqrt(dt_value)
+    floor_hits = 0
+    samples = np.empty(n_samples, dtype=np.float64)
+    output_index = 0
+    total_steps = burn_steps + sample_steps
+    for step in range(total_steps):
+        standard_normal = float(rng.standard_normal())
+        if measure_value is Measure.Q_EXACT:
+            mean, variance = _exact_q_law_scalar(sigma, dt_value, params)
+            z = mean + math.sqrt(variance) * standard_normal
+            sigma_drift = float(params.drift(sigma))
+        elif measure_value is Measure.P:
+            z = standard_normal
+            sigma_drift = float(params.drift(sigma))
+        else:
+            if limit is None:  # pragma: no cover - guarded by _resolve_limit_params
+                raise RuntimeError("missing Q-limit parameters")
+            z = standard_normal
+            sigma_drift = float(limit.drift(sigma))
+        w = (abs(z) - M1) / S1
+        sigma_next = (
+            sigma + sigma_drift * dt_value + sigma * sqrt_dt * (params.beta * z + params.eps * w)
+        )
+        hit = sigma_next < SIGMA_FLOOR
+        sigma = max(sigma_next, SIGMA_FLOOR)
+        floor_hits += int(hit)
+        post_burn_step = step - burn_steps + 1
+        if post_burn_step > 0 and post_burn_step % interval_steps == 0:
+            samples[output_index] = sigma
+            output_index += 1
+        if not math.isfinite(sigma):
+            raise FloatingPointError(
+                f"non-finite state encountered after simulation step {step + 1}"
+            )
+    return StationarySimulationResult(
+        samples=samples,
+        measure=measure_value,
+        dt=dt_value,
+        burn_steps=burn_steps,
+        sample_steps=sample_steps,
+        sample_interval=interval_steps * dt_value,
+        sample_interval_steps=interval_steps,
+        floor_hits=floor_hits,
+    )
+
+
+def simulate_discrete_path(
+    params: TgarchParams,
+    measure: Measure | str,
+    dt: float,
+    years: float,
+    seed: int,
+    limit_params: LimitParams | None = None,
+) -> PathSimulationResult:
+    """Store one path of the finite-step one-shock recursion."""
+
+    if not isinstance(params, TgarchParams):
+        raise ValueError("params must be a TgarchParams instance")
+    measure_value = _as_measure(measure)
+    years_value = _positive_float(years, "years")
+    n_steps, actual_dt = _step_grid(years_value, dt)
+    seed_value = _validated_seed(seed)
+    limit = _resolve_limit_params(params, measure_value, limit_params)
+    rng = np.random.Generator(np.random.PCG64(seed_value))
+    times = np.linspace(0.0, years_value, n_steps + 1, dtype=np.float64)
+    log_prices = np.empty(n_steps + 1, dtype=np.float64)
+    sigmas = np.empty(n_steps + 1, dtype=np.float64)
+    log_prices[0] = math.log(params.spot0)
+    sigmas[0] = params.sigma0
+    floor_hits = 0
+    for step in range(n_steps):
+        next_log_price, next_sigma, hit = _scalar_discrete_update(
+            sigma=float(sigmas[step]),
+            log_price=float(log_prices[step]),
+            params=params,
+            measure=measure_value,
+            dt=actual_dt,
+            standard_normal=float(rng.standard_normal()),
+            limit_params=limit,
+        )
+        log_prices[step + 1] = next_log_price
+        sigmas[step + 1] = next_sigma
+        floor_hits += int(hit)
+        if not math.isfinite(next_log_price) or not math.isfinite(next_sigma):
+            raise FloatingPointError(
+                f"non-finite state encountered after simulation step {step + 1}"
+            )
+    return PathSimulationResult(
+        times=times,
+        log_prices=log_prices,
+        sigmas=sigmas,
+        floor_hits=floor_hits,
+        measure=measure_value,
+        dt=actual_dt,
+        two_shock=False,
+    )
+
+
+def simulate_two_shock_limit_path(
+    params: TgarchParams,
+    dt: float,
+    years: float,
+    seed: int,
+    limit_params: LimitParams | None = None,
+) -> PathSimulationResult:
+    """Store one Euler path of the two-independent-Brownian limit model.
+
+    With ``limit_params=None`` the path is under P.  Passing hatted parameters selects limit Q.
+    This explicit convention keeps the signature small for the P-path filtering experiment.
+    """
+
+    if not isinstance(params, TgarchParams):
+        raise ValueError("params must be a TgarchParams instance")
+    years_value = _positive_float(years, "years")
+    n_steps, actual_dt = _step_grid(years_value, dt)
+    seed_value = _validated_seed(seed)
+    measure = Measure.P if limit_params is None else Measure.Q_LIMIT
+    limit = _resolve_limit_params(params, measure, limit_params)
+    rng = np.random.Generator(np.random.PCG64(seed_value))
+    shocks = rng.standard_normal((n_steps, 2), dtype=np.float64)
+    times = np.linspace(0.0, years_value, n_steps + 1, dtype=np.float64)
+    log_prices = np.empty(n_steps + 1, dtype=np.float64)
+    sigmas = np.empty(n_steps + 1, dtype=np.float64)
+    log_prices[0] = math.log(params.spot0)
+    sigmas[0] = params.sigma0
+    sqrt_dt = math.sqrt(actual_dt)
+    floor_hits = 0
+    for step in range(n_steps):
+        sigma = float(sigmas[step])
+        z0 = float(shocks[step, 0])
+        z1 = float(shocks[step, 1])
+        if measure is Measure.P:
+            log_drift = params.r + float(params.gamma(sigma)) * sigma - 0.5 * sigma * sigma
+            sigma_drift = float(params.drift(sigma))
+        else:
+            if limit is None:  # pragma: no cover - guarded by measure construction
+                raise RuntimeError("missing Q-limit parameters")
+            log_drift = params.r - 0.5 * sigma * sigma
+            sigma_drift = float(limit.drift(sigma))
+        log_prices[step + 1] = log_prices[step] + log_drift * actual_dt + sigma * sqrt_dt * z0
+        next_sigma = (
+            sigma + sigma_drift * actual_dt + sigma * sqrt_dt * (params.beta * z0 + params.eps * z1)
+        )
+        hit = next_sigma < SIGMA_FLOOR
+        floor_hits += int(hit)
+        sigmas[step + 1] = max(next_sigma, SIGMA_FLOOR)
+        if not math.isfinite(log_prices[step + 1]) or not math.isfinite(sigmas[step + 1]):
+            raise FloatingPointError(
+                f"non-finite state encountered after simulation step {step + 1}"
+            )
+    return PathSimulationResult(
+        times=times,
+        log_prices=log_prices,
+        sigmas=sigmas,
+        floor_hits=floor_hits,
+        measure=measure,
+        dt=actual_dt,
+        two_shock=True,
+    )
+
+
+def filter_discrete_returns(
+    log_prices: NDArray[np.floating[Any]],
+    observation_times: NDArray[np.floating[Any]],
+    params: TgarchParams,
+    sigma0: float,
+) -> FloatArray:
+    """Run the exact physical-measure volatility filter from observed log prices.
+
+    The returned vector is aligned with ``log_prices`` and begins with the supplied ``sigma0``.
+    Irregular positive time increments are supported.
+    """
+
+    if not isinstance(params, TgarchParams):
+        raise ValueError("params must be a TgarchParams instance")
+    prices = np.asarray(log_prices, dtype=np.float64)
+    times = np.asarray(observation_times, dtype=np.float64)
+    if prices.ndim != 1 or times.ndim != 1:
+        raise ValueError("log_prices and observation_times must be one-dimensional")
+    if prices.size != times.size or prices.size < 2:
+        raise ValueError("log_prices and observation_times must have the same length of at least 2")
+    if not np.isfinite(prices).all() or not np.isfinite(times).all():
+        raise ValueError("log_prices and observation_times must be finite")
+    increments = np.diff(times)
+    if np.any(increments <= 0.0):
+        raise ValueError("observation_times must be strictly increasing")
+    sigma_initial = _positive_float(sigma0, "sigma0")
+    sigmas = np.empty(prices.size, dtype=np.float64)
+    sigmas[0] = sigma_initial
+    for step, step_dt in enumerate(increments):
+        sigma = float(sigmas[step])
+        gamma = float(params.gamma(sigma))
+        conditional_drift = params.r + gamma * sigma - 0.5 * sigma * sigma
+        z = (prices[step + 1] - prices[step] - conditional_drift * step_dt) / (
+            sigma * math.sqrt(float(step_dt))
+        )
+        w = (abs(z) - M1) / S1
+        next_sigma = (
+            sigma
+            + float(params.drift(sigma)) * step_dt
+            + sigma * math.sqrt(float(step_dt)) * (params.beta * z + params.eps * w)
+        )
+        sigmas[step + 1] = max(next_sigma, SIGMA_FLOOR)
+        if not math.isfinite(sigmas[step + 1]):
+            raise FloatingPointError(f"non-finite filtered volatility at observation {step + 1}")
+    sigmas.setflags(write=False)
+    return sigmas
+
+
+def closed_form_one_step_moments(
+    params: TgarchParams,
+    *,
+    sigma: float,
+    dt: float,
+    measure: Measure | str = Measure.P,
+) -> OneStepMoments:
+    """Return exact moments of ``(z, beta*z + eps*w)`` at a fixed state."""
+
+    if not isinstance(params, TgarchParams):
+        raise ValueError("params must be a TgarchParams instance")
+    sigma_value = _positive_float(sigma, "sigma")
+    dt_value = _positive_float(dt, "dt")
+    measure_value = _as_measure(measure)
+    if measure_value is Measure.Q_EXACT:
+        mean_z, variance_z = _exact_q_law_scalar(sigma_value, dt_value, params)
+    else:
+        mean_z, variance_z = 0.0, 1.0
+    std_z = math.sqrt(variance_z)
+    delta = mean_z / std_z
+    signed_probability = math.erf(delta / _SQRT_TWO)
+    phi = math.exp(-0.5 * delta * delta) / _SQRT_TWO_PI
+    mean_abs_z = std_z * (2.0 * phi + delta * signed_probability)
+    variance_abs_z = variance_z + mean_z * mean_z - mean_abs_z * mean_abs_z
+    covariance_z_abs_z = variance_z * signed_probability
+    mean_w = (mean_abs_z - M1) / S1
+    variance_w = variance_abs_z / (S1 * S1)
+    covariance_z_w = covariance_z_abs_z / S1
+    mean_u = params.beta * mean_z + params.eps * mean_w
+    variance_u = (
+        params.beta * params.beta * variance_z
+        + params.eps * params.eps * variance_w
+        + 2.0 * params.beta * params.eps * covariance_z_w
+    )
+    covariance = params.beta * variance_z + params.eps * covariance_z_w
+    return OneStepMoments(
+        mean_z=mean_z,
+        mean_volatility_innovation=mean_u,
+        variance_z=variance_z,
+        variance_volatility_innovation=max(0.0, variance_u),
+        covariance=covariance,
+    )
+
+
+def _sample_one_step_moments(z: FloatArray, u: FloatArray) -> OneStepMoments:
+    mean_z = float(np.mean(z))
+    mean_u = float(np.mean(u))
+    return OneStepMoments(
+        mean_z=mean_z,
+        mean_volatility_innovation=mean_u,
+        variance_z=float(np.mean(z * z) - mean_z * mean_z),
+        variance_volatility_innovation=float(np.mean(u * u) - mean_u * mean_u),
+        covariance=float(np.mean(z * u) - mean_z * mean_u),
+    )
+
+
+def _moment_standard_errors(z: FloatArray, u: FloatArray) -> dict[str, float]:
+    pair_count = z.size // 2
+    if pair_count < 2 or z.size % 2:
+        raise ValueError("moment validation requires an even n_paths of at least 4")
+    raw = np.column_stack((z, u, z * z, u * u, z * u))
+    pair_raw = 0.5 * (raw[:pair_count] + raw[pair_count : 2 * pair_count])
+    covariance_raw = np.cov(pair_raw, rowvar=False, ddof=1) / pair_count
+    raw_mean = np.mean(raw, axis=0)
+    mean_z, mean_u = float(raw_mean[0]), float(raw_mean[1])
+    gradients = {
+        "mean_z": np.array([1.0, 0.0, 0.0, 0.0, 0.0]),
+        "mean_volatility_innovation": np.array([0.0, 1.0, 0.0, 0.0, 0.0]),
+        "variance_z": np.array([-2.0 * mean_z, 0.0, 1.0, 0.0, 0.0]),
+        "variance_volatility_innovation": np.array([0.0, -2.0 * mean_u, 0.0, 1.0, 0.0]),
+        "covariance": np.array([-mean_u, -mean_z, 0.0, 0.0, 1.0]),
+    }
+    standard_errors: dict[str, float] = {}
+    for name, gradient in gradients.items():
+        variance = float(gradient @ covariance_raw @ gradient)
+        standard_errors[name] = math.sqrt(max(0.0, variance))
+    return standard_errors
+
+
+def validate_one_step_moments(
+    params: TgarchParams,
+    *,
+    dt: float,
+    n_paths: int,
+    seed: int,
+    sigma: float | None = None,
+    measure: Measure | str = Measure.P,
+) -> dict[str, Any]:
+    """Monte Carlo check of exact one-step means, variances, and covariance."""
+
+    n_paths_value = _positive_int(n_paths, "n_paths", minimum=4)
+    if n_paths_value % 2:
+        raise ValueError("n_paths must be even for antithetic moment validation")
+    seed_value = _validated_seed(seed)
+    dt_value = _positive_float(dt, "dt")
+    sigma_value = params.sigma0 if sigma is None else _positive_float(sigma, "sigma")
+    measure_value = _as_measure(measure)
+    rng = np.random.Generator(np.random.PCG64(seed_value))
+    base = _antithetic_normal_block(rng, block_steps=1, n_paths=n_paths_value)[0]
+    if measure_value is Measure.Q_EXACT:
+        mean, variance = _exact_q_law_scalar(sigma_value, dt_value, params)
+        z = mean + math.sqrt(variance) * base
+    else:
+        z = base
+    u = params.beta * z + params.eps * ((np.abs(z) - M1) / S1)
+    empirical = _sample_one_step_moments(z, u)
+    theoretical = closed_form_one_step_moments(
+        params,
+        sigma=sigma_value,
+        dt=dt_value,
+        measure=measure_value,
+    )
+    standard_errors = _moment_standard_errors(z, u)
+    errors: dict[str, float] = {}
+    z_scores: dict[str, float] = {}
+    passed = True
+    empirical_values = empirical.as_dict()
+    theoretical_values = theoretical.as_dict()
+    for name, expected in theoretical_values.items():
+        error = empirical_values[name] - expected
+        se = standard_errors[name]
+        tolerance = max(5.0 * se, 2.0e-12 * max(1.0, abs(expected)))
+        errors[name] = error
+        z_scores[name] = abs(error) / se if se > 0.0 else (0.0 if error == 0.0 else math.inf)
+        passed = passed and abs(error) <= tolerance
+    return {
+        "passed": passed,
+        "measure": measure_value.value,
+        "dt": dt_value,
+        "sigma": sigma_value,
+        "n_paths": n_paths_value,
+        "seed": seed_value,
+        "empirical": empirical_values,
+        "theoretical": theoretical_values,
+        "standard_errors": standard_errors,
+        "errors": errors,
+        "absolute_z_scores": z_scores,
+    }
+
+
+def _paired_mean_standard_error(values: FloatArray) -> float:
+    if values.size < 4 or values.size % 2:
+        raise ValueError("antithetic standard errors require an even number of at least 4 paths")
+    pair_count = values.size // 2
+    pair_means = 0.5 * (values[:pair_count] + values[pair_count:])
+    return float(np.std(pair_means, ddof=1) / math.sqrt(pair_count))
+
+
+def validate_martingale(
+    params: TgarchParams,
+    *,
+    dt: float,
+    maturity: float,
+    n_paths: int,
+    seed: int,
+    limit_params: LimitParams | None = None,
+) -> dict[str, Any]:
+    """Check the exact-Q discounted-spot martingale identity within three MC errors."""
+
+    if n_paths % 2:
+        raise ValueError("n_paths must be even for the antithetic martingale standard error")
+    result = simulate_terminal(
+        params=params,
+        measure=Measure.Q_EXACT,
+        maturity=maturity,
+        max_dt=dt,
+        n_paths=n_paths,
+        seed=seed,
+        limit_params=limit_params,
+    )
+    discounted_spot = result.terminal_spot * math.exp(-params.r * result.maturity)
+    if not np.isfinite(discounted_spot).all():
+        raise FloatingPointError("discounted terminal spot is non-finite in martingale check")
+    estimate = float(np.mean(discounted_spot))
+    standard_error = _paired_mean_standard_error(discounted_spot)
+    error = estimate - params.spot0
+    tolerance = 3.0 * standard_error + 2.0e-13 * params.spot0
+    return {
+        "passed": abs(error) <= tolerance,
+        "estimate": estimate,
+        "target": params.spot0,
+        "error": error,
+        "standard_error": standard_error,
+        "absolute_z_score": abs(error) / standard_error if standard_error else 0.0,
+        "dt": result.dt,
+        "n_steps": result.n_steps,
+        "n_paths": result.n_paths,
+        "seed": int(seed),
+        "floor_hits": result.floor_hits,
+    }
+
+
+def validate_zero_kernel_law(
+    params: TgarchParams,
+    *,
+    dt: float,
+    maturity: float,
+    n_paths: int,
+    seed: int,
+) -> dict[str, Any]:
+    """Check that P, exact Q, and limit Q coincide when ``gamma=eta=0``."""
+
+    zero = replace(params, gamma0=0.0, gamma1=0.0, eta0=0.0, eta1=0.0)
+    results = {
+        measure: simulate_terminal(
+            params=zero,
+            measure=measure,
+            maturity=maturity,
+            max_dt=dt,
+            n_paths=n_paths,
+            seed=seed,
+        )
+        for measure in Measure
+    }
+    reference = results[Measure.P]
+    differences: dict[str, dict[str, float]] = {}
+    passed = True
+    for measure in (Measure.Q_EXACT, Measure.Q_LIMIT):
+        result = results[measure]
+        log_difference = float(
+            np.max(np.abs(result.terminal_log_spot - reference.terminal_log_spot))
+        )
+        sigma_difference = float(np.max(np.abs(result.terminal_sigma - reference.terminal_sigma)))
+        scale = max(
+            1.0,
+            float(np.max(np.abs(reference.terminal_log_spot))),
+            float(np.max(reference.terminal_sigma)),
+        )
+        tolerance = 2.0e-11 * scale
+        differences[measure.value] = {
+            "max_abs_log_spot_difference": log_difference,
+            "max_abs_sigma_difference": sigma_difference,
+            "tolerance": tolerance,
+        }
+        passed = passed and log_difference <= tolerance and sigma_difference <= tolerance
+        passed = passed and result.floor_hits == reference.floor_hits
+    moments = {
+        measure.value: {
+            "mean_log_spot": float(np.mean(result.terminal_log_spot)),
+            "variance_log_spot": float(np.var(result.terminal_log_spot)),
+            "mean_sigma": float(np.mean(result.terminal_sigma)),
+            "variance_sigma": float(np.var(result.terminal_sigma)),
+            "floor_hits": result.floor_hits,
+        }
+        for measure, result in results.items()
+    }
+    return {
+        "passed": passed,
+        "dt": reference.dt,
+        "n_steps": reference.n_steps,
+        "n_paths": reference.n_paths,
+        "seed": int(seed),
+        "differences": differences,
+        "moments": moments,
+    }
+
+
+def run_unit_checks(
+    parameter_sets: Mapping[str, TgarchParams] | Sequence[TgarchParams],
+    dt_grid: Sequence[float],
+    maturity: float,
+    seed: int,
+    n_paths: int,
+    moment_draws: int | None = None,
+) -> dict[str, Any]:
+    """Run all pre-experiment simulation checks and return complete diagnostics.
+
+    ``all_passed`` is the gate for downstream experiments.  Diagnostics are returned even after
+    a failed check so a stochastic or algebraic failure is not hidden by an early assertion.
+    """
+
+    if isinstance(parameter_sets, Mapping):
+        items = list(parameter_sets.items())
+    else:
+        items = [(f"parameter_set_{index}", value) for index, value in enumerate(parameter_sets)]
+    if not items:
+        raise ValueError("parameter_sets cannot be empty")
+    for name, params in items:
+        if not isinstance(name, str) or not name:
+            raise ValueError("parameter-set labels must be non-empty strings")
+        if not isinstance(params, TgarchParams):
+            raise ValueError(f"parameter set {name!r} is not TgarchParams")
+    dt_values = [_positive_float(value, "dt_grid item") for value in dt_grid]
+    if not dt_values:
+        raise ValueError("dt_grid cannot be empty")
+    maturity_value = _positive_float(maturity, "maturity")
+    seed_value = _validated_seed(seed)
+    n_paths_value = _positive_int(n_paths, "n_paths", minimum=4)
+    if n_paths_value % 2:
+        raise ValueError("n_paths must be even for antithetic unit checks")
+    moment_paths = (
+        n_paths_value
+        if moment_draws is None
+        else _positive_int(moment_draws, "moment_draws", minimum=4)
+    )
+    if moment_paths % 2:
+        raise ValueError("moment_draws must be even for antithetic unit checks")
+
+    report: dict[str, Any] = {
+        "one_step_moments": {},
+        "martingale": {},
+        "zero_kernel_law": {},
+    }
+    all_passed = True
+    for parameter_index, (name, params) in enumerate(items):
+        for dt_index, dt_value in enumerate(dt_values):
+            label = f"{name}|dt={dt_value:.12g}"
+            check_seed = seed_value + 100_000 * parameter_index + 100 * dt_index
+            p_moments = validate_one_step_moments(
+                params,
+                dt=dt_value,
+                n_paths=moment_paths,
+                seed=check_seed,
+                measure=Measure.P,
+            )
+            q_moments = validate_one_step_moments(
+                params,
+                dt=dt_value,
+                n_paths=moment_paths,
+                seed=check_seed + 1,
+                measure=Measure.Q_EXACT,
+            )
+            report["one_step_moments"][label] = {
+                "P": p_moments,
+                "Q_EXACT": q_moments,
+            }
+            martingale = validate_martingale(
+                params,
+                dt=dt_value,
+                maturity=maturity_value,
+                n_paths=n_paths_value,
+                seed=check_seed + 2,
+            )
+            report["martingale"][label] = martingale
+            all_passed = (
+                all_passed
+                and bool(p_moments["passed"])
+                and bool(q_moments["passed"])
+                and bool(martingale["passed"])
+            )
+
+        zero_check = validate_zero_kernel_law(
+            params,
+            dt=max(dt_values),
+            maturity=maturity_value,
+            n_paths=n_paths_value,
+            seed=seed_value + 100_000 * parameter_index + 90_000,
+        )
+        report["zero_kernel_law"][name] = zero_check
+        all_passed = all_passed and bool(zero_check["passed"])
+
+    report["all_passed"] = all_passed
+    report["seed"] = seed_value
+    report["n_paths"] = n_paths_value
+    report["moment_draws"] = moment_paths
+    report["maturity"] = maturity_value
+    return report
+
+
+__all__ = [
+    "M1",
+    "S1",
+    "SIGMA_FLOOR",
+    "LimitParams",
+    "Measure",
+    "OneStepMoments",
+    "PathSimulationResult",
+    "SimulationResult",
+    "StationarySimulationResult",
+    "TgarchParams",
+    "closed_form_one_step_moments",
+    "derived_limit_params",
+    "filter_discrete_returns",
+    "run_unit_checks",
+    "simulate_discrete_path",
+    "simulate_stationary_sigma",
+    "simulate_terminal",
+    "simulate_two_shock_limit_path",
+    "validate_martingale",
+    "validate_one_step_moments",
+    "validate_zero_kernel_law",
+]


### PR DESCRIPTION
## Summary

- restore the audited TGARCH discrete-versus-continuous chapter source from `tgarch-study-round3-reportfix-v3`
- delegate terminal TGARCH simulation, European payoff, and raw path valuation to the existing `stochvolmodels` model, product, and valuation interfaces while retaining research-local estimators and controls
- make the Round 1–3 production chain portable with ignored profile-specific outputs, tracked-note provenance, explicit upstream ordering, and a static acceptance manifest

## Scope

- add the 18 audited repository-only chapter inputs plus one acceptance manifest under `volatility_book/ch_discrete_vol`
- do not change package public APIs, dependencies, versions, changelog, docs, regression baselines, or generated artifacts
- keep the chapter outside the installed wheel (setuptools discovery remains limited to `src/stochvolmodels*`)

## Verification

- [x] D3.0 source subtree matches the authoritative tag exactly
- [x] 48 legacy terminal cases are bitwise identical
- [x] deterministic D3.1 smoke reproduced canonical SHA-256 `02443b3bf27e357a049b41320840f9adfb8bf6215557eb77369977047e096e98`
- [x] 81 focused tests, complete non-slow source suite, seven OCA 5.2.0 adapter tests, and eight slow numerical regressions passed
- [x] configured/critical Ruff, JSON, import, scope, diff, and 16 deliberate mutation gates passed
- [x] wheel and sdist built; repository wheel-content checker passed; both archives exclude `volatility_book`
- [x] isolated installed-wheel suite passed with OCA 5.2.0: 562 passed, 15 skipped, 8 deselected
- [x] offline quickstart passed
- [x] warning-free Sphinx build passed (14/14 sources)
- [x] Round-1 eight-page and Round-3 four-page PDFs passed visual QA
- [x] generated results, figures, caches, and isolated verification targets remain ignored

Remote CI will be monitored before merge.