### PR TITLE
Add regime LogSV and Student risk-premia book analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Entries start at 1.2.0. For earlier releases see the git log.
   `stochvolmodels.pricers.regime_switch_logsv_pricer` add a provisional two-state
   regime-switching LogSV equilibrium, its consistently induced risk-neutral dynamics, coupled
   Fourier pricing, state-conditional implied volatilities, and an independent fixed-seed Monte
-  Carlo implementation for European calls and puts.
+  Carlo implementation for European calls and puts. The model-specific
+  `RegimeRiskPremiaScales` provides analytic, explicitly non-equilibrium channel counterfactuals
+  for the volatility-book attribution study without changing the physical model or equilibrium.
 - `ModelPaths` and the provisional `PathModel`, `TransformModel`,
   `TerminalDistributionModel`, `TerminalSmileModel`, and `Payoff` capability contracts establish
   the path, terminal-model, and pathwise-product boundaries for book analytics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Entries start at 1.2.0. For earlier releases see the git log.
 ## [Unreleased]
 
 ### Added
+- `stochvolmodels.models.regime_logsv`, `stochvolmodels.models.regime_logsv_simulation`, and
+  `stochvolmodels.pricers.regime_switch_logsv_pricer` add a provisional two-state
+  regime-switching LogSV equilibrium, its consistently induced risk-neutral dynamics, coupled
+  Fourier pricing, state-conditional implied volatilities, and an independent fixed-seed Monte
+  Carlo implementation for European calls and puts.
 - `ModelPaths` and the provisional `PathModel`, `TransformModel`,
   `TerminalDistributionModel`, `TerminalSmileModel`, and `Payoff` capability contracts establish
   the path, terminal-model, and pathwise-product boundaries for book analytics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Entries start at 1.2.0. For earlier releases see the git log.
 ## [Unreleased]
 
 ### Added
+- `stochvolmodels.models.inverse_gamma_normal` adds a provisional, maturity-specific
+  inverse-gamma/normal terminal distribution and Black-smile model for the volatility-book
+  risk-premia study. It uses prepaid-forward normalization, supports skew conditional means,
+  and keeps physical-to-pricing risk-premium mappings outside package core.
 - `stochvolmodels.models.regime_logsv`, `stochvolmodels.models.regime_logsv_simulation`, and
   `stochvolmodels.pricers.regime_switch_logsv_pricer` add a provisional two-state
   regime-switching LogSV equilibrium, its consistently induced risk-neutral dynamics, coupled

--- a/scripts/check_wheel_contents.py
+++ b/scripts/check_wheel_contents.py
@@ -47,7 +47,10 @@ def check_wheel(wheel_path: Path) -> None:
         "stochvolmodels/data/model_paths.py",
         "stochvolmodels/models/__init__.py",
         "stochvolmodels/models/logsv.py",
+        "stochvolmodels/models/regime_logsv.py",
+        "stochvolmodels/models/regime_logsv_simulation.py",
         "stochvolmodels/models/tgarch.py",
+        "stochvolmodels/pricers/regime_switch_logsv_pricer.py",
         "stochvolmodels/products/__init__.py",
         "stochvolmodels/products/payoffs.py",
         "stochvolmodels/valuation.py",
@@ -61,8 +64,8 @@ def check_wheel(wheel_path: Path) -> None:
         for member in members
         if member.startswith("stochvolmodels/tests/test_") and member.endswith(".py")
     }
-    assert len(test_modules) == 30, (
-        f"expected exactly 30 automated test modules, found {len(test_modules)}"
+    assert len(test_modules) == 31, (
+        f"expected exactly 31 automated test modules, found {len(test_modules)}"
     )
     assert not any(member.endswith("_test.py") for member in members), (
         "automated tests must use the test_*.py form"

--- a/scripts/check_wheel_contents.py
+++ b/scripts/check_wheel_contents.py
@@ -46,6 +46,7 @@ def check_wheel(wheel_path: Path) -> None:
         "stochvolmodels/__init__.py",
         "stochvolmodels/data/model_paths.py",
         "stochvolmodels/models/__init__.py",
+        "stochvolmodels/models/inverse_gamma_normal.py",
         "stochvolmodels/models/logsv.py",
         "stochvolmodels/models/regime_logsv.py",
         "stochvolmodels/models/regime_logsv_simulation.py",
@@ -64,8 +65,8 @@ def check_wheel(wheel_path: Path) -> None:
         for member in members
         if member.startswith("stochvolmodels/tests/test_") and member.endswith(".py")
     }
-    assert len(test_modules) == 31, (
-        f"expected exactly 31 automated test modules, found {len(test_modules)}"
+    assert len(test_modules) == 32, (
+        f"expected exactly 32 automated test modules, found {len(test_modules)}"
     )
     assert not any(member.endswith("_test.py") for member in members), (
         "automated tests must use the test_*.py form"

--- a/src/stochvolmodels/models/inverse_gamma_normal.py
+++ b/src/stochvolmodels/models/inverse_gamma_normal.py
@@ -1,0 +1,362 @@
+"""One-maturity inverse-gamma/normal terminal-law analytics."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from functools import lru_cache
+from numbers import Integral, Real
+
+import numpy as np
+import vanilla_option_pricers as bsm
+from scipy.optimize import brentq
+from scipy.special import ndtr, roots_genlaguerre
+
+from stochvolmodels.data.option_chain import OptionSlice
+
+__all__ = (
+    "InverseGammaNormalParams",
+    "InverseGammaNormalTerminalModel",
+)
+
+
+@dataclass(frozen=True)
+class InverseGammaNormalParams:
+    """Risk-neutral parameters of one inverse-gamma/normal terminal law.
+
+    The maturity-specific law is
+
+    ``V ~ IG(alpha, beta)`` and ``X | V ~ N(q * V, c * V)``.
+
+    The shock is measured relative to the prepaid forward. The terminal asset is
+    ``S_T = D_T * F_T * max(A_T + X, 0)``, where the model solves ``A_T`` from
+    ``E[max(A_T + X, 0)] = 1 / D_T`` for each option slice.
+    """
+
+    alpha: float
+    beta: float
+    c: float
+    q: float
+    ttm: float
+
+
+@lru_cache(maxsize=64)
+def _gamma_precision_rule(alpha: float, quadrature_order: int) -> tuple[np.ndarray, np.ndarray]:
+    """Return a read-only quadrature rule for ``U ~ Gamma(alpha, 1)``."""
+
+    nodes, raw_weights = roots_genlaguerre(quadrature_order, alpha - 1.0)
+    weight_sum = float(np.sum(raw_weights))
+    if (
+        not np.all(np.isfinite(nodes))
+        or not np.all(nodes > 0.0)
+        or not np.all(np.isfinite(raw_weights))
+        or np.any(raw_weights < 0.0)
+        or not np.isfinite(weight_sum)
+        or weight_sum <= 0.0
+    ):
+        raise ValueError("generalized Gauss-Laguerre quadrature failed for these parameters")
+    weights = np.asarray(raw_weights / weight_sum, dtype=float)
+    nodes = np.asarray(nodes, dtype=float)
+    nodes.setflags(write=False)
+    weights.setflags(write=False)
+    return nodes, weights
+
+
+def _normal_positive_part(mean: np.ndarray, stdev: np.ndarray) -> np.ndarray:
+    """Return ``E[(mean + stdev * Z)^+]`` with a stable Gaussian left tail."""
+
+    means = np.asarray(mean, dtype=float)
+    stdevs = np.broadcast_to(np.asarray(stdev, dtype=float), means.shape)
+    d = means / stdevs
+    scaled = np.empty_like(d, dtype=float)
+    middle = np.abs(d) <= 8.0
+    right = d > 8.0
+    left = d < -8.0
+
+    middle_d = d[middle]
+    density = np.exp(-0.5 * np.square(middle_d)) / math.sqrt(2.0 * math.pi)
+    scaled[middle] = density + middle_d * ndtr(middle_d)
+    scaled[right] = d[right]
+
+    z = -d[left]
+    inverse_square = 1.0 / np.square(z)
+    mills_remainder = inverse_square * (
+        1.0
+        + inverse_square
+        * (-3.0 + inverse_square * (15.0 + inverse_square * (-105.0 + 945.0 * inverse_square)))
+    )
+    scaled[left] = np.exp(-0.5 * np.square(z)) * mills_remainder / math.sqrt(2.0 * math.pi)
+    return np.maximum(stdevs * scaled, 0.0)
+
+
+class InverseGammaNormalTerminalModel:
+    """Validated inverse-gamma normal mean-variance mixture for European options.
+
+    This is a static, one-maturity terminal distribution and Black-smile model. It
+    deliberately does not claim path or transform capabilities: for nonzero ``q``
+    the marginal law is skewed and heavy-tailed, while at ``q=0`` it reduces to the
+    arithmetic Student law without a nontrivial real moment-generating function.
+
+    Parameters are risk-neutral law inputs. Physical parameters and the book's
+    ``p``/``eta`` risk-premium mapping remain outside this model.
+    """
+
+    def __init__(
+        self,
+        params: InverseGammaNormalParams,
+        *,
+        quadrature_order: int = 256,
+    ) -> None:
+        """Validate and bind one maturity-specific risk-neutral law."""
+
+        if not isinstance(params, InverseGammaNormalParams):
+            raise TypeError("params must be an InverseGammaNormalParams instance")
+
+        values = {
+            "alpha": params.alpha,
+            "beta": params.beta,
+            "c": params.c,
+            "q": params.q,
+            "ttm": params.ttm,
+        }
+        for name, value in values.items():
+            if (
+                isinstance(value, (bool, np.bool_))
+                or not isinstance(value, Real)
+                or not np.isfinite(value)
+            ):
+                raise ValueError(f"{name} must be a finite real scalar")
+        if values["alpha"] <= 1.0:
+            raise ValueError("alpha must be greater than one")
+        for name in ("beta", "c", "ttm"):
+            if values[name] <= 0.0:
+                raise ValueError(f"{name} must be positive")
+        if (
+            isinstance(quadrature_order, (bool, np.bool_))
+            or not isinstance(quadrature_order, Integral)
+            or quadrature_order < 2
+        ):
+            raise ValueError("quadrature_order must be an integer of at least two")
+
+        alpha = float(values["alpha"])
+        beta = float(values["beta"])
+        c = float(values["c"])
+        q = float(values["q"])
+        ttm = float(values["ttm"])
+        order = int(quadrature_order)
+        nodes, weights = _gamma_precision_rule(alpha, order)
+        variances = np.asarray(beta / nodes, dtype=float)
+        stdevs = np.asarray(np.sqrt(c * variances), dtype=float)
+        conditional_means = np.asarray(q * variances, dtype=float)
+        mean_mixing_variance = beta / (alpha - 1.0)
+        if (
+            not np.all(np.isfinite(variances))
+            or not np.all(np.isfinite(stdevs))
+            or not np.all(np.isfinite(conditional_means))
+            or not np.isfinite(mean_mixing_variance)
+        ):
+            raise ValueError("params produce non-finite quadrature state")
+        for array in (variances, stdevs, conditional_means):
+            array.setflags(write=False)
+
+        self._alpha = alpha
+        self._beta = beta
+        self._c = c
+        self._q = q
+        self._ttm = ttm
+        self._quadrature_order = order
+        self._weights = weights
+        self._variances = variances
+        self._stdevs = stdevs
+        self._conditional_means = conditional_means
+        self._mean_mixing_variance = float(mean_mixing_variance)
+
+    @property
+    def params(self) -> InverseGammaNormalParams:
+        """Return the immutable risk-neutral parameter payload."""
+
+        return InverseGammaNormalParams(
+            alpha=self._alpha,
+            beta=self._beta,
+            c=self._c,
+            q=self._q,
+            ttm=self._ttm,
+        )
+
+    @property
+    def ttm(self) -> float:
+        """Return the terminal law's exact maturity in years."""
+
+        return self._ttm
+
+    @property
+    def quadrature_order(self) -> int:
+        """Return the generalized Gauss-Laguerre node count."""
+
+        return self._quadrature_order
+
+    @property
+    def mean_mixing_variance(self) -> float:
+        """Return ``E[V] = beta / (alpha - 1)`` under the bound pricing law."""
+
+        return self._mean_mixing_variance
+
+    def _expect_positive(
+        self,
+        intercept: float | np.ndarray,
+        *,
+        shock_sign: float = 1.0,
+    ) -> np.ndarray:
+        intercepts = np.asarray(intercept, dtype=float)
+        means = intercepts[..., np.newaxis] + shock_sign * self._conditional_means
+        conditional = _normal_positive_part(means, self._stdevs)
+        return np.sum(conditional * self._weights, axis=-1)
+
+    @staticmethod
+    def _validate_discfactor(discfactor: float) -> float:
+        if (
+            isinstance(discfactor, (bool, np.bool_))
+            or not isinstance(discfactor, Real)
+            or not np.isfinite(discfactor)
+            or discfactor <= 0.0
+        ):
+            raise ValueError("discfactor must be a finite positive real scalar")
+        return float(discfactor)
+
+    @lru_cache(maxsize=32)
+    def _solve_martingale_shift(self, discfactor: float) -> float:
+        target = 1.0 / discfactor
+
+        def objective(shift: float) -> float:
+            return float(self._expect_positive(shift)) - target
+
+        center = target - self._q * self._mean_mixing_variance
+        radius = max(
+            1.0,
+            abs(center),
+            math.sqrt(self._c * self._mean_mixing_variance),
+        )
+        for _ in range(128):
+            lower = center - radius
+            upper = center + radius
+            lower_value = objective(lower)
+            upper_value = objective(upper)
+            if lower_value <= 0.0 <= upper_value:
+                break
+            radius *= 2.0
+            if not np.isfinite(radius):
+                raise ValueError("could not bracket the martingale shift")
+        else:
+            raise ValueError("could not bracket the martingale shift")
+
+        return float(
+            brentq(
+                objective,
+                lower,
+                upper,
+                xtol=1.0e-13,
+                rtol=1.0e-13,
+                maxiter=200,
+            )
+        )
+
+    def martingale_shift(self, *, discfactor: float) -> float:
+        """Return the unique prepaid-forward shift for ``discfactor``."""
+
+        validated = self._validate_discfactor(discfactor)
+        return self._solve_martingale_shift(validated)
+
+    def default_probability(self, *, discfactor: float) -> float:
+        """Return the terminal zero-price mass for ``discfactor``."""
+
+        shift = self.martingale_shift(discfactor=discfactor)
+        standardized_boundary = (-shift - self._conditional_means) / self._stdevs
+        return float(np.dot(self._weights, ndtr(standardized_boundary)))
+
+    def _validated_slice(
+        self,
+        option_slice: OptionSlice,
+    ) -> tuple[float, float, np.ndarray, np.ndarray]:
+        if not isinstance(option_slice, OptionSlice):
+            raise TypeError("option_slice must be an OptionSlice instance")
+        slice_ttm = option_slice.ttm
+        if (
+            isinstance(slice_ttm, (bool, np.bool_))
+            or not isinstance(slice_ttm, Real)
+            or not np.isfinite(slice_ttm)
+            or slice_ttm <= 0.0
+        ):
+            raise ValueError("option_slice.ttm must be a finite positive real scalar")
+        if float(slice_ttm) != self.ttm:
+            raise ValueError("option_slice.ttm must exactly match the bound params.ttm")
+
+        forward = option_slice.forward
+        if (
+            isinstance(forward, (bool, np.bool_))
+            or not isinstance(forward, Real)
+            or not np.isfinite(forward)
+            or forward <= 0.0
+        ):
+            raise ValueError("option_slice.forward must be a finite positive real scalar")
+        discfactor = self._validate_discfactor(option_slice.discfactor)
+
+        raw_strikes = np.asarray(option_slice.strikes)
+        if raw_strikes.dtype.kind == "b":
+            raise ValueError("option_slice.strikes must contain finite positive real values")
+        strikes = np.asarray(option_slice.strikes, dtype=float)
+        optiontypes = np.asarray(option_slice.optiontypes).astype(str)
+        if (
+            strikes.ndim != 1
+            or strikes.size == 0
+            or optiontypes.ndim != 1
+            or optiontypes.size != strikes.size
+            or not np.all(np.isfinite(strikes))
+            or np.any(strikes <= 0.0)
+        ):
+            raise ValueError("option_slice strikes and optiontypes must be aligned and valid")
+        unsupported = set(optiontypes) - {"C", "P"}
+        if unsupported:
+            raise NotImplementedError(
+                "InverseGammaNormalTerminalModel supports C/P only; "
+                "inverse IC/IP settlement is not implemented"
+            )
+        return float(forward), discfactor, strikes, optiontypes
+
+    def price_european(self, option_slice: OptionSlice) -> np.ndarray:
+        """Return discounted standard-call/put prices for one exact-maturity slice."""
+
+        forward, discfactor, strikes, optiontypes = self._validated_slice(option_slice)
+        prepaid_forward = discfactor * forward
+        normalized_strikes = strikes / prepaid_forward
+        shift = self.martingale_shift(discfactor=discfactor)
+
+        normalized_prices = np.empty_like(normalized_strikes, dtype=float)
+        call_mask = optiontypes == "C"
+        if np.any(call_mask):
+            normalized_prices[call_mask] = self._expect_positive(
+                shift - normalized_strikes[call_mask]
+            )
+        put_mask = ~call_mask
+        if np.any(put_mask):
+            raw_puts = self._expect_positive(
+                normalized_strikes[put_mask] - shift,
+                shock_sign=-1.0,
+            )
+            floor_adjustment = float(self._expect_positive(-shift, shock_sign=-1.0))
+            normalized_prices[put_mask] = raw_puts - floor_adjustment
+        return np.asarray(discfactor * prepaid_forward * normalized_prices, dtype=float)
+
+    def implied_vols(self, option_slice: OptionSlice) -> np.ndarray:
+        """Return Black implied volatilities shaped like ``option_slice.strikes``."""
+
+        forward, discfactor, strikes, optiontypes = self._validated_slice(option_slice)
+        prices = self.price_european(option_slice)
+        ivols = bsm.infer_bsm_ivols_from_slice_prices(
+            ttm=self.ttm,
+            forward=forward,
+            discfactor=discfactor,
+            strikes=strikes,
+            optiontypes=optiontypes,
+            model_prices=prices,
+        )
+        return np.asarray(ivols, dtype=float)

--- a/src/stochvolmodels/models/regime_logsv.py
+++ b/src/stochvolmodels/models/regime_logsv.py
@@ -1,0 +1,721 @@
+r"""Parameters for the two-state equilibrium regime-switching LogSV model.
+
+The physical volatility dynamics in regime :math:`i` are
+
+.. math::
+
+   d\sigma_t = (\kappa_{1i}+\kappa_{2i}\sigma_t)
+       (\theta_i-\sigma_t)dt
+       + \beta_i\sigma_t dW_t^{(0)}
+       + \epsilon_i\sigma_t dW_t^{(1)}.
+
+A transition from growth to stress carries a negative exponential log jump; a
+transition from stress to growth carries a positive exponential log jump.  The
+CRRA specification derives the Brownian, transition-timing, and jump-tail risk
+premia jointly.  The default closure is log-linear, which preserves a quadratic
+risk-neutral volatility drift.
+
+The model is the production counterpart of the derivation in the volatility-book
+chapter ``ch_lognormal_sv_risk_premia``.  It combines the LogSV dynamics of Sepp
+and Rakhmonov (2024) with the transition-jump convention of Sepp (2026).
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+from enum import Enum, IntEnum
+from math import comb
+from numbers import Integral, Real
+from typing import Any
+
+import numpy as np
+from scipy.integrate import solve_ivp
+
+
+def _finite_float(value: object, name: str) -> float:
+    """Return a finite built-in float while rejecting booleans."""
+
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite real number")
+    result = float(value)
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+class Regime(IntEnum):
+    """Economic state used by the two-state model."""
+
+    GROWTH = 0
+    STRESS = 1
+
+
+def _as_regime(value: Regime | int, name: str = "regime") -> Regime:
+    """Return a strict two-state selector without numeric coercion."""
+
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be Regime.GROWTH or Regime.STRESS")
+    try:
+        return Regime(int(value))
+    except ValueError as error:
+        raise ValueError(f"{name} must be Regime.GROWTH or Regime.STRESS") from error
+
+
+class EquilibriumClosure(Enum):
+    """Polynomial closure for the logarithm of the CRRA value coefficient."""
+
+    LOG_LINEAR = 1
+    LOG_QUADRATIC = 2
+
+    @property
+    def degree(self) -> int:
+        """Polynomial degree associated with the closure."""
+
+        return int(self.value)
+
+
+@dataclass(frozen=True, slots=True)
+class RegimeLogSvDynamics:
+    """Physical LogSV coefficients within one regime.
+
+    These coefficients parameterize equation (3.1) of the published LogSV
+    paper, applied separately in each economic state.
+
+    Parameters
+    ----------
+    theta : float
+        Positive long-run volatility level.
+    kappa1 : float
+        Positive linear mean-reversion coefficient.
+    kappa2 : float
+        Non-negative quadratic mean-reversion coefficient.
+    beta : float
+        Loading of volatility on the return Brownian motion.
+    volvol : float
+        Non-negative loading on the orthogonal volatility Brownian motion.
+    """
+
+    theta: float
+    kappa1: float
+    kappa2: float
+    beta: float
+    volvol: float
+
+    def __post_init__(self) -> None:
+        for name in ("theta", "kappa1", "kappa2", "beta", "volvol"):
+            object.__setattr__(self, name, _finite_float(getattr(self, name), name))
+        values = (self.theta, self.kappa1, self.kappa2, self.beta, self.volvol)
+        if not all(np.isfinite(values)):
+            raise ValueError("all within-regime LogSV parameters must be finite")
+        if self.theta <= 0.0:
+            raise ValueError("theta must be positive")
+        if self.kappa1 <= 0.0:
+            raise ValueError("kappa1 must be positive")
+        if self.kappa2 < 0.0:
+            raise ValueError("kappa2 must be non-negative")
+        if self.volvol < 0.0:
+            raise ValueError("volvol must be non-negative")
+
+    @property
+    def vartheta2(self) -> float:
+        """Total instantaneous variance coefficient of volatility."""
+
+        return self.beta * self.beta + self.volvol * self.volvol
+
+    @property
+    def kappa_bar(self) -> float:
+        """Mean-reversion speed after centring volatility at ``theta``."""
+
+        return self.kappa1 + self.kappa2 * self.theta
+
+
+@dataclass(frozen=True, slots=True)
+class RegimeTransition:
+    """Physical transition clock and signed exponential log-jump mean.
+
+    The jump MGF is ``ell(z) = 1 / (1 - mean_log_jump * z)``.  Consequently a
+    negative mean denotes a crash and a positive mean denotes a recovery.  Zero
+    intensity and zero jump mean are permitted so the model nests useful exact
+    benchmarks.
+
+    The generator and transition-tied price jump follow equations (2.1)--(2.9)
+    of the published goal-based-allocation model. A switch changes the price and
+    economic state atomically while volatility remains continuous.
+
+    Parameters
+    ----------
+    intensity : float
+        Non-negative annual transition intensity under the physical measure.
+    mean_log_jump : float
+        Signed mean of the exponential log jump.
+    """
+
+    intensity: float
+    mean_log_jump: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "intensity", _finite_float(self.intensity, "intensity"))
+        object.__setattr__(
+            self,
+            "mean_log_jump",
+            _finite_float(self.mean_log_jump, "mean_log_jump"),
+        )
+        if not np.isfinite(self.intensity) or self.intensity < 0.0:
+            raise ValueError("transition intensity must be finite and non-negative")
+        if not np.isfinite(self.mean_log_jump):
+            raise ValueError("mean_log_jump must be finite")
+        if self.mean_log_jump >= 0.5:
+            raise ValueError(
+                "positive mean_log_jump must be below 0.5 so Monte Carlo payoffs "
+                "have finite variance"
+            )
+
+    @property
+    def arithmetic_jump_mean(self) -> float:
+        """Physical expected arithmetic return ``E[exp(J)-1]``."""
+
+        return 1.0 / (1.0 - self.mean_log_jump) - 1.0
+
+
+@dataclass(frozen=True, slots=True)
+class CrraRiskPremia:
+    """CRRA equilibrium specification that generates all risk premia.
+
+    Parameters
+    ----------
+    utility_power : float
+        Power :math:`u<1` in utility ``U(wealth)=wealth**u/u``.  Relative risk
+        aversion is ``1-u``; ``u=0`` denotes the log-utility limit.  The name
+        avoids collision with
+        :attr:`LogSvParams.gamma`, which has a different meaning.
+    agent_horizon : float
+        Remaining representative-agent terminal horizon in years.  Every priced
+        option maturity must be no greater than this fixed horizon.
+    closure : EquilibriumClosure, default EquilibriumClosure.LOG_LINEAR
+        Approximation for the logarithm of the value coefficient.  LOG_LINEAR
+        gives quadratic risk-neutral volatility drift; LOG_QUADRATIC retains the
+        full induced cubic drift when its leading term is inward.  The
+        equilibrium solver rejects continuous-boundary inadmissible dynamics.
+    """
+
+    utility_power: float
+    agent_horizon: float
+    closure: EquilibriumClosure = EquilibriumClosure.LOG_LINEAR
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "utility_power",
+            _finite_float(self.utility_power, "utility_power"),
+        )
+        object.__setattr__(
+            self,
+            "agent_horizon",
+            _finite_float(self.agent_horizon, "agent_horizon"),
+        )
+        if not np.isfinite(self.utility_power) or self.utility_power >= 1.0:
+            raise ValueError("CRRA utility_power must be finite and below one")
+        if not np.isfinite(self.agent_horizon) or self.agent_horizon <= 0.0:
+            raise ValueError("agent_horizon must be finite and positive")
+        if not isinstance(self.closure, EquilibriumClosure):
+            raise TypeError("closure must be an EquilibriumClosure")
+
+    @property
+    def relative_risk_aversion(self) -> float:
+        """CRRA coefficient ``1 - utility_power``."""
+
+        return 1.0 - self.utility_power
+
+
+@dataclass(frozen=True, slots=True)
+class RegimeSwitchLogSvParams:
+    """Complete primitive parameter set for the two-state equilibrium model.
+
+    ``regimes`` and ``transitions`` are ordered as growth then stress.  A growth
+    transition must have a non-positive signed jump mean and a stress transition
+    a non-negative one.  Volatility is continuous across a transition; only the
+    active coefficient set and the price jump change.
+
+    Parameters
+    ----------
+    sigma0 : float
+        Current volatility, common to both conditional initial-state valuations.
+    regimes : tuple[RegimeLogSvDynamics, RegimeLogSvDynamics]
+        Physical growth and stress LogSV dynamics.
+    transitions : tuple[RegimeTransition, RegimeTransition]
+        Growth-to-stress and stress-to-growth physical transition specifications.
+    risk_premia : CrraRiskPremia
+        CRRA preference, horizon, and equilibrium-closure specification.
+    initial_regime : Regime, default Regime.GROWTH
+        State selected by the ordinary :class:`ModelPricer` interface.  The
+        conditional interface returns both states from the same transform solve.
+    """
+
+    sigma0: float
+    regimes: tuple[RegimeLogSvDynamics, RegimeLogSvDynamics]
+    transitions: tuple[RegimeTransition, RegimeTransition]
+    risk_premia: CrraRiskPremia
+    initial_regime: Regime = Regime.GROWTH
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "sigma0", _finite_float(self.sigma0, "sigma0"))
+        object.__setattr__(self, "regimes", tuple(self.regimes))
+        object.__setattr__(self, "transitions", tuple(self.transitions))
+        if not np.isfinite(self.sigma0) or self.sigma0 <= 0.0:
+            raise ValueError("sigma0 must be finite and positive")
+        if len(self.regimes) != 2 or not all(
+            isinstance(value, RegimeLogSvDynamics) for value in self.regimes
+        ):
+            raise TypeError("regimes must contain exactly two RegimeLogSvDynamics objects")
+        if len(self.transitions) != 2 or not all(
+            isinstance(value, RegimeTransition) for value in self.transitions
+        ):
+            raise TypeError("transitions must contain exactly two RegimeTransition objects")
+        if not isinstance(self.risk_premia, CrraRiskPremia):
+            raise TypeError("risk_premia must be a CrraRiskPremia object")
+        object.__setattr__(
+            self,
+            "initial_regime",
+            _as_regime(self.initial_regime, "initial_regime"),
+        )
+        if self.transitions[Regime.GROWTH].mean_log_jump > 0.0:
+            raise ValueError("the growth-to-stress transition must be a crash or zero jump")
+        if self.transitions[Regime.STRESS].mean_log_jump < 0.0:
+            raise ValueError("the stress-to-growth transition must be a recovery or zero jump")
+        self.validate_equilibrium_moments()
+
+    @classmethod
+    def copy(cls, obj: "RegimeSwitchLogSvParams") -> "RegimeSwitchLogSvParams":
+        """Return an immutable shallow copy without flattening nested dataclasses."""
+
+        if not isinstance(obj, cls):
+            raise TypeError(f"obj must be {cls.__name__}")
+        return replace(obj)
+
+    def with_initial_regime(self, regime: Regime) -> "RegimeSwitchLogSvParams":
+        """Return parameters selecting one state for the standard pricer interface."""
+
+        return replace(self, initial_regime=_as_regime(regime, "initial_regime"))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the nested dataclass structure as dictionaries."""
+
+        return asdict(self)
+
+    def jump_mgf(
+        self, regime: Regime | int, exponent: complex | np.ndarray
+    ) -> complex | np.ndarray:
+        """Physical jump MGF ``E[exp(exponent * J)]`` for one source state."""
+
+        state = _as_regime(regime)
+        mean = self.transitions[state].mean_log_jump
+        return 1.0 / (1.0 - mean * exponent)
+
+    def validate_jump_moment(self, regime: Regime | int, exponent: complex | np.ndarray) -> None:
+        """Raise when the requested exponential jump moment does not exist."""
+
+        state = _as_regime(regime)
+        mean = self.transitions[state].mean_log_jump
+        if mean == 0.0:
+            return
+        real_exponent = np.real(np.asarray(exponent))
+        denominator = 1.0 - mean * real_exponent
+        if np.any(denominator <= 0.0):
+            bound = 1.0 / mean
+            relation = "below" if mean > 0.0 else "above"
+            raise ValueError(
+                f"jump moment in regime {int(state)} requires Re(z) {relation} {bound:.6g}"
+            )
+
+    def transition_factor(self, regime: Regime | int) -> float:
+        """CRRA equilibrium transition factor ``Lambda_i``."""
+
+        utility_power = self.risk_premia.utility_power
+        value = (1.0 - utility_power) * self.jump_mgf(regime, utility_power)
+        value += utility_power * self.jump_mgf(regime, utility_power - 1.0)
+        return float(value)
+
+    def validate_equilibrium_moments(self) -> None:
+        """Validate the CRRA jump moments and positive transition coupling."""
+
+        utility_power = self.risk_premia.utility_power
+        for regime in Regime:
+            self.validate_jump_moment(regime, utility_power)
+            self.validate_jump_moment(regime, utility_power - 1.0)
+            factor = self.transition_factor(regime)
+            if not np.isfinite(factor) or factor <= 0.0:
+                raise ValueError(
+                    f"equilibrium transition factor in regime {int(regime)} must be positive"
+                )
+
+
+# Polynomial projection and equilibrium analytics.
+
+
+def _poly_pad(values: np.ndarray, degree: int) -> np.ndarray:
+    """Pad or truncate ascending polynomial coefficients to ``degree``."""
+
+    values = np.asarray(values)
+    output = np.zeros(values.shape[:-1] + (degree + 1,), dtype=values.dtype)
+    count = min(values.shape[-1], degree + 1)
+    output[..., :count] = values[..., :count]
+    return output
+
+
+def _poly_mul(left: np.ndarray, right: np.ndarray, degree: int) -> np.ndarray:
+    """Multiply ascending-coefficient polynomials and truncate at ``degree``."""
+
+    left = _poly_pad(np.asarray(left), degree)
+    right = _poly_pad(np.asarray(right), degree)
+    shape = np.broadcast_shapes(left.shape[:-1], right.shape[:-1]) + (degree + 1,)
+    output = np.zeros(shape, dtype=np.result_type(left, right))
+    for total in range(degree + 1):
+        for index in range(total + 1):
+            output[..., total] += left[..., index] * right[..., total - index]
+    return output
+
+
+def _poly_derivative(values: np.ndarray, degree: int) -> np.ndarray:
+    """Differentiate an ascending-coefficient polynomial."""
+
+    values = _poly_pad(np.asarray(values), degree)
+    output = np.zeros_like(values)
+    for index in range(1, degree + 1):
+        output[..., index - 1] = index * values[..., index]
+    return output
+
+
+def _poly_shift(values: np.ndarray, delta: float, degree: int) -> np.ndarray:
+    """Return coefficients of ``P(v + delta)`` through ``v**degree``."""
+
+    values = _poly_pad(np.asarray(values), degree)
+    output = np.zeros_like(values)
+    for power in range(degree + 1):
+        for original in range(power, degree + 1):
+            output[..., power] += (
+                comb(original, power) * values[..., original] * delta ** (original - power)
+            )
+    return output
+
+
+def _poly_exp(values: np.ndarray, degree: int) -> np.ndarray:
+    """Taylor coefficients of ``exp(P(v))`` through ``v**degree``."""
+
+    values = _poly_pad(np.asarray(values), degree)
+    output = np.zeros_like(values)
+    output[..., 0] = np.exp(values[..., 0])
+    for power in range(1, degree + 1):
+        for index in range(1, power + 1):
+            output[..., power] += index * values[..., index] * output[..., power - index] / power
+    return output
+
+
+def _poly_value(values: np.ndarray, argument: float | np.ndarray) -> np.ndarray:
+    """Evaluate ascending-coefficient polynomials with Horner's rule."""
+
+    values = np.asarray(values)
+    result = np.zeros(
+        np.broadcast_shapes(values.shape[:-1], np.shape(argument)), dtype=values.dtype
+    )
+    for coefficient in np.moveaxis(values, -1, 0)[::-1]:
+        result = result * argument + coefficient
+    return result
+
+
+def _sigma2_polynomial(theta: float, degree: int, dtype: Any = float) -> np.ndarray:
+    """Coefficients of ``(theta + v)**2`` at the requested degree."""
+
+    output = np.zeros(degree + 1, dtype=dtype)
+    count = min(3, degree + 1)
+    output[:count] = np.asarray((theta * theta, 2.0 * theta, 1.0))[:count]
+    return output
+
+
+def _physical_drift_polynomial(
+    dynamics: RegimeLogSvDynamics,
+    degree: int,
+    dtype: Any = float,
+) -> np.ndarray:
+    """Coefficients of the physical volatility drift in mean-adjusted volatility."""
+
+    output = np.zeros(degree + 1, dtype=dtype)
+    if degree >= 1:
+        output[1] = -dynamics.kappa_bar
+    if degree >= 2:
+        output[2] = -dynamics.kappa2
+    return output
+
+
+def _regime_difference(
+    coefficients: np.ndarray,
+    params: RegimeSwitchLogSvParams,
+    regime: Regime,
+    degree: int,
+) -> np.ndarray:
+    """Target-minus-source polynomial at the same physical volatility."""
+
+    other = Regime(1 - int(regime))
+    delta = params.regimes[regime].theta - params.regimes[other].theta
+    own = _poly_pad(coefficients[..., regime, :], degree)
+    target = coefficients[..., other, :]
+    return _poly_shift(target, delta, degree) - own
+
+
+def _equilibrium_rhs(
+    _horizon: float,
+    flat_coefficients: np.ndarray,
+    params: RegimeSwitchLogSvParams,
+    degree: int,
+) -> np.ndarray:
+    """Projected coupled CRRA coefficient PDE in time-to-agent-horizon."""
+
+    coefficients = flat_coefficients.reshape(2, degree + 1)
+    output = np.zeros_like(coefficients)
+    utility_power = params.risk_premia.utility_power
+    qvar_loading = 0.5 * utility_power * (1.0 - utility_power)
+
+    for regime in Regime:
+        dynamics = params.regimes[regime]
+        first = _poly_derivative(coefficients[regime], degree)
+        second = _poly_derivative(first, degree)
+        sigma2 = _sigma2_polynomial(dynamics.theta, degree, coefficients.dtype)
+        diffusion = second + _poly_mul(first, first, degree)
+        local = _poly_mul(_physical_drift_polynomial(dynamics, degree), first, degree)
+        local += 0.5 * dynamics.vartheta2 * _poly_mul(sigma2, diffusion, degree)
+        local += qvar_loading * sigma2
+
+        difference = _regime_difference(coefficients, params, regime, degree)
+        transition = params.transitions[regime]
+        coupling = transition.intensity * params.transition_factor(regime)
+        coupling *= _poly_exp(difference, degree)
+        coupling[0] -= transition.intensity
+        output[regime] = local + coupling
+    return output.ravel()
+
+
+@dataclass(frozen=True)
+class EquilibriumSolution:
+    """Dense solution of the coupled log-polynomial CRRA coefficient system.
+
+    The fixed-horizon regime coupling is a new synthesis; it is not assigned a
+    published equation number.
+    """
+
+    params: RegimeSwitchLogSvParams
+    degree: int
+    ode_result: Any
+
+    def coefficients(self, horizon: float) -> np.ndarray:
+        """Return both regimes' coefficients at a remaining agent horizon."""
+
+        maximum = self.params.risk_premia.agent_horizon
+        if horizon < -1.0e-12 or horizon > maximum + 1.0e-12:
+            raise ValueError("horizon is outside the solved representative-agent interval")
+        horizon = float(np.clip(horizon, 0.0, maximum))
+        values = np.asarray(self.ode_result.sol(horizon)).reshape(2, self.degree + 1)
+        if not np.all(np.isfinite(values)):
+            raise FloatingPointError("non-finite equilibrium coefficients")
+        return values
+
+    def log_value_coefficient(
+        self, horizon: float, sigma: float | np.ndarray, regime: Regime | int
+    ) -> float | np.ndarray:
+        """Evaluate ``log(g_hat_i)`` at a physical volatility."""
+
+        state = _as_regime(regime)
+        mean_adjusted = np.asarray(sigma) - self.params.regimes[state].theta
+        value = _poly_value(self.coefficients(horizon)[state], mean_adjusted)
+        return float(value) if np.ndim(value) == 0 else value
+
+    def volatility_loading(
+        self, horizon: float, sigma: float | np.ndarray, regime: Regime | int
+    ) -> float | np.ndarray:
+        """Evaluate ``partial_sigma log(g_hat_i)``."""
+
+        state = _as_regime(regime)
+        first = _poly_derivative(self.coefficients(horizon)[state], self.degree)
+        mean_adjusted = np.asarray(sigma) - self.params.regimes[state].theta
+        value = _poly_value(first, mean_adjusted)
+        return float(value) if np.ndim(value) == 0 else value
+
+    def log_timing_ratio(
+        self, horizon: float, sigma: float | np.ndarray, regime: Regime | int
+    ) -> float | np.ndarray:
+        """Evaluate ``log(g_hat_j/g_hat_i)`` at the same physical volatility."""
+
+        state = _as_regime(regime)
+        other = Regime(1 - int(state))
+        values = self.coefficients(horizon)
+        own = _poly_value(values[state], np.asarray(sigma) - self.params.regimes[state].theta)
+        target = _poly_value(values[other], np.asarray(sigma) - self.params.regimes[other].theta)
+        value = target - own
+        return float(value) if np.ndim(value) == 0 else value
+
+
+def solve_regime_switch_equilibrium(
+    params: RegimeSwitchLogSvParams,
+    rtol: float = 2.0e-10,
+    atol: float = 2.0e-12,
+) -> EquilibriumSolution:
+    """Solve the log-linear or log-quadratic CRRA equilibrium system.
+
+    The closure is read from ``params.risk_premia``.  A chain pricer solves this
+    once and passes the same fixed representative-agent measure to every
+    maturity. The within-state Brownian shifts use the density and risk-premium
+    construction in equations (3.2)--(3.10) of the published LogSV paper; the
+    coupled representative-agent system is a new synthesis.
+    """
+
+    degree = params.risk_premia.closure.degree
+    maximum = params.risk_premia.agent_horizon
+    initial = np.zeros(2 * (degree + 1), dtype=float)
+    result = solve_ivp(
+        _equilibrium_rhs,
+        (0.0, maximum),
+        initial,
+        args=(params, degree),
+        method="DOP853",
+        dense_output=True,
+        rtol=rtol,
+        atol=atol,
+        max_step=min(0.05, maximum / 4.0),
+    )
+    if not result.success:
+        raise RuntimeError(f"equilibrium ODE failed: {result.message}")
+    solution = EquilibriumSolution(params=params, degree=degree, ode_result=result)
+    solution.coefficients(maximum)
+    _validate_continuous_boundary_admissibility(solution)
+    return solution
+
+
+def _risk_neutral_drift_polynomial(
+    equilibrium_coefficients: np.ndarray,
+    params: RegimeSwitchLogSvParams,
+    regime: Regime,
+    degree: int,
+) -> np.ndarray:
+    """Polynomial of the consistently induced risk-neutral volatility drift.
+
+    The continuous Brownian-shift terms follow published LogSV equations
+    (3.5)--(3.10); the timing-tilted regime coupling is handled separately.
+    """
+
+    dynamics = params.regimes[regime]
+    sigma2 = _sigma2_polynomial(dynamics.theta, degree, equilibrium_coefficients.dtype)
+    loading = _poly_derivative(equilibrium_coefficients[regime], degree)
+    output = _physical_drift_polynomial(dynamics, degree, equilibrium_coefficients.dtype)
+    output -= dynamics.beta * params.risk_premia.relative_risk_aversion * sigma2
+    output += dynamics.vartheta2 * _poly_mul(sigma2, loading, degree)
+    return output
+
+
+def _validate_continuous_boundary_admissibility(
+    solution: EquilibriumSolution,
+    tolerance: float = 1.0e-10,
+) -> None:
+    """Reject an outward Q drift or failed continuous share-measure diagnostic.
+
+    For the log-linear closure, ``hat_kappa2 >= max(0, beta)`` combines
+    non-explosion of the quadratic Q-volatility drift with the ordinary-forward
+    martingale condition of the scalar quadratic-drift LogSV model.  The
+    log-quadratic closure additionally requires an inward cubic.  Because that
+    cubic necessarily vanishes at the agent terminal boundary, the quadratic
+    diagnostic is retained pointwise as a conservative finite-horizon guard.
+
+    The marked switching clock is state dependent, so this is a conservative
+    continuous-boundary check rather than a global if-and-only-if theorem for
+    the full regime-switching model.
+    """
+
+    params = solution.params
+    maximum = params.risk_premia.agent_horizon
+    count = max(33, int(np.ceil(24.0 * maximum)) + 1)
+    for horizon in np.linspace(0.0, maximum, count):
+        coefficients = solution.coefficients(float(horizon))
+        for regime in Regime:
+            dynamics = params.regimes[regime]
+            linear = coefficients[regime, 1]
+            quadratic = coefficients[regime, 2] if solution.degree == 2 else 0.0
+            cubic = 2.0 * dynamics.vartheta2 * quadratic
+            if cubic > tolerance:
+                raise ValueError(
+                    "LOG_QUADRATIC induces an outward cubic Q-volatility drift "
+                    f"in regime {int(regime)} at horizon {horizon:.6g}"
+                )
+
+            effective_kappa2 = (
+                dynamics.kappa2
+                + dynamics.beta * params.risk_premia.relative_risk_aversion
+                - dynamics.vartheta2 * linear
+                + 2.0 * dynamics.vartheta2 * quadratic * dynamics.theta
+            )
+            required = max(0.0, dynamics.beta)
+            if effective_kappa2 + tolerance < required:
+                raise ValueError(
+                    "induced Q dynamics fail the continuous-boundary "
+                    "admissibility diagnostic "
+                    f"in regime {int(regime)} at horizon {horizon:.6g}: "
+                    f"effective kappa2={effective_kappa2:.6g} must be at least "
+                    f"max(0, beta)={required:.6g}"
+                )
+
+
+@dataclass(frozen=True)
+class RiskNeutralState:
+    """Derived risk-neutral dynamics at one horizon, volatility, and source state."""
+
+    volatility_drift: float | np.ndarray
+    transition_intensity: float | np.ndarray
+    mean_log_jump: float
+    arithmetic_jump_mean: float
+    volatility_loading: float | np.ndarray
+    log_timing_ratio: float | np.ndarray
+
+
+def evaluate_risk_neutral_state(
+    params: RegimeSwitchLogSvParams,
+    equilibrium: EquilibriumSolution,
+    horizon: float,
+    sigma: float | np.ndarray,
+    regime: Regime | int,
+) -> RiskNeutralState:
+    """Evaluate the exact dynamics induced by the selected equilibrium closure.
+
+    LOG_LINEAR produces an exactly quadratic volatility drift.  LOG_QUADRATIC
+    makes the loading affine in volatility and retains the resulting cubic term.
+    The continuous drift follows published LogSV equations (3.5)--(3.10), while
+    the state-dependent transition clock is the fixed-horizon regime synthesis.
+    """
+
+    if equilibrium.params != params:
+        raise ValueError("equilibrium solution was built for different parameters")
+    state = _as_regime(regime)
+    sigma_values = np.asarray(sigma, dtype=float)
+    if np.any(~np.isfinite(sigma_values)) or np.any(sigma_values <= 0.0):
+        raise ValueError("sigma must be finite and positive")
+    dynamics = params.regimes[state]
+    loading = equilibrium.volatility_loading(horizon, sigma_values, state)
+    log_ratio = equilibrium.log_timing_ratio(horizon, sigma_values, state)
+    drift = (dynamics.kappa1 + dynamics.kappa2 * sigma_values) * (dynamics.theta - sigma_values)
+    drift -= dynamics.beta * params.risk_premia.relative_risk_aversion * sigma_values**2
+    drift += dynamics.vartheta2 * loading * sigma_values**2
+
+    tail_tilt = params.risk_premia.utility_power - 1.0
+    ell_tilt = float(params.jump_mgf(state, tail_tilt))
+    physical_mean = params.transitions[state].mean_log_jump
+    tilted_mean = physical_mean / (1.0 - physical_mean * tail_tilt)
+    arithmetic_mean = float(params.jump_mgf(state, tail_tilt + 1.0) / ell_tilt - 1.0)
+    timing_ratio = np.exp(log_ratio)
+    intensity = params.transitions[state].intensity * timing_ratio * ell_tilt
+    if np.any(~np.isfinite(drift)) or np.any(~np.isfinite(intensity)):
+        raise FloatingPointError("non-finite induced risk-neutral state")
+    if np.any(intensity < 0.0):
+        raise FloatingPointError("negative induced transition intensity")
+    return RiskNeutralState(
+        volatility_drift=float(drift) if np.ndim(drift) == 0 else drift,
+        transition_intensity=(float(intensity) if np.ndim(intensity) == 0 else intensity),
+        mean_log_jump=float(tilted_mean),
+        arithmetic_jump_mean=arithmetic_mean,
+        volatility_loading=loading,
+        log_timing_ratio=log_ratio,
+    )

--- a/src/stochvolmodels/models/regime_logsv.py
+++ b/src/stochvolmodels/models/regime_logsv.py
@@ -75,6 +75,51 @@ class EquilibriumClosure(Enum):
 
 
 @dataclass(frozen=True, slots=True)
+class RegimeRiskPremiaScales:
+    """Diagnostic multipliers for analytic risk-premium attribution.
+
+    All four values equal to one recover the equilibrium measure. Other values
+    produce explicitly non-equilibrium counterfactuals used to attribute the
+    model's analytic smile to its Brownian, transition-timing, and jump-tail
+    channels. The scales are deliberately not part of
+    :class:`RegimeSwitchLogSvParams`: they do not alter physical parameters or
+    re-solve the representative-agent equilibrium, and they are not supported
+    by the Monte Carlo simulator.
+
+    Parameters
+    ----------
+    equity_brownian : float, default 1.0
+        Multiplier for the return-Brownian risk-premium terms.
+    orthogonal_brownian : float, default 1.0
+        Multiplier for the orthogonal volatility-Brownian loading term.
+    timing : float, default 1.0
+        Multiplier for the log value-coefficient ratio in transition intensity.
+    tail : float, default 1.0
+        Multiplier for the equilibrium Esscher jump-tail exponent.
+    """
+
+    equity_brownian: float = 1.0
+    orthogonal_brownian: float = 1.0
+    timing: float = 1.0
+    tail: float = 1.0
+
+    def __post_init__(self) -> None:
+        for name in ("equity_brownian", "orthogonal_brownian", "timing", "tail"):
+            object.__setattr__(self, name, _finite_float(getattr(self, name), name))
+
+    @property
+    def is_full_equilibrium(self) -> bool:
+        """Whether all channels retain their equilibrium values."""
+
+        return (
+            self.equity_brownian == 1.0
+            and self.orthogonal_brownian == 1.0
+            and self.timing == 1.0
+            and self.tail == 1.0
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class RegimeLogSvDynamics:
     """Physical LogSV coefficients within one regime.
 
@@ -593,6 +638,8 @@ def _risk_neutral_drift_polynomial(
     params: RegimeSwitchLogSvParams,
     regime: Regime,
     degree: int,
+    *,
+    scales: RegimeRiskPremiaScales = RegimeRiskPremiaScales(),
 ) -> np.ndarray:
     """Polynomial of the consistently induced risk-neutral volatility drift.
 
@@ -604,8 +651,19 @@ def _risk_neutral_drift_polynomial(
     sigma2 = _sigma2_polynomial(dynamics.theta, degree, equilibrium_coefficients.dtype)
     loading = _poly_derivative(equilibrium_coefficients[regime], degree)
     output = _physical_drift_polynomial(dynamics, degree, equilibrium_coefficients.dtype)
-    output -= dynamics.beta * params.risk_premia.relative_risk_aversion * sigma2
-    output += dynamics.vartheta2 * _poly_mul(sigma2, loading, degree)
+    if scales.is_full_equilibrium:
+        output -= dynamics.beta * params.risk_premia.relative_risk_aversion * sigma2
+        output += dynamics.vartheta2 * _poly_mul(sigma2, loading, degree)
+    else:
+        output -= (
+            scales.equity_brownian
+            * dynamics.beta
+            * params.risk_premia.relative_risk_aversion
+            * sigma2
+        )
+        loading_scale = scales.equity_brownian * dynamics.beta**2
+        loading_scale += scales.orthogonal_brownian * dynamics.volvol**2
+        output += loading_scale * _poly_mul(sigma2, loading, degree)
     return output
 
 
@@ -662,7 +720,7 @@ def _validate_continuous_boundary_admissibility(
 
 @dataclass(frozen=True)
 class RiskNeutralState:
-    """Derived risk-neutral dynamics at one horizon, volatility, and source state."""
+    """Derived full-equilibrium or diagnostic-Q state at one horizon and volatility."""
 
     volatility_drift: float | np.ndarray
     transition_intensity: float | np.ndarray
@@ -678,6 +736,8 @@ def evaluate_risk_neutral_state(
     horizon: float,
     sigma: float | np.ndarray,
     regime: Regime | int,
+    *,
+    scales: RegimeRiskPremiaScales = RegimeRiskPremiaScales(),
 ) -> RiskNeutralState:
     """Evaluate the exact dynamics induced by the selected equilibrium closure.
 
@@ -685,10 +745,14 @@ def evaluate_risk_neutral_state(
     makes the loading affine in volatility and retains the resulting cubic term.
     The continuous drift follows published LogSV equations (3.5)--(3.10), while
     the state-dependent transition clock is the fixed-horizon regime synthesis.
+    Non-unit ``scales`` return a non-equilibrium analytic attribution state and
+    are not supported by the Monte Carlo simulator.
     """
 
     if equilibrium.params != params:
         raise ValueError("equilibrium solution was built for different parameters")
+    if not isinstance(scales, RegimeRiskPremiaScales):
+        raise TypeError("scales must be a RegimeRiskPremiaScales object")
     state = _as_regime(regime)
     sigma_values = np.asarray(sigma, dtype=float)
     if np.any(~np.isfinite(sigma_values)) or np.any(sigma_values <= 0.0):
@@ -697,15 +761,31 @@ def evaluate_risk_neutral_state(
     loading = equilibrium.volatility_loading(horizon, sigma_values, state)
     log_ratio = equilibrium.log_timing_ratio(horizon, sigma_values, state)
     drift = (dynamics.kappa1 + dynamics.kappa2 * sigma_values) * (dynamics.theta - sigma_values)
-    drift -= dynamics.beta * params.risk_premia.relative_risk_aversion * sigma_values**2
-    drift += dynamics.vartheta2 * loading * sigma_values**2
+    if scales.is_full_equilibrium:
+        drift -= dynamics.beta * params.risk_premia.relative_risk_aversion * sigma_values**2
+        drift += dynamics.vartheta2 * loading * sigma_values**2
+        tail_tilt = params.risk_premia.utility_power - 1.0
+        timing_log_ratio = log_ratio
+    else:
+        drift -= (
+            scales.equity_brownian
+            * dynamics.beta
+            * params.risk_premia.relative_risk_aversion
+            * sigma_values**2
+        )
+        loading_scale = scales.equity_brownian * dynamics.beta**2
+        loading_scale += scales.orthogonal_brownian * dynamics.volvol**2
+        drift += loading_scale * loading * sigma_values**2
+        tail_tilt = scales.tail * (params.risk_premia.utility_power - 1.0)
+        timing_log_ratio = scales.timing * log_ratio
 
-    tail_tilt = params.risk_premia.utility_power - 1.0
+    params.validate_jump_moment(state, tail_tilt)
+    params.validate_jump_moment(state, tail_tilt + 1.0)
     ell_tilt = float(params.jump_mgf(state, tail_tilt))
     physical_mean = params.transitions[state].mean_log_jump
     tilted_mean = physical_mean / (1.0 - physical_mean * tail_tilt)
     arithmetic_mean = float(params.jump_mgf(state, tail_tilt + 1.0) / ell_tilt - 1.0)
-    timing_ratio = np.exp(log_ratio)
+    timing_ratio = np.exp(timing_log_ratio)
     intensity = params.transitions[state].intensity * timing_ratio * ell_tilt
     if np.any(~np.isfinite(drift)) or np.any(~np.isfinite(intensity)):
         raise FloatingPointError("non-finite induced risk-neutral state")

--- a/src/stochvolmodels/models/regime_logsv_simulation.py
+++ b/src/stochvolmodels/models/regime_logsv_simulation.py
@@ -1,0 +1,198 @@
+r"""Induced risk-neutral simulation for the two-state equilibrium LogSV model.
+
+The simulator advances log forward return, volatility, integrated variance, and
+the active source regime together. A transition atomically applies its signed
+exponential price jump and flips the regime while leaving volatility continuous.
+The two Brownian vectors are drawn in full before transition uniforms, preserving
+the audited fixed-seed ordering.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from numbers import Integral, Real
+from typing import Optional
+
+import numpy as np
+
+from stochvolmodels.models.regime_logsv import (
+    EquilibriumSolution,
+    Regime,
+    RegimeSwitchLogSvParams,
+    _as_regime,
+    evaluate_risk_neutral_state,
+    solve_regime_switch_equilibrium,
+)
+
+
+def _positive_int(value: object, name: str, *, minimum: int = 1) -> int:
+    """Return an integer at or above ``minimum`` while rejecting booleans."""
+
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer")
+    result = int(value)
+    if result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return result
+
+
+def _initial_regime(value: Regime | int) -> Regime:
+    """Canonicalize a source state without accepting booleans as integers."""
+
+    return _as_regime(value, "initial_regime")
+
+
+@dataclass(frozen=True, slots=True)
+class RegimeTerminalSample:
+    """Terminal normalized-forward state from an induced-Q simulation."""
+
+    log_forward_return: np.ndarray
+    sigma: np.ndarray
+    qvar: np.ndarray
+    regime: np.ndarray
+
+    @property
+    def forward_martingale(self) -> tuple[float, float]:
+        """Sample mean and standard error of ``exp(log_forward_return)``."""
+
+        terminal = np.exp(self.log_forward_return)
+        return (
+            float(np.mean(terminal)),
+            float(np.std(terminal, ddof=1) / np.sqrt(terminal.size)),
+        )
+
+
+def _simulate_regime_interval(
+    *,
+    params: RegimeSwitchLogSvParams,
+    equilibrium: EquilibriumSolution,
+    log_return: np.ndarray,
+    sigma: np.ndarray,
+    qvar: np.ndarray,
+    regimes: np.ndarray,
+    time0: float,
+    interval: float,
+    steps_per_year: int,
+    rng: np.random.Generator,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Advance all paths over one calendar-time interval."""
+
+    if interval <= 0.0:
+        raise ValueError("simulation interval must be positive")
+    steps = max(1, int(np.ceil(interval * steps_per_year)))
+    dt = interval / steps
+    sqrt_dt = np.sqrt(dt)
+    log_sigma = np.log(sigma)
+
+    for step in range(steps):
+        calendar_time = time0 + step * dt
+        horizon = params.risk_premia.agent_horizon - calendar_time
+        normal0 = rng.standard_normal(sigma.size) * sqrt_dt
+        normal1 = rng.standard_normal(sigma.size) * sqrt_dt
+        old_sigma = sigma.copy()
+        source_regimes = regimes.copy()
+        qvar += old_sigma**2 * dt
+
+        for regime in Regime:
+            mask = source_regimes == int(regime)
+            if not np.any(mask):
+                continue
+            dynamics = params.regimes[regime]
+            state = evaluate_risk_neutral_state(
+                params=params,
+                equilibrium=equilibrium,
+                horizon=horizon,
+                sigma=old_sigma[mask],
+                regime=regime,
+            )
+            intensity = np.asarray(state.transition_intensity)
+            integrated_intensity = intensity * dt
+            if np.any(integrated_intensity > 0.25):
+                raise RuntimeError(
+                    "transition intensity is too large for the selected Monte Carlo time step"
+                )
+            log_return[mask] += (
+                -0.5 * old_sigma[mask] ** 2 - intensity * state.arithmetic_jump_mean
+            ) * dt
+            log_return[mask] += old_sigma[mask] * normal0[mask]
+            drift = np.asarray(state.volatility_drift)
+            log_sigma[mask] += (drift / old_sigma[mask] - 0.5 * dynamics.vartheta2) * dt
+            log_sigma[mask] += dynamics.beta * normal0[mask] + dynamics.volvol * normal1[mask]
+
+            transition_probability = -np.expm1(-integrated_intensity)
+            transition = rng.random(np.count_nonzero(mask)) < transition_probability
+            if np.any(transition):
+                indices = np.flatnonzero(mask)[transition]
+                mean = state.mean_log_jump
+                if mean == 0.0:
+                    jumps = np.zeros(indices.size)
+                else:
+                    jumps = np.sign(mean) * rng.exponential(abs(mean), indices.size)
+                log_return[indices] += jumps
+                regimes[indices] = 1 - int(regime)
+
+        sigma = np.exp(log_sigma)
+        invalid_state = (
+            np.any(~np.isfinite(log_return))
+            or np.any(~np.isfinite(sigma))
+            or np.any(sigma <= 0.0)
+            or np.any(~np.isfinite(qvar))
+            or np.any(qvar < 0.0)
+        )
+        if invalid_state:
+            raise FloatingPointError("invalid state encountered in Q simulation")
+    return log_return, sigma, qvar, regimes
+
+
+def simulate_regime_switch_logsv_terminal(
+    params: RegimeSwitchLogSvParams,
+    ttm: float,
+    *,
+    equilibrium: EquilibriumSolution | None = None,
+    initial_regime: Regime | int | None = None,
+    nb_path: int = 100_000,
+    nb_steps_per_year: int = 360,
+    seed: Optional[int] = 7,
+) -> RegimeTerminalSample:
+    """Simulate one terminal state under the consistently induced Q dynamics.
+
+    The return and volatility share the first Brownian shock. Transition
+    uniforms are drawn only for paths in the active source state, and exponential
+    jump sizes only for paths that switch. These choices are part of the
+    fixed-seed numerical contract.
+    """
+
+    if isinstance(ttm, (bool, np.bool_)) or not isinstance(ttm, Real):
+        raise ValueError("ttm must be finite and positive")
+    ttm_value = float(ttm)
+    if not np.isfinite(ttm_value) or ttm_value <= 0.0:
+        raise ValueError("ttm must be finite and positive")
+    if ttm_value > params.risk_premia.agent_horizon:
+        raise ValueError("ttm must be no greater than agent_horizon")
+    path_count = _positive_int(nb_path, "nb_path", minimum=2)
+    step_count = _positive_int(nb_steps_per_year, "nb_steps_per_year")
+    if seed is not None:
+        seed = _positive_int(seed, "seed", minimum=0)
+    if equilibrium is None:
+        equilibrium = solve_regime_switch_equilibrium(params)
+    elif equilibrium.params != params:
+        raise ValueError("equilibrium solution was built for different parameters")
+    state = params.initial_regime if initial_regime is None else _initial_regime(initial_regime)
+    rng = np.random.default_rng(seed)
+    log_return = np.zeros(path_count)
+    sigma = np.full(path_count, params.sigma0)
+    qvar = np.zeros(path_count)
+    regimes = np.full(path_count, int(state), dtype=np.int8)
+    log_return, sigma, qvar, regimes = _simulate_regime_interval(
+        params=params,
+        equilibrium=equilibrium,
+        log_return=log_return,
+        sigma=sigma,
+        qvar=qvar,
+        regimes=regimes,
+        time0=0.0,
+        interval=ttm_value,
+        steps_per_year=step_count,
+        rng=rng,
+    )
+    return RegimeTerminalSample(log_return, sigma, qvar, regimes)

--- a/src/stochvolmodels/pricers/regime_switch_logsv_pricer.py
+++ b/src/stochvolmodels/pricers/regime_switch_logsv_pricer.py
@@ -1,0 +1,530 @@
+r"""Transform, Fourier, and chain pricing for equilibrium regime-switching LogSV.
+
+All prices condition on an initial regime and integrate over the terminal state.
+The representative-agent equilibrium is solved once at its fixed horizon and is
+then sampled at ``H - T + s`` inside each derivative transform. The option
+chain remains a market-data container and acquires no model-specific state axis.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+from numba.typed import List
+from scipy.integrate import solve_ivp
+
+from stochvolmodels.data.option_chain import OptionChain
+from stochvolmodels.models.regime_logsv import (
+    EquilibriumSolution,
+    Regime,
+    RegimeSwitchLogSvParams,
+    _poly_derivative,
+    _poly_exp,
+    _poly_mul,
+    _poly_value,
+    _regime_difference,
+    _risk_neutral_drift_polynomial,
+    _sigma2_polynomial,
+    solve_regime_switch_equilibrium,
+)
+from stochvolmodels.models.regime_logsv_simulation import (
+    _initial_regime,
+    _positive_int,
+    _simulate_regime_interval,
+    simulate_regime_switch_logsv_terminal,
+)
+from stochvolmodels.pricers.logsv.affine_expansion import ExpansionOrder
+from stochvolmodels.pricers.model_pricer import ModelPricer
+from stochvolmodels.utils import mgf_pricer as mgfp
+from stochvolmodels.utils.config import VariableType
+from stochvolmodels.utils.mc_payoffs import compute_mc_vars_payoff
+
+
+def _option_rhs(
+    backward_time: float,
+    flat_coefficients: np.ndarray,
+    *,
+    params: RegimeSwitchLogSvParams,
+    equilibrium: EquilibriumSolution,
+    ttm: float,
+    phi_grid: np.ndarray,
+    degree: int,
+) -> np.ndarray:
+    """Projected coupled option-transform PDE.
+
+    The local FIRST/SECOND polynomial projection follows equations (4.13)--(4.25)
+    of the published LogSV paper. The state coupling, simultaneous marked jump,
+    and fixed-agent-horizon index are the regime-switching synthesis.
+    """
+
+    count = phi_grid.size
+    coefficients = flat_coefficients.reshape(count, 2, degree + 1)
+    output = np.zeros_like(coefficients)
+    equilibrium_horizon = params.risk_premia.agent_horizon - ttm + backward_time
+    equilibrium_coefficients = equilibrium.coefficients(equilibrium_horizon)
+    phi = phi_grid[:, None]
+    tail_tilt = params.risk_premia.utility_power - 1.0
+
+    for regime in Regime:
+        dynamics = params.regimes[regime]
+        sigma2 = _sigma2_polynomial(dynamics.theta, degree, complex)
+        first = _poly_derivative(coefficients[:, regime, :], degree)
+        second = _poly_derivative(first, degree)
+        local = _poly_mul(
+            _risk_neutral_drift_polynomial(equilibrium_coefficients, params, regime, degree),
+            first,
+            degree,
+        )
+        local += (
+            0.5
+            * dynamics.vartheta2
+            * _poly_mul(sigma2, second + _poly_mul(first, first, degree), degree)
+        )
+        local -= dynamics.beta * phi * _poly_mul(sigma2, first, degree)
+        local += 0.5 * phi * (phi + 1.0) * sigma2
+
+        timing_difference = _regime_difference(equilibrium_coefficients, params, regime, degree)
+        timing_ratio = _poly_exp(timing_difference, degree)
+        price_difference = _regime_difference(coefficients, params, regime, degree)
+        price_ratio = _poly_exp(price_difference, degree)
+        ell_tilt = params.jump_mgf(regime, tail_tilt)
+        ell_shifted = params.jump_mgf(regime, tail_tilt - phi_grid)
+        compensator_difference = params.jump_mgf(regime, tail_tilt + 1.0) - ell_tilt
+        bracket = ell_shifted[:, None] * price_ratio
+        bracket[:, 0] += phi_grid * compensator_difference - ell_tilt
+        transition = params.transitions[regime]
+        jump = transition.intensity * _poly_mul(timing_ratio, bracket, degree)
+        output[:, regime, :] = local + jump
+    return output.ravel()
+
+
+def _option_degree(expansion_order: ExpansionOrder) -> int:
+    """Map the existing LogSV expansion enum to its polynomial degree."""
+
+    if expansion_order == ExpansionOrder.FIRST:
+        return 2
+    if expansion_order == ExpansionOrder.SECOND:
+        return 4
+    raise ValueError("regime-switching options support FIRST or SECOND expansion")
+
+
+def compute_regime_switch_log_mgf_grid(
+    params: RegimeSwitchLogSvParams,
+    ttm: float,
+    phi_grid: np.ndarray,
+    *,
+    equilibrium: EquilibriumSolution | None = None,
+    expansion_order: ExpansionOrder = ExpansionOrder.SECOND,
+    rtol: float = 2.0e-7,
+    atol: float = 2.0e-9,
+) -> np.ndarray:
+    r"""Return both state-conditional log MGFs of the forward log return.
+
+    The output has shape ``(2, len(phi_grid))`` and element ``[i, k]`` is
+    ``log E^Q[exp(-phi_grid[k] X_T) | regime_0=i]``.  Conditioning is on the
+    initial regime and integrates over both possible terminal regimes.
+
+    The common projection uses the published LogSV FIRST equations
+    (4.13)--(4.22) or SECOND equations (4.23)--(4.25). The coupled two-state
+    transform itself is a new synthesis rather than a published equation.
+    """
+
+    maximum = params.risk_premia.agent_horizon
+    if not np.isfinite(ttm) or ttm <= 0.0 or ttm > maximum:
+        raise ValueError("ttm must lie in (0, agent_horizon]")
+    if equilibrium is None:
+        equilibrium = solve_regime_switch_equilibrium(params)
+    if equilibrium.params != params:
+        raise ValueError("equilibrium solution was built for different parameters")
+    degree = _option_degree(expansion_order)
+    phi_grid = np.asarray(phi_grid, dtype=np.complex128)
+    if phi_grid.ndim != 1 or phi_grid.size == 0:
+        raise ValueError("phi_grid must be a non-empty one-dimensional array")
+    if not np.all(np.isfinite(phi_grid)):
+        raise ValueError("phi_grid must be finite")
+    tail_tilt = params.risk_premia.utility_power - 1.0
+    for regime in Regime:
+        params.validate_jump_moment(regime, tail_tilt)
+        params.validate_jump_moment(regime, tail_tilt + 1.0)
+        params.validate_jump_moment(regime, tail_tilt - phi_grid)
+
+    initial = np.zeros(phi_grid.size * 2 * (degree + 1), dtype=np.complex128)
+    result = solve_ivp(
+        lambda time, values: _option_rhs(
+            time,
+            values,
+            params=params,
+            equilibrium=equilibrium,
+            ttm=ttm,
+            phi_grid=phi_grid,
+            degree=degree,
+        ),
+        (0.0, ttm),
+        initial,
+        method="DOP853",
+        rtol=rtol,
+        atol=atol,
+        max_step=min(1.0 / 24.0, ttm / 4.0),
+    )
+    if not result.success:
+        raise RuntimeError(f"option MGF ODE failed: {result.message}")
+    coefficients = result.y[:, -1].reshape(phi_grid.size, 2, degree + 1)
+    if not np.all(np.isfinite(coefficients)):
+        raise FloatingPointError("non-finite option-transform coefficients")
+
+    log_mgf = np.empty((2, phi_grid.size), dtype=np.complex128)
+    for regime in Regime:
+        mean_adjusted = params.sigma0 - params.regimes[regime].theta
+        log_mgf[regime] = _poly_value(coefficients[:, regime, :], mean_adjusted)
+    return log_mgf
+
+
+def _validate_pricing_mode(
+    *,
+    variable_type: VariableType,
+    is_spot_measure: bool,
+) -> None:
+    """Validate the deliberately narrow first production surface."""
+
+    if variable_type != VariableType.LOG_RETURN:
+        raise NotImplementedError(
+            "regime-switching LogSV currently prices only forward European options"
+        )
+    if not is_spot_measure:
+        raise NotImplementedError(
+            "regime-switching LogSV currently supports only the money-market measure"
+        )
+
+
+def _validate_chain_inputs(
+    params: RegimeSwitchLogSvParams,
+    ttms: np.ndarray,
+    strikes_ttms,
+    optiontypes_ttms,
+) -> np.ndarray:
+    """Validate maturities and the vanilla payoff surface."""
+
+    ttms = np.asarray(ttms, dtype=float)
+    if ttms.ndim != 1 or ttms.size == 0:
+        raise ValueError("ttms must be a non-empty one-dimensional array")
+    if np.any(~np.isfinite(ttms)) or np.any(ttms <= 0.0):
+        raise ValueError("ttms must be finite and positive")
+    if np.any(np.diff(ttms) <= 0.0):
+        raise ValueError("ttms must be strictly increasing")
+    if ttms[-1] > params.risk_premia.agent_horizon:
+        raise ValueError("every option maturity must be no greater than agent_horizon")
+    if len(strikes_ttms) != ttms.size or len(optiontypes_ttms) != ttms.size:
+        raise ValueError("strike and option-type slices must align with ttms")
+    for strikes, optiontypes in zip(strikes_ttms, optiontypes_ttms):
+        strikes = np.asarray(strikes, dtype=float)
+        optiontypes = np.asarray(optiontypes)
+        if strikes.ndim != 1 or optiontypes.ndim != 1 or strikes.size == 0:
+            raise ValueError("strike and option-type slices must be non-empty vectors")
+        if strikes.shape != optiontypes.shape:
+            raise ValueError("strikes and option types must have matching shapes")
+        if np.any(~np.isfinite(strikes)) or np.any(strikes <= 0.0):
+            raise ValueError("strikes must be finite and positive")
+        if not np.all(np.isin(optiontypes, ("C", "P"))):
+            raise NotImplementedError("only ordinary European C/P payoffs are supported")
+    return ttms
+
+
+def _validate_market_vectors(
+    ttms: np.ndarray,
+    forwards: np.ndarray,
+    discfactors: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Validate chain-level forward and discount vectors."""
+
+    forwards = np.asarray(forwards, dtype=float)
+    discfactors = np.asarray(discfactors, dtype=float)
+    if forwards.shape != ttms.shape or discfactors.shape != ttms.shape:
+        raise ValueError("forwards and discfactors must align with ttms")
+    if np.any(~np.isfinite(forwards)) or np.any(forwards <= 0.0):
+        raise ValueError("forwards must be finite and positive")
+    if np.any(~np.isfinite(discfactors)) or np.any(discfactors <= 0.0):
+        raise ValueError("discfactors must be finite and positive")
+    return forwards, discfactors
+
+
+def _set_vol_scaler(sigma0: float, shortest_ttm: float) -> float:
+    """Match the scalar LogSV transform-grid scaling convention."""
+
+    return sigma0 * np.sqrt(min(shortest_ttm, 0.5 / 12.0))
+
+
+def regime_switch_logsv_chain_pricer(
+    params: RegimeSwitchLogSvParams,
+    ttms: np.ndarray,
+    forwards: np.ndarray,
+    discfactors: np.ndarray,
+    strikes_ttms,
+    optiontypes_ttms,
+    *,
+    equilibrium: EquilibriumSolution | None = None,
+    expansion_order: ExpansionOrder = ExpansionOrder.SECOND,
+    max_phi: int = 1_601,
+    vol_scaler: float | None = None,
+    variable_type: VariableType = VariableType.LOG_RETURN,
+    is_spot_measure: bool = True,
+) -> tuple[list[np.ndarray], list[np.ndarray]]:
+    """Price the chain conditional on each possible initial regime.
+
+    Returns
+    -------
+    tuple[list[numpy.ndarray], list[numpy.ndarray]]
+        Growth-conditioned and stress-conditioned prices.  Each list contains
+        one array per maturity in the input chain.
+    """
+
+    _validate_pricing_mode(variable_type=variable_type, is_spot_measure=is_spot_measure)
+    ttms = _validate_chain_inputs(params, ttms, strikes_ttms, optiontypes_ttms)
+    forwards, discfactors = _validate_market_vectors(ttms, forwards, discfactors)
+    if not isinstance(max_phi, (int, np.integer)) or max_phi < 3 or max_phi % 2 == 0:
+        raise ValueError("max_phi must be an odd integer of at least three")
+    if vol_scaler is None:
+        vol_scaler = _set_vol_scaler(params.sigma0, float(ttms[0]))
+    if not np.isfinite(vol_scaler) or vol_scaler <= 0.0:
+        raise ValueError("vol_scaler must be finite and positive")
+    if equilibrium is None:
+        equilibrium = solve_regime_switch_equilibrium(params)
+    if equilibrium.params != params:
+        raise ValueError("equilibrium solution was built for different parameters")
+
+    phi_grid, _, _ = mgfp.get_transform_var_grid(
+        variable_type=VariableType.LOG_RETURN,
+        is_spot_measure=True,
+        max_phi=max_phi,
+        vol_scaler=vol_scaler,
+    )
+    prices_by_regime = (List(), List())
+    for ttm, forward, discfactor, strikes, optiontypes in zip(
+        ttms,
+        forwards,
+        discfactors,
+        strikes_ttms,
+        optiontypes_ttms,
+    ):
+        log_mgf = compute_regime_switch_log_mgf_grid(
+            params=params,
+            equilibrium=equilibrium,
+            ttm=float(ttm),
+            phi_grid=phi_grid,
+            expansion_order=expansion_order,
+        )
+        for regime in Regime:
+            prices = mgfp.vanilla_slice_pricer_with_mgf_grid(
+                log_mgf_grid=log_mgf[regime],
+                phi_grid=phi_grid,
+                forward=float(forward),
+                strikes=np.asarray(strikes),
+                optiontypes=np.asarray(optiontypes),
+                discfactor=float(discfactor),
+                is_spot_measure=True,
+            )
+            prices_by_regime[regime].append(np.asarray(prices))
+    return prices_by_regime
+
+
+@dataclass(frozen=True, slots=True)
+class StateConditionalOptionChain:
+    """Growth- and stress-conditioned prices and Black implied volatilities."""
+
+    growth_prices: list[np.ndarray]
+    growth_implied_vols: list[np.ndarray]
+    stress_prices: list[np.ndarray]
+    stress_implied_vols: list[np.ndarray]
+
+    def for_regime(self, regime: Regime | int) -> tuple[list[np.ndarray], list[np.ndarray]]:
+        """Return ``(prices, implied_vols)`` for one initial regime."""
+
+        if _initial_regime(regime) == Regime.GROWTH:
+            return self.growth_prices, self.growth_implied_vols
+        return self.stress_prices, self.stress_implied_vols
+
+
+def regime_switch_logsv_mc_chain_pricer(
+    params: RegimeSwitchLogSvParams,
+    ttms: np.ndarray,
+    forwards: np.ndarray,
+    discfactors: np.ndarray,
+    strikes_ttms,
+    optiontypes_ttms,
+    *,
+    equilibrium: EquilibriumSolution | None = None,
+    initial_regime: Regime | int | None = None,
+    nb_path: int = 100_000,
+    nb_steps_per_year: int = 360,
+    seed: Optional[int] = 7,
+    variable_type: VariableType = VariableType.LOG_RETURN,
+    is_spot_measure: bool = True,
+) -> tuple[list[np.ndarray], list[np.ndarray]]:
+    """Price a chain from one sequential state-conditional Monte Carlo path set."""
+
+    _validate_pricing_mode(variable_type=variable_type, is_spot_measure=is_spot_measure)
+    ttms = _validate_chain_inputs(params, ttms, strikes_ttms, optiontypes_ttms)
+    forwards, discfactors = _validate_market_vectors(ttms, forwards, discfactors)
+    path_count = _positive_int(nb_path, "nb_path", minimum=2)
+    step_count = _positive_int(nb_steps_per_year, "nb_steps_per_year")
+    seed_value = None if seed is None else _positive_int(seed, "seed", minimum=0)
+    if equilibrium is None:
+        equilibrium = solve_regime_switch_equilibrium(params)
+    elif equilibrium.params != params:
+        raise ValueError("equilibrium solution was built for different parameters")
+    state = params.initial_regime if initial_regime is None else _initial_regime(initial_regime)
+    rng = np.random.default_rng(seed_value)
+    log_return = np.zeros(path_count)
+    sigma = np.full(path_count, params.sigma0)
+    qvar = np.zeros(path_count)
+    regimes = np.full(path_count, int(state), dtype=np.int8)
+    prices_ttms = List()
+    errors_ttms = List()
+    time0 = 0.0
+
+    for ttm, forward, discfactor, strikes, optiontypes in zip(
+        ttms,
+        forwards,
+        discfactors,
+        strikes_ttms,
+        optiontypes_ttms,
+    ):
+        log_return, sigma, qvar, regimes = _simulate_regime_interval(
+            params=params,
+            equilibrium=equilibrium,
+            log_return=log_return,
+            sigma=sigma,
+            qvar=qvar,
+            regimes=regimes,
+            time0=time0,
+            interval=float(ttm - time0),
+            steps_per_year=step_count,
+            rng=rng,
+        )
+        prices, errors = compute_mc_vars_payoff(
+            x0=log_return,
+            sigma0=sigma,
+            qvar0=qvar,
+            ttm=float(ttm),
+            forward=float(forward),
+            strikes_ttm=np.asarray(strikes),
+            optiontypes_ttm=np.asarray(optiontypes),
+            discfactor=float(discfactor),
+            variable_type=VariableType.LOG_RETURN,
+        )
+        prices_ttms.append(np.asarray(prices))
+        errors_ttms.append(np.asarray(errors))
+        time0 = float(ttm)
+    return prices_ttms, errors_ttms
+
+
+class RegimeSwitchLogSVPricer(ModelPricer):
+    """ModelPricer implementation for the two-state equilibrium LogSV model."""
+
+    def price_chain(
+        self,
+        option_chain: OptionChain,
+        params: RegimeSwitchLogSvParams,
+        *,
+        initial_regime: Regime | int | None = None,
+        is_spot_measure: bool = True,
+        variable_type: VariableType = VariableType.LOG_RETURN,
+        **kwargs,
+    ) -> list[np.ndarray]:
+        """Return prices conditional on the selected initial regime."""
+
+        prices = regime_switch_logsv_chain_pricer(
+            params=params,
+            ttms=option_chain.ttms,
+            forwards=option_chain.forwards,
+            discfactors=option_chain.discfactors,
+            strikes_ttms=option_chain.strikes_ttms,
+            optiontypes_ttms=option_chain.optiontypes_ttms,
+            is_spot_measure=is_spot_measure,
+            variable_type=variable_type,
+            **kwargs,
+        )
+        state = params.initial_regime if initial_regime is None else _initial_regime(initial_regime)
+        return prices[state]
+
+    def compute_state_conditional_prices_with_vols(
+        self,
+        option_chain: OptionChain,
+        params: RegimeSwitchLogSvParams,
+        **kwargs,
+    ) -> StateConditionalOptionChain:
+        """Return prices and Black vols conditional on growth and stress."""
+
+        growth_prices, stress_prices = regime_switch_logsv_chain_pricer(
+            params=params,
+            ttms=option_chain.ttms,
+            forwards=option_chain.forwards,
+            discfactors=option_chain.discfactors,
+            strikes_ttms=option_chain.strikes_ttms,
+            optiontypes_ttms=option_chain.optiontypes_ttms,
+            **kwargs,
+        )
+        growth_ivols = option_chain.compute_model_ivols_from_chain_data(model_prices=growth_prices)
+        stress_ivols = option_chain.compute_model_ivols_from_chain_data(model_prices=stress_prices)
+        return StateConditionalOptionChain(
+            growth_prices=growth_prices,
+            growth_implied_vols=growth_ivols,
+            stress_prices=stress_prices,
+            stress_implied_vols=stress_ivols,
+        )
+
+    def model_mc_price_chain(
+        self,
+        option_chain: OptionChain,
+        params: RegimeSwitchLogSvParams,
+        *,
+        initial_regime: Regime | int | None = None,
+        variable_type: VariableType = VariableType.LOG_RETURN,
+        is_spot_measure: bool = True,
+        nb_path: int = 100_000,
+        nb_steps_per_year: int = 360,
+        seed: Optional[int] = 7,
+        **kwargs,
+    ) -> tuple[list[np.ndarray], list[np.ndarray]]:
+        """Return Monte Carlo prices and standard errors for one initial state."""
+
+        return regime_switch_logsv_mc_chain_pricer(
+            params=params,
+            ttms=option_chain.ttms,
+            forwards=option_chain.forwards,
+            discfactors=option_chain.discfactors,
+            strikes_ttms=option_chain.strikes_ttms,
+            optiontypes_ttms=option_chain.optiontypes_ttms,
+            initial_regime=initial_regime,
+            variable_type=variable_type,
+            is_spot_measure=is_spot_measure,
+            nb_path=nb_path,
+            nb_steps_per_year=nb_steps_per_year,
+            seed=seed,
+            **kwargs,
+        )
+
+    def simulate_terminal_values(
+        self,
+        params: RegimeSwitchLogSvParams,
+        ttm: float = 1.0,
+        *,
+        initial_regime: Regime | int | None = None,
+        nb_path: int = 100_000,
+        nb_steps_per_year: int = 360,
+        seed: Optional[int] = 7,
+        **kwargs,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Return terminal log return, volatility, and quadratic variance arrays."""
+
+        sample = simulate_regime_switch_logsv_terminal(
+            params=params,
+            ttm=ttm,
+            initial_regime=initial_regime,
+            nb_path=nb_path,
+            nb_steps_per_year=nb_steps_per_year,
+            seed=seed,
+            **kwargs,
+        )
+        return sample.log_forward_return, sample.sigma, sample.qvar

--- a/src/stochvolmodels/pricers/regime_switch_logsv_pricer.py
+++ b/src/stochvolmodels/pricers/regime_switch_logsv_pricer.py
@@ -19,6 +19,7 @@ from stochvolmodels.data.option_chain import OptionChain
 from stochvolmodels.models.regime_logsv import (
     EquilibriumSolution,
     Regime,
+    RegimeRiskPremiaScales,
     RegimeSwitchLogSvParams,
     _poly_derivative,
     _poly_exp,
@@ -51,6 +52,7 @@ def _option_rhs(
     ttm: float,
     phi_grid: np.ndarray,
     degree: int,
+    scales: RegimeRiskPremiaScales = RegimeRiskPremiaScales(),
 ) -> np.ndarray:
     """Projected coupled option-transform PDE.
 
@@ -65,7 +67,11 @@ def _option_rhs(
     equilibrium_horizon = params.risk_premia.agent_horizon - ttm + backward_time
     equilibrium_coefficients = equilibrium.coefficients(equilibrium_horizon)
     phi = phi_grid[:, None]
-    tail_tilt = params.risk_premia.utility_power - 1.0
+    tail_tilt = (
+        params.risk_premia.utility_power - 1.0
+        if scales.is_full_equilibrium
+        else scales.tail * (params.risk_premia.utility_power - 1.0)
+    )
 
     for regime in Regime:
         dynamics = params.regimes[regime]
@@ -73,7 +79,13 @@ def _option_rhs(
         first = _poly_derivative(coefficients[:, regime, :], degree)
         second = _poly_derivative(first, degree)
         local = _poly_mul(
-            _risk_neutral_drift_polynomial(equilibrium_coefficients, params, regime, degree),
+            _risk_neutral_drift_polynomial(
+                equilibrium_coefficients,
+                params,
+                regime,
+                degree,
+                scales=scales,
+            ),
             first,
             degree,
         )
@@ -86,6 +98,8 @@ def _option_rhs(
         local += 0.5 * phi * (phi + 1.0) * sigma2
 
         timing_difference = _regime_difference(equilibrium_coefficients, params, regime, degree)
+        if not scales.is_full_equilibrium:
+            timing_difference *= scales.timing
         timing_ratio = _poly_exp(timing_difference, degree)
         price_difference = _regime_difference(coefficients, params, regime, degree)
         price_ratio = _poly_exp(price_difference, degree)
@@ -116,6 +130,7 @@ def compute_regime_switch_log_mgf_grid(
     phi_grid: np.ndarray,
     *,
     equilibrium: EquilibriumSolution | None = None,
+    scales: RegimeRiskPremiaScales = RegimeRiskPremiaScales(),
     expansion_order: ExpansionOrder = ExpansionOrder.SECOND,
     rtol: float = 2.0e-7,
     atol: float = 2.0e-9,
@@ -129,11 +144,15 @@ def compute_regime_switch_log_mgf_grid(
     The common projection uses the published LogSV FIRST equations
     (4.13)--(4.22) or SECOND equations (4.23)--(4.25). The coupled two-state
     transform itself is a new synthesis rather than a published equation.
+    Non-unit ``scales`` define analytic attribution counterfactuals rather than
+    separately solved equilibrium measures.
     """
 
     maximum = params.risk_premia.agent_horizon
     if not np.isfinite(ttm) or ttm <= 0.0 or ttm > maximum:
         raise ValueError("ttm must lie in (0, agent_horizon]")
+    if not isinstance(scales, RegimeRiskPremiaScales):
+        raise TypeError("scales must be a RegimeRiskPremiaScales object")
     if equilibrium is None:
         equilibrium = solve_regime_switch_equilibrium(params)
     if equilibrium.params != params:
@@ -144,7 +163,11 @@ def compute_regime_switch_log_mgf_grid(
         raise ValueError("phi_grid must be a non-empty one-dimensional array")
     if not np.all(np.isfinite(phi_grid)):
         raise ValueError("phi_grid must be finite")
-    tail_tilt = params.risk_premia.utility_power - 1.0
+    tail_tilt = (
+        params.risk_premia.utility_power - 1.0
+        if scales.is_full_equilibrium
+        else scales.tail * (params.risk_premia.utility_power - 1.0)
+    )
     for regime in Regime:
         params.validate_jump_moment(regime, tail_tilt)
         params.validate_jump_moment(regime, tail_tilt + 1.0)
@@ -160,6 +183,7 @@ def compute_regime_switch_log_mgf_grid(
             ttm=ttm,
             phi_grid=phi_grid,
             degree=degree,
+            scales=scales,
         ),
         (0.0, ttm),
         initial,
@@ -264,6 +288,7 @@ def regime_switch_logsv_chain_pricer(
     optiontypes_ttms,
     *,
     equilibrium: EquilibriumSolution | None = None,
+    scales: RegimeRiskPremiaScales = RegimeRiskPremiaScales(),
     expansion_order: ExpansionOrder = ExpansionOrder.SECOND,
     max_phi: int = 1_601,
     vol_scaler: float | None = None,
@@ -277,9 +302,16 @@ def regime_switch_logsv_chain_pricer(
     tuple[list[numpy.ndarray], list[numpy.ndarray]]
         Growth-conditioned and stress-conditioned prices.  Each list contains
         one array per maturity in the input chain.
+
+    Notes
+    -----
+    Non-unit ``scales`` are analytic channel-attribution counterfactuals. They
+    are intentionally unavailable from the Monte Carlo pricing path.
     """
 
     _validate_pricing_mode(variable_type=variable_type, is_spot_measure=is_spot_measure)
+    if not isinstance(scales, RegimeRiskPremiaScales):
+        raise TypeError("scales must be a RegimeRiskPremiaScales object")
     ttms = _validate_chain_inputs(params, ttms, strikes_ttms, optiontypes_ttms)
     forwards, discfactors = _validate_market_vectors(ttms, forwards, discfactors)
     if not isinstance(max_phi, (int, np.integer)) or max_phi < 3 or max_phi % 2 == 0:
@@ -312,6 +344,7 @@ def regime_switch_logsv_chain_pricer(
             equilibrium=equilibrium,
             ttm=float(ttm),
             phi_grid=phi_grid,
+            scales=scales,
             expansion_order=expansion_order,
         )
         for regime in Regime:

--- a/src/stochvolmodels/tests/test_inverse_gamma_normal_characterization.py
+++ b/src/stochvolmodels/tests/test_inverse_gamma_normal_characterization.py
@@ -1,0 +1,547 @@
+"""Independent characterization of the inverse-gamma/normal terminal law."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+
+import numpy as np
+import pytest
+import vanilla_option_pricers as bsm
+from scipy.integrate import quad
+from scipy.special import gammaln, kve, ndtr
+
+from stochvolmodels import OptionSlice
+from stochvolmodels.fitters.tdist import cdf_tdist, imply_drift_tdist
+from stochvolmodels.models import (
+    PathModel,
+    TerminalDistributionModel,
+    TerminalSmileModel,
+    TransformModel,
+)
+from stochvolmodels.models.inverse_gamma_normal import (
+    InverseGammaNormalParams,
+    InverseGammaNormalTerminalModel,
+)
+from stochvolmodels.pricers.tdist_pricer import TdistParams, TdistTerminalModel
+
+_FROZEN_CURVE_HASH = "2f78c1e678774f692946fc37f97496c754a0f306604af136d5800a342fbefeae"
+_CHAPTER_LAWS = (
+    (4.75, 0.120, 0.0),
+    (4.00, 0.120, 0.0),
+    (3.25, 0.120, 0.0),
+    (4.00, 0.096, 0.0),
+    (4.00, 0.120, 0.0),
+    (4.00, 0.144, 0.0),
+    (4.00, 0.120, -2.0),
+    (4.00, 0.120, 0.0),
+    (4.00, 0.120, 2.0),
+    (4.75, 0.150, 0.0),
+    (4.00, 0.120, 0.0),
+    (3.25, 0.090, 0.0),
+)
+_EXPECTED_SHIFTS = np.array(
+    [
+        0.9999920955561977,
+        0.9999646285152991,
+        0.9998319143510996,
+        0.9999838027697864,
+        0.9999646285152991,
+        0.9999341249741032,
+        1.079741087577782,
+        0.9999646285152991,
+        0.9199967270263122,
+        0.9999807026924815,
+        0.9999646285152991,
+        0.9999266976092555,
+    ]
+)
+_EXPECTED_DEFAULT_PROBABILITIES = np.array(
+    [
+        5.635434956124023e-05,
+        2.0885213649389573e-04,
+        7.858410761328880e-04,
+        9.864535092085288e-05,
+        2.0885213649389573e-04,
+        3.7759424368605086e-04,
+        9.935804567066705e-04,
+        2.0885213649389573e-04,
+        3.055402025491766e-05,
+        1.324334797811496e-04,
+        2.0885213649389573e-04,
+        3.5571943435259675e-04,
+    ]
+)
+
+
+def _model(
+    *,
+    alpha: float = 4.0,
+    beta: float = 0.12,
+    c: float = 1.0,
+    q: float = 0.0,
+    ttm: float = 1.0,
+    quadrature_order: int = 256,
+) -> InverseGammaNormalTerminalModel:
+    return InverseGammaNormalTerminalModel(
+        InverseGammaNormalParams(alpha=alpha, beta=beta, c=c, q=q, ttm=ttm),
+        quadrature_order=quadrature_order,
+    )
+
+
+def _slice(
+    *,
+    ttm: float = 1.0,
+    forward: float = 1.0,
+    discfactor: float = 1.0,
+    strikes: np.ndarray | None = None,
+    optiontypes: np.ndarray | None = None,
+) -> OptionSlice:
+    if strikes is None:
+        strikes = np.array([0.8, 1.0, 1.2])
+    if optiontypes is None:
+        optiontypes = np.array(["P", "C", "C"])
+    return OptionSlice(
+        ttm=ttm,
+        forward=forward,
+        strikes=strikes,
+        optiontypes=optiontypes,
+        discfactor=discfactor,
+        id="inverse-gamma-normal",
+    )
+
+
+def _canonical_curve_payload() -> tuple[dict[str, object], np.ndarray, np.ndarray]:
+    log_moneyness = np.linspace(-0.35, 0.35, 29)
+    strikes = np.exp(log_moneyness)
+    optiontypes = np.array(["C"] * strikes.size)
+    records = []
+    shifts = []
+    default_probabilities = []
+    for alpha, beta, q in _CHAPTER_LAWS:
+        model = _model(alpha=alpha, beta=beta, q=q)
+        option_slice = _slice(strikes=strikes, optiontypes=optiontypes)
+        calls = model.price_european(option_slice)
+        ivols = model.implied_vols(option_slice)
+        shift = model.martingale_shift(discfactor=1.0)
+        default_probability = model.default_probability(discfactor=1.0)
+        shifts.append(shift)
+        default_probabilities.append(default_probability)
+        records.append(
+            {
+                "alpha": round(alpha, 12),
+                "beta": round(beta, 12),
+                "q": round(q, 12),
+                "shift": round(shift, 12),
+                "default_probability": round(default_probability, 12),
+                "call_prices": np.round(calls, 10).tolist(),
+                "implied_volatilities": np.round(ivols, 10).tolist(),
+            }
+        )
+    payload = {
+        "log_moneyness": np.round(log_moneyness, 8).tolist(),
+        "records": records,
+    }
+    return payload, np.asarray(shifts), np.asarray(default_probabilities)
+
+
+def _normal_positive_part(mean: float, stdev: float) -> float:
+    d = mean / stdev
+    return float(mean * ndtr(d) + stdev * np.exp(-0.5 * d * d) / math.sqrt(2.0 * math.pi))
+
+
+def _adaptive_normalized_call(
+    model: InverseGammaNormalTerminalModel,
+    *,
+    normalized_strike: float,
+    discfactor: float,
+) -> float:
+    params = model.params
+    shift = model.martingale_shift(discfactor=discfactor)
+
+    def integrand(precision: float) -> float:
+        if precision <= 0.0:
+            return 0.0
+        variance = params.beta / precision
+        positive_part = _normal_positive_part(
+            shift - normalized_strike + params.q * variance,
+            math.sqrt(params.c * variance),
+        )
+        if positive_part == 0.0:
+            return 0.0
+        log_density = (params.alpha - 1.0) * math.log(precision) - precision - gammaln(params.alpha)
+        return math.exp(log_density) * positive_part
+
+    return float(
+        quad(integrand, 0.0, 1.0, epsabs=2.0e-11, epsrel=2.0e-11, limit=300)[0]
+        + quad(
+            integrand,
+            1.0,
+            np.inf,
+            epsabs=2.0e-11,
+            epsrel=2.0e-11,
+            limit=300,
+        )[0]
+    )
+
+
+def _skew_marginal_density(
+    params: InverseGammaNormalParams,
+    shock: float,
+) -> float:
+    radius_squared = shock * shock + 2.0 * params.beta * params.c
+    radius = math.sqrt(radius_squared)
+    absolute_q = abs(params.q)
+    bessel_argument = absolute_q * radius / params.c
+    if params.q * shock >= 0.0:
+        exponential_term = -2.0 * params.beta * absolute_q / (radius + abs(shock))
+    else:
+        exponential_term = -absolute_q * (radius + abs(shock)) / params.c
+    log_density = (
+        math.log(2.0)
+        + params.alpha * math.log(params.beta)
+        - gammaln(params.alpha)
+        - 0.5 * math.log(2.0 * math.pi * params.c)
+        + exponential_term
+        + 0.5 * (params.alpha + 0.5) * (math.log(params.q * params.q) - math.log(radius_squared))
+        + math.log(kve(params.alpha + 0.5, bessel_argument))
+    )
+    return math.exp(log_density)
+
+
+def _bessel_normalized_call(
+    model: InverseGammaNormalTerminalModel,
+    *,
+    normalized_strike: float,
+    discfactor: float,
+) -> float:
+    params = model.params
+    shift = model.martingale_shift(discfactor=discfactor)
+    threshold = normalized_strike - shift
+
+    def integrand(shock: float) -> float:
+        return max(shift + shock - normalized_strike, 0.0) * _skew_marginal_density(
+            params,
+            shock,
+        )
+
+    value = 0.0
+    if threshold < 0.0:
+        value += quad(
+            integrand,
+            threshold,
+            0.0,
+            epsabs=2.0e-11,
+            epsrel=2.0e-11,
+            limit=300,
+        )[0]
+        threshold = 0.0
+    value += quad(
+        integrand,
+        threshold,
+        np.inf,
+        epsabs=2.0e-11,
+        epsrel=2.0e-11,
+        limit=300,
+    )[0]
+    return float(value)
+
+
+def test_inverse_gamma_normal_matches_all_frozen_chapter_curves() -> None:
+    """All 12 captured laws reproduce the frozen 29-point calls and Black smiles."""
+
+    payload, shifts, default_probabilities = _canonical_curve_payload()
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode()
+
+    assert hashlib.sha256(encoded).hexdigest() == _FROZEN_CURVE_HASH
+    np.testing.assert_allclose(shifts, _EXPECTED_SHIFTS, rtol=0.0, atol=5.0e-14)
+    np.testing.assert_allclose(
+        default_probabilities,
+        _EXPECTED_DEFAULT_PROBABILITIES,
+        rtol=0.0,
+        atol=5.0e-14,
+    )
+
+
+def test_inverse_gamma_normal_exposes_only_terminal_capabilities() -> None:
+    """The one-maturity law is a distribution/smile model, not a path or transform model."""
+
+    model = _model()
+
+    assert isinstance(model, TerminalDistributionModel)
+    assert isinstance(model, TerminalSmileModel)
+    assert not isinstance(model, PathModel)
+    assert not isinstance(model, TransformModel)
+    assert model.params == InverseGammaNormalParams(4.0, 0.12, 1.0, 0.0, 1.0)
+    assert model.ttm == 1.0
+    assert model.quadrature_order == 256
+    assert model.mean_mixing_variance == 0.04
+    assert not hasattr(model, "log_mgf_grid")
+
+
+def test_q_zero_matches_tdist_at_nonunit_discount() -> None:
+    """The symmetric law matches the accepted T2 adapter under prepaid-forward scaling."""
+
+    alpha = 4.0
+    beta = 0.12
+    c = 1.0
+    ttm = 0.75
+    discfactor = 0.96
+    model = _model(alpha=alpha, beta=beta, c=c, q=0.0, ttm=ttm)
+    nu = 2.0 * alpha
+    vol = math.sqrt(c * beta / ((alpha - 1.0) * ttm))
+    rate = -math.log(discfactor) / ttm
+    drift = imply_drift_tdist(rf_rate=rate, vol=vol, nu=nu, ttm=ttm)
+    reference = TdistTerminalModel(TdistParams(drift=drift, vol=vol, nu=nu, ttm=ttm))
+    option_slice = _slice(
+        ttm=ttm,
+        forward=105.0,
+        discfactor=discfactor,
+        strikes=np.array([80.0, 95.0, 105.0, 115.0, 130.0]),
+        optiontypes=np.array(["P", "P", "C", "C", "C"]),
+    )
+
+    expected_shift = 1.0 + drift * ttm
+    expected_default = cdf_tdist(
+        x=-expected_shift,
+        mu=0.0,
+        vol=vol,
+        nu=nu,
+        ttm=ttm,
+    )
+    np.testing.assert_allclose(
+        model.martingale_shift(discfactor=discfactor),
+        expected_shift,
+        rtol=0.0,
+        atol=4.0e-8,
+    )
+    np.testing.assert_allclose(
+        model.default_probability(discfactor=discfactor),
+        expected_default,
+        rtol=0.0,
+        atol=4.0e-8,
+    )
+    np.testing.assert_allclose(
+        model.price_european(option_slice),
+        reference.price_european(option_slice),
+        rtol=0.0,
+        atol=4.0e-6,
+    )
+    np.testing.assert_allclose(
+        model.implied_vols(option_slice),
+        reference.implied_vols(option_slice),
+        rtol=0.0,
+        atol=2.0e-7,
+    )
+
+
+@pytest.mark.parametrize("q", [-2.0, 2.0])
+def test_skew_calls_match_adaptive_precision_integration(q: float) -> None:
+    """Production Gauss-Laguerre calls match an adaptive Gamma-precision integral."""
+
+    model = _model(q=q)
+    discfactor = 0.97
+    forward = 1.2
+    prepaid_forward = discfactor * forward
+    normalized_strikes = np.array([0.8, 1.0, 1.2])
+    strikes = prepaid_forward * normalized_strikes
+    option_slice = _slice(
+        forward=forward,
+        discfactor=discfactor,
+        strikes=strikes,
+        optiontypes=np.array(["C", "C", "C"]),
+    )
+    expected = np.array(
+        [
+            discfactor
+            * prepaid_forward
+            * _adaptive_normalized_call(
+                model,
+                normalized_strike=float(strike),
+                discfactor=discfactor,
+            )
+            for strike in normalized_strikes
+        ]
+    )
+
+    np.testing.assert_allclose(
+        model.price_european(option_slice),
+        expected,
+        rtol=0.0,
+        atol=4.0e-8,
+    )
+    np.testing.assert_allclose(
+        _adaptive_normalized_call(model, normalized_strike=0.0, discfactor=discfactor),
+        1.0 / discfactor,
+        rtol=0.0,
+        atol=4.0e-8,
+    )
+
+
+@pytest.mark.parametrize("q", [-2.0, 2.0])
+def test_skew_atm_call_matches_bessel_density_integration(q: float) -> None:
+    """A direct Bessel-K marginal-density integral independently prices the skew law."""
+
+    model = _model(q=q)
+    discfactor = 0.97
+    forward = 1.2
+    prepaid_forward = discfactor * forward
+    option_slice = _slice(
+        forward=forward,
+        discfactor=discfactor,
+        strikes=np.array([prepaid_forward]),
+        optiontypes=np.array(["C"]),
+    )
+    expected = (
+        discfactor
+        * prepaid_forward
+        * _bessel_normalized_call(
+            model,
+            normalized_strike=1.0,
+            discfactor=discfactor,
+        )
+    )
+
+    np.testing.assert_allclose(
+        model.price_european(option_slice)[0],
+        expected,
+        rtol=0.0,
+        atol=4.0e-8,
+    )
+
+
+def test_prices_obey_parity_shape_refinement_and_black_round_trip() -> None:
+    """The skew law is arbitrage-consistent and numerically converged on a strike grid."""
+
+    strikes = np.linspace(0.55, 1.45, 25)
+    calls_slice = _slice(strikes=strikes, optiontypes=np.array(["C"] * strikes.size))
+    puts_slice = _slice(strikes=strikes, optiontypes=np.array(["P"] * strikes.size))
+    model = _model(q=-2.0)
+    calls = model.price_european(calls_slice)
+    puts = model.price_european(puts_slice)
+
+    np.testing.assert_allclose(calls - puts, 1.0 - strikes, rtol=0.0, atol=7.0e-14)
+    assert np.max(np.diff(calls)) <= 2.0e-13
+    assert np.min(np.diff(puts)) >= -2.0e-13
+    assert np.min(np.diff(calls, n=2)) >= -2.0e-13
+    assert np.min(np.diff(puts, n=2)) >= -2.0e-13
+
+    lower_order = _model(q=-2.0, quadrature_order=128)
+    representative = _slice(
+        strikes=np.exp(np.array([-0.25, 0.0, 0.25])),
+        optiontypes=np.array(["C", "C", "C"]),
+    )
+    np.testing.assert_allclose(
+        model.price_european(representative),
+        lower_order.price_european(representative),
+        rtol=0.0,
+        atol=3.0e-7,
+    )
+
+    ivols = model.implied_vols(calls_slice)
+    repriced = np.array(
+        [
+            bsm.compute_bsm_vanilla_price(
+                forward=1.0,
+                strike=float(strike),
+                ttm=1.0,
+                vol=float(vol),
+                optiontype="C",
+                discfactor=1.0,
+            )
+            for strike, vol in zip(strikes, ivols)
+        ]
+    )
+    np.testing.assert_allclose(repriced, calls, rtol=0.0, atol=5.0e-13)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("alpha", 1.0),
+        ("alpha", 0.9),
+        ("alpha", np.nan),
+        ("alpha", True),
+        ("beta", 0.0),
+        ("beta", -0.1),
+        ("beta", np.inf),
+        ("c", 0.0),
+        ("c", np.nan),
+        ("q", np.inf),
+        ("q", np.bool_(True)),
+        ("ttm", 0.0),
+        ("ttm", -0.1),
+        ("ttm", np.nan),
+    ],
+)
+def test_model_rejects_invalid_parameters(field: str, value: float) -> None:
+    """The package boundary rejects non-finite and mathematically invalid law inputs."""
+
+    values = {"alpha": 4.0, "beta": 0.12, "c": 1.0, "q": 0.0, "ttm": 1.0}
+    values[field] = value
+    with pytest.raises(ValueError, match=field):
+        InverseGammaNormalTerminalModel(InverseGammaNormalParams(**values))
+
+
+@pytest.mark.parametrize("quadrature_order", [True, 0, 1, 2.5, np.nan])
+def test_model_rejects_invalid_quadrature_order(quadrature_order: object) -> None:
+    """The numerical integration rule requires a usable integer node count."""
+
+    with pytest.raises(ValueError, match="quadrature_order"):
+        _model(quadrature_order=quadrature_order)
+
+
+def test_model_rejects_wrong_payload_maturity_payoff_and_discount() -> None:
+    """One-maturity and standard-payoff boundaries fail closed."""
+
+    with pytest.raises(TypeError, match="InverseGammaNormalParams"):
+        InverseGammaNormalTerminalModel(object())
+    with pytest.raises(TypeError, match="OptionSlice"):
+        _model().price_european(object())
+    with pytest.raises(ValueError, match="exactly match"):
+        _model().price_european(_slice(ttm=np.nextafter(1.0, np.inf)))
+    with pytest.raises(ValueError, match="finite positive"):
+        _model().price_european(_slice(ttm=True))
+    with pytest.raises(NotImplementedError, match="inverse"):
+        _model().price_european(_slice(strikes=np.array([1.0]), optiontypes=np.array(["IC"])))
+    with pytest.raises(ValueError, match="discfactor"):
+        _model().martingale_shift(discfactor=True)
+
+
+def test_integer_strikes_return_floating_prices_and_ivols() -> None:
+    """Integer strike storage cannot truncate prices or Black implied volatilities."""
+
+    model = _model(q=2.0)
+    integer_slice = _slice(
+        forward=100.0,
+        strikes=np.array([80, 100, 120]),
+        optiontypes=np.array(["P", "C", "C"]),
+    )
+    float_slice = _slice(
+        forward=100.0,
+        strikes=np.array([80.0, 100.0, 120.0]),
+        optiontypes=np.array(["P", "C", "C"]),
+    )
+    integer_prices = model.price_european(integer_slice)
+    integer_ivols = model.implied_vols(integer_slice)
+
+    assert np.issubdtype(integer_prices.dtype, np.floating)
+    assert np.issubdtype(integer_ivols.dtype, np.floating)
+    np.testing.assert_allclose(
+        integer_prices,
+        model.price_european(float_slice),
+        rtol=0.0,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        integer_ivols,
+        model.implied_vols(float_slice),
+        rtol=0.0,
+        atol=0.0,
+    )

--- a/src/stochvolmodels/tests/test_regime_switch_logsv_characterization.py
+++ b/src/stochvolmodels/tests/test_regime_switch_logsv_characterization.py
@@ -7,6 +7,7 @@ import pytest
 from numba.typed import List
 from scipy.linalg import expm
 
+import stochvolmodels.models.regime_logsv as regime_model
 from stochvolmodels.data.option_chain import OptionChain
 from stochvolmodels.pricers.logsv import affine_expansion as scalar_afe
 from stochvolmodels.models.regime_logsv import (
@@ -110,6 +111,261 @@ def test_regime_switch_params_encode_paper_jumps_and_copy_nested_specs() -> None
                 RegimeTransition(0.1, 0.01),
                 params.transitions[Regime.STRESS],
             ),
+        )
+
+
+def test_regime_risk_premia_scales_are_strict_frozen_diagnostics() -> None:
+    scales = regime_model.RegimeRiskPremiaScales()
+
+    assert scales.equity_brownian == 1.0
+    assert scales.orthogonal_brownian == 1.0
+    assert scales.timing == 1.0
+    assert scales.tail == 1.0
+    assert scales.is_full_equilibrium
+    with pytest.raises(FrozenInstanceError):
+        scales.tail = 0.0
+
+    for name in ("equity_brownian", "orthogonal_brownian", "timing", "tail"):
+        for invalid in (True, np.inf, np.nan, "1"):
+            with pytest.raises(ValueError, match="finite"):
+                replace(scales, **{name: invalid})
+
+    unrestricted = regime_model.RegimeRiskPremiaScales(-1.0, 2.0, -3.0, 4.0)
+    assert not unrestricted.is_full_equilibrium
+
+
+def test_full_regime_risk_premia_scales_preserve_default_transform_exactly() -> None:
+    params = _equity_params()
+    equilibrium = solve_regime_switch_equilibrium(params)
+    phi_grid = np.array([0.0, -1.0, 0.2 + 0.7j, -0.5 + 1.3j])
+
+    default = compute_regime_switch_log_mgf_grid(
+        params,
+        ttm=0.25,
+        phi_grid=phi_grid,
+        equilibrium=equilibrium,
+    )
+    explicit = compute_regime_switch_log_mgf_grid(
+        params,
+        ttm=0.25,
+        phi_grid=phi_grid,
+        equilibrium=equilibrium,
+        scales=regime_model.RegimeRiskPremiaScales(),
+    )
+
+    np.testing.assert_array_equal(explicit, default)
+    for regime in Regime:
+        default_state = evaluate_risk_neutral_state(
+            params,
+            equilibrium,
+            horizon=1.2,
+            sigma=0.19,
+            regime=regime,
+        )
+        explicit_state = evaluate_risk_neutral_state(
+            params,
+            equilibrium,
+            horizon=1.2,
+            sigma=0.19,
+            regime=regime,
+            scales=regime_model.RegimeRiskPremiaScales(),
+        )
+        assert explicit_state == default_state
+    with pytest.raises(TypeError, match="RegimeRiskPremiaScales"):
+        compute_regime_switch_log_mgf_grid(
+            params,
+            ttm=0.25,
+            phi_grid=phi_grid,
+            equilibrium=equilibrium,
+            scales=None,
+        )
+
+
+def test_regime_risk_premia_scales_match_hand_derived_q_state_decomposition() -> None:
+    params = _equity_params()
+    equilibrium = solve_regime_switch_equilibrium(params)
+    scales = regime_model.RegimeRiskPremiaScales(0.3, 0.7, 0.4, 0.2)
+    horizon = 1.2
+    sigma = 0.19
+    regime = Regime.GROWTH
+    dynamics = params.regimes[regime]
+    loading = equilibrium.volatility_loading(horizon, sigma, regime)
+    log_ratio = equilibrium.log_timing_ratio(horizon, sigma, regime)
+    tail_tilt = scales.tail * (params.risk_premia.utility_power - 1.0)
+    ell_tilt = params.jump_mgf(regime, tail_tilt)
+    expected_drift = (dynamics.kappa1 + dynamics.kappa2 * sigma) * (dynamics.theta - sigma)
+    expected_drift -= (
+        scales.equity_brownian
+        * dynamics.beta
+        * params.risk_premia.relative_risk_aversion
+        * sigma**2
+    )
+    expected_drift += (
+        (
+            scales.equity_brownian * dynamics.beta**2
+            + scales.orthogonal_brownian * dynamics.volvol**2
+        )
+        * loading
+        * sigma**2
+    )
+    expected_intensity = params.transitions[regime].intensity
+    expected_intensity *= np.exp(scales.timing * log_ratio) * ell_tilt
+    expected_jump_mean = params.transitions[regime].mean_log_jump
+    expected_jump_mean /= 1.0 - expected_jump_mean * tail_tilt
+    expected_arithmetic_mean = params.jump_mgf(regime, tail_tilt + 1.0) / ell_tilt - 1.0
+
+    state = evaluate_risk_neutral_state(
+        params,
+        equilibrium,
+        horizon,
+        sigma,
+        regime,
+        scales=scales,
+    )
+
+    np.testing.assert_allclose(
+        (
+            state.volatility_drift,
+            state.transition_intensity,
+            state.mean_log_jump,
+            state.arithmetic_jump_mean,
+            state.volatility_loading,
+            state.log_timing_ratio,
+        ),
+        (
+            expected_drift,
+            expected_intensity,
+            expected_jump_mean,
+            expected_arithmetic_mean,
+            loading,
+            log_ratio,
+        ),
+        rtol=0.0,
+        atol=2.0e-15,
+    )
+
+
+def test_analytic_regime_risk_premia_channels_match_frozen_chapter_oracle() -> None:
+    log_moneyness = np.linspace(-0.30, 0.20, 31)
+    strikes = np.exp(log_moneyness)
+    optiontypes = np.where(strikes < 1.0, "P", "C")
+    chain = OptionChain.slice_to_chain(
+        ttm=0.25,
+        forward=1.0,
+        strikes=strikes,
+        optiontypes=optiontypes,
+        id="3m",
+    )
+    params = _equity_params()
+    equilibrium = solve_regime_switch_equilibrium(params)
+    pricer = RegimeSwitchLogSVPricer()
+    selected = np.array([0, 6, 12, 18, 24, 30])
+    scenarios = (
+        (
+            regime_model.RegimeRiskPremiaScales(0.0, 0.0, 0.0, 0.0),
+            [
+                34.799145449632,
+                28.762816043292,
+                22.534731212228,
+                16.242068479341,
+                10.582902544890,
+                13.592731914187,
+            ],
+            [
+                -0.019344416231497248 - 0.004650502361071163j,
+                -0.03751125270880886 + 0.0020582735401356088j,
+            ],
+        ),
+        (
+            regime_model.RegimeRiskPremiaScales(1.0, 1.0, 0.0, 0.0),
+            [
+                35.191913150100,
+                29.271264409580,
+                23.089002999124,
+                16.712030832712,
+                10.913737351373,
+                13.605481975684,
+            ],
+            [
+                -0.02038517727598558 - 0.0048845276238280505j,
+                -0.03909450899480648 + 0.001638838458468522j,
+            ],
+        ),
+        (
+            regime_model.RegimeRiskPremiaScales(0.0, 0.0, 1.0, 0.0),
+            [
+                34.799446638392,
+                28.763167873213,
+                22.535123687118,
+                16.242473551049,
+                10.583168808267,
+                13.592785371068,
+            ],
+            [
+                -0.01934522939884087 - 0.004650684817072648j,
+                -0.03751212788443771 + 0.002057660901379376j,
+            ],
+        ),
+        (
+            regime_model.RegimeRiskPremiaScales(0.0, 0.0, 0.0, 1.0),
+            [
+                47.176385634239,
+                38.563317155283,
+                29.472817366671,
+                20.385313375699,
+                12.446937125298,
+                13.021095772689,
+            ],
+            [
+                -0.03486054914022379 - 0.022361192892172848j,
+                -0.031762131135938995 - 0.0015712614346930682j,
+            ],
+        ),
+        (
+            regime_model.RegimeRiskPremiaScales(),
+            [
+                47.359678403215,
+                38.863951473492,
+                29.906520899408,
+                20.859939639867,
+                12.828313462224,
+                13.043665846078,
+            ],
+            [
+                -0.035904056514211774 - 0.02259830761030641j,
+                -0.033356228072906245 - 0.001990430276935223j,
+            ],
+        ),
+    )
+
+    for scales, expected_percent, expected_log_mgf in scenarios:
+        conditional = pricer.compute_state_conditional_prices_with_vols(
+            chain,
+            params,
+            equilibrium=equilibrium,
+            scales=scales,
+            max_phi=1_601,
+        )
+        _, implied_vols = conditional.for_regime(Regime.GROWTH)
+        np.testing.assert_allclose(
+            100.0 * np.asarray(implied_vols[0])[selected],
+            expected_percent,
+            rtol=1.0e-7,
+            atol=5.0e-10,
+        )
+        roots = compute_regime_switch_log_mgf_grid(
+            params,
+            ttm=0.25,
+            phi_grid=np.array([0.0, -1.0, -0.5 + 2.0j]),
+            equilibrium=equilibrium,
+            scales=scales,
+        )
+        np.testing.assert_allclose(roots[:, :2], 0.0, rtol=0.0, atol=2.0e-11)
+        np.testing.assert_allclose(
+            roots[:, 2],
+            expected_log_mgf,
+            rtol=1.0e-7,
+            atol=5.0e-12,
         )
 
 

--- a/src/stochvolmodels/tests/test_regime_switch_logsv_characterization.py
+++ b/src/stochvolmodels/tests/test_regime_switch_logsv_characterization.py
@@ -1,0 +1,704 @@
+"""Characterization of the two-state equilibrium regime-switching LogSV pipeline."""
+
+from dataclasses import FrozenInstanceError, replace
+
+import numpy as np
+import pytest
+from numba.typed import List
+from scipy.linalg import expm
+
+from stochvolmodels.data.option_chain import OptionChain
+from stochvolmodels.pricers.logsv import affine_expansion as scalar_afe
+from stochvolmodels.models.regime_logsv import (
+    CrraRiskPremia,
+    EquilibriumClosure,
+    Regime,
+    RegimeLogSvDynamics,
+    RegimeSwitchLogSvParams,
+    RegimeTransition,
+    _equilibrium_rhs,
+    evaluate_risk_neutral_state,
+    solve_regime_switch_equilibrium,
+)
+from stochvolmodels.models.regime_logsv_simulation import (
+    simulate_regime_switch_logsv_terminal,
+)
+from stochvolmodels.pricers.regime_switch_logsv_pricer import (
+    RegimeSwitchLogSVPricer,
+    _option_rhs,
+    compute_regime_switch_log_mgf_grid,
+)
+from stochvolmodels.utils.mc_payoffs import compute_mc_vars_payoff
+
+
+def _state_chain() -> OptionChain:
+    ttms = np.array([0.10, 0.25])
+    strikes = np.array([0.90, 1.00, 1.10])
+    return OptionChain(
+        ttms=ttms,
+        forwards=np.ones_like(ttms),
+        discfactors=np.exp(-0.01 * ttms),
+        strikes_ttms=List(strikes.copy() for _ in ttms),
+        optiontypes_ttms=List(np.array(["P", "C", "C"]) for _ in ttms),
+        ids=np.array(["1m", "3m"]),
+    )
+
+
+def _paired_chain() -> OptionChain:
+    strikes = np.array([0.90, 1.00, 1.10])
+    return OptionChain.slice_to_chain(
+        ttm=0.25,
+        forward=1.0,
+        strikes=np.concatenate((strikes, strikes)),
+        optiontypes=np.array(["C", "C", "C", "P", "P", "P"]),
+        discfactor=0.98,
+        id="3m",
+    )
+
+
+def _equity_params(
+    closure: EquilibriumClosure = EquilibriumClosure.LOG_LINEAR,
+    *,
+    utility_power: float = -0.5,
+    agent_horizon: float = 3.0,
+    initial_regime: Regime = Regime.GROWTH,
+) -> RegimeSwitchLogSvParams:
+    common = dict(kappa1=2.6949, kappa2=10.0107, beta=-1.5082, volvol=0.8503)
+    return RegimeSwitchLogSvParams(
+        sigma0=0.15,
+        regimes=(
+            RegimeLogSvDynamics(theta=0.15, **common),
+            RegimeLogSvDynamics(theta=0.225, **common),
+        ),
+        transitions=(
+            RegimeTransition(intensity=0.10, mean_log_jump=-0.25 / 0.75),
+            RegimeTransition(intensity=1.00, mean_log_jump=0.15 / 1.15),
+        ),
+        risk_premia=CrraRiskPremia(
+            utility_power=utility_power,
+            agent_horizon=agent_horizon,
+            closure=closure,
+        ),
+        initial_regime=initial_regime,
+    )
+
+
+def test_regime_switch_params_encode_paper_jumps_and_copy_nested_specs() -> None:
+    params = _equity_params()
+    copied = RegimeSwitchLogSvParams.copy(params)
+
+    assert copied is not params
+    assert copied.regimes == params.regimes
+    assert isinstance(copied.regimes[0], RegimeLogSvDynamics)
+    assert isinstance(copied.risk_premia, CrraRiskPremia)
+    assert copied.risk_premia.relative_risk_aversion == pytest.approx(1.5)
+    observed = [transition.arithmetic_jump_mean for transition in params.transitions]
+    np.testing.assert_allclose(observed, [-0.25, 0.15], rtol=0.0, atol=1.0e-15)
+    assert [transition.intensity for transition in params.transitions] == [0.1, 1.0]
+    with pytest.raises(FrozenInstanceError):
+        params.risk_premia = CrraRiskPremia(0.0, 3.0)
+
+    with pytest.raises(ValueError, match="initial_regime"):
+        replace(params, initial_regime=True)
+    with pytest.raises(ValueError, match="initial_regime"):
+        params.with_initial_regime(1.0)
+
+    with pytest.raises(ValueError, match="growth-to-stress"):
+        replace(
+            params,
+            transitions=(
+                RegimeTransition(0.1, 0.01),
+                params.transitions[Regime.STRESS],
+            ),
+        )
+
+
+def test_equity_risk_premia_match_hand_computed_jump_and_timing_tilts() -> None:
+    params = _equity_params()
+    equilibrium = solve_regime_switch_equilibrium(params)
+
+    np.testing.assert_allclose(
+        [params.transition_factor(regime) for regime in Regime],
+        [4.0 / 5.0, 2668.0 / 2695.0],
+        rtol=0.0,
+        atol=2.0e-15,
+    )
+    expected = (
+        (0.2, -2.0 / 3.0, -2.0 / 5.0, 0.05090175),
+        (46.0 / 55.0, 6.0 / 55.0, 6.0 / 49.0, 0.365639625),
+    )
+    for regime in Regime:
+        state = evaluate_risk_neutral_state(
+            params,
+            equilibrium,
+            horizon=0.0,
+            sigma=params.sigma0,
+            regime=regime,
+        )
+        np.testing.assert_allclose(
+            (
+                state.transition_intensity,
+                state.mean_log_jump,
+                state.arithmetic_jump_mean,
+                state.volatility_drift,
+            ),
+            expected[regime],
+            rtol=0.0,
+            atol=2.0e-14,
+        )
+
+
+def test_log_linear_equilibrium_collector_matches_explicit_four_equations() -> None:
+    params = _equity_params()
+    coefficients = np.array([[0.021, -0.037], [-0.014, 0.029]])
+    generic = _equilibrium_rhs(0.7, coefficients.ravel(), params, 1).reshape(2, 2)
+    explicit = np.zeros_like(generic)
+    utility_power = params.risk_premia.utility_power
+    qvar_loading = 0.5 * utility_power * (1.0 - utility_power)
+
+    for regime in Regime:
+        other = Regime(1 - int(regime))
+        dynamics = params.regimes[regime]
+        delta = dynamics.theta - params.regimes[other].theta
+        difference0 = coefficients[other, 0] + coefficients[other, 1] * delta
+        difference0 -= coefficients[regime, 0]
+        difference1 = coefficients[other, 1] - coefficients[regime, 1]
+        loading = coefficients[regime, 1]
+        transition = params.transitions[regime]
+        coupling = transition.intensity * params.transition_factor(regime) * np.exp(difference0)
+        explicit[regime, 0] = (
+            0.5 * dynamics.vartheta2 * dynamics.theta**2 * loading**2
+            + qvar_loading * dynamics.theta**2
+            + coupling
+            - transition.intensity
+        )
+        explicit[regime, 1] = (
+            -dynamics.kappa_bar * loading
+            + dynamics.vartheta2 * dynamics.theta * loading**2
+            + 2.0 * qvar_loading * dynamics.theta
+            + coupling * difference1
+        )
+    np.testing.assert_allclose(generic, explicit, rtol=0.0, atol=2.0e-14)
+
+
+def test_log_quadratic_equilibrium_collector_matches_explicit_six_equations() -> None:
+    params = _equity_params(EquilibriumClosure.LOG_QUADRATIC)
+    coefficients = np.array([[0.021, -0.037, 0.016], [-0.014, 0.029, -0.011]])
+    generic = _equilibrium_rhs(0.7, coefficients.ravel(), params, 2).reshape(2, 3)
+    explicit = np.zeros_like(generic)
+    utility_power = params.risk_premia.utility_power
+    qvar_loading = 0.5 * utility_power * (1.0 - utility_power)
+
+    for regime in Regime:
+        other = Regime(1 - int(regime))
+        dynamics = params.regimes[regime]
+        delta = dynamics.theta - params.regimes[other].theta
+        own0, own1, own2 = coefficients[regime]
+        target0, target1, target2 = coefficients[other]
+        difference0 = target0 + target1 * delta + target2 * delta**2 - own0
+        difference1 = target1 + 2.0 * target2 * delta - own1
+        difference2 = target2 - own2
+        square_plus_second = own1**2 + 2.0 * own2
+        coupling = (
+            params.transitions[regime].intensity
+            * params.transition_factor(regime)
+            * np.exp(difference0)
+        )
+        explicit[regime, 0] = (
+            0.5 * dynamics.vartheta2 * dynamics.theta**2 * square_plus_second
+            + qvar_loading * dynamics.theta**2
+            + coupling
+            - params.transitions[regime].intensity
+        )
+        explicit[regime, 1] = (
+            -dynamics.kappa_bar * own1
+            + dynamics.vartheta2 * dynamics.theta * square_plus_second
+            + 2.0 * dynamics.vartheta2 * dynamics.theta**2 * own1 * own2
+            + 2.0 * qvar_loading * dynamics.theta
+            + coupling * difference1
+        )
+        explicit[regime, 2] = (
+            -2.0 * dynamics.kappa_bar * own2
+            - dynamics.kappa2 * own1
+            + 0.5 * dynamics.vartheta2 * square_plus_second
+            + 4.0 * dynamics.vartheta2 * dynamics.theta * own1 * own2
+            + 2.0 * dynamics.vartheta2 * dynamics.theta**2 * own2**2
+            + qvar_loading
+            + coupling * (difference2 + 0.5 * difference1**2)
+        )
+    np.testing.assert_allclose(generic, explicit, rtol=0.0, atol=3.0e-14)
+
+
+def test_equilibrium_solver_rejects_outward_quadratic_and_cubic_q_drifts() -> None:
+    outward_quadratic = RegimeLogSvDynamics(
+        theta=0.2,
+        kappa1=1.0,
+        kappa2=0.0,
+        beta=-1.0,
+        volvol=0.0,
+    )
+    log_linear = RegimeSwitchLogSvParams(
+        sigma0=0.2,
+        regimes=(outward_quadratic, outward_quadratic),
+        transitions=(RegimeTransition(0.0, 0.0), RegimeTransition(0.0, 0.0)),
+        risk_premia=CrraRiskPremia(0.0, 1.0),
+    )
+    with pytest.raises(ValueError, match="continuous-boundary"):
+        solve_regime_switch_equilibrium(log_linear)
+
+    log_quadratic = _equity_params(
+        EquilibriumClosure.LOG_QUADRATIC,
+        utility_power=0.5,
+    )
+    with pytest.raises(ValueError, match="outward cubic"):
+        solve_regime_switch_equilibrium(log_quadratic)
+
+
+@pytest.mark.parametrize("closure", list(EquilibriumClosure))
+def test_frozen_volatility_equilibrium_matches_matrix_exponential(
+    closure: EquilibriumClosure,
+) -> None:
+    frozen = RegimeLogSvDynamics(
+        theta=0.2,
+        kappa1=2.0,
+        kappa2=2.0,
+        beta=0.0,
+        volvol=0.0,
+    )
+    params = RegimeSwitchLogSvParams(
+        sigma0=0.2,
+        regimes=(frozen, frozen),
+        transitions=(
+            RegimeTransition(0.1, -1.0 / 3.0),
+            RegimeTransition(1.0, 3.0 / 23.0),
+        ),
+        risk_premia=CrraRiskPremia(-0.5, 3.0, closure),
+    )
+    solution = solve_regime_switch_equilibrium(params)
+    utility_power = params.risk_premia.utility_power
+    potential = 0.5 * utility_power * (1.0 - utility_power) * params.sigma0**2
+    matrix = np.array(
+        [
+            [
+                potential - params.transitions[Regime.GROWTH].intensity,
+                params.transitions[Regime.GROWTH].intensity
+                * params.transition_factor(Regime.GROWTH),
+            ],
+            [
+                params.transitions[Regime.STRESS].intensity
+                * params.transition_factor(Regime.STRESS),
+                potential - params.transitions[Regime.STRESS].intensity,
+            ],
+        ]
+    )
+    for horizon in (0.25, 1.0, 3.0):
+        expected = expm(matrix * horizon) @ np.ones(2)
+        observed = np.array(
+            [
+                np.exp(solution.log_value_coefficient(horizon, params.sigma0, regime))
+                for regime in Regime
+            ]
+        )
+        np.testing.assert_allclose(observed, expected, rtol=0.0, atol=2.0e-10)
+
+
+@pytest.mark.parametrize("closure", list(EquilibriumClosure))
+def test_mgf_martingale_roots_hold_conditionally_on_each_state(
+    closure: EquilibriumClosure,
+) -> None:
+    params = _equity_params(closure)
+    log_mgf = compute_regime_switch_log_mgf_grid(
+        params=params,
+        equilibrium=solve_regime_switch_equilibrium(params),
+        ttm=0.25,
+        phi_grid=np.array([0.0, -1.0]),
+    )
+
+    assert log_mgf.shape == (2, 2)
+    np.testing.assert_allclose(log_mgf, 0.0, rtol=0.0, atol=2.0e-11)
+
+
+def test_option_rhs_uses_fixed_agent_horizon_time_index() -> None:
+    class RecordingEquilibrium:
+        def __init__(self) -> None:
+            self.horizons: list[float] = []
+
+        def coefficients(self, horizon: float) -> np.ndarray:
+            self.horizons.append(horizon)
+            return np.zeros((2, 2))
+
+    params = _equity_params()
+    recording = RecordingEquilibrium()
+    _option_rhs(
+        0.07,
+        np.zeros(6, dtype=np.complex128),
+        params=params,
+        equilibrium=recording,
+        ttm=0.25,
+        phi_grid=np.array([-0.5 + 0.3j]),
+        degree=2,
+    )
+    assert recording.horizons == pytest.approx([2.82])
+
+
+@pytest.mark.parametrize("closure", list(EquilibriumClosure))
+def test_induced_volatility_drift_has_the_derived_polynomial_degree(
+    closure: EquilibriumClosure,
+) -> None:
+    params = _equity_params(closure)
+    equilibrium = solve_regime_switch_equilibrium(params)
+    sigma = np.linspace(0.08, 0.36, 31)
+
+    for regime in Regime:
+        dynamics = params.regimes[regime]
+        state = evaluate_risk_neutral_state(
+            params,
+            equilibrium,
+            params.risk_premia.agent_horizon,
+            sigma,
+            regime,
+        )
+        degree = closure.degree + 1
+        fitted = np.polynomial.polynomial.polyfit(
+            sigma - dynamics.theta, state.volatility_drift, degree
+        )
+        reconstructed = np.polynomial.polynomial.polyval(sigma - dynamics.theta, fitted)
+        np.testing.assert_allclose(state.volatility_drift, reconstructed, rtol=0.0, atol=2.0e-10)
+        if closure == EquilibriumClosure.LOG_LINEAR:
+            loading = equilibrium.coefficients(params.risk_premia.agent_horizon)[regime, 1]
+            expected = (dynamics.kappa1 + dynamics.kappa2 * sigma) * (dynamics.theta - sigma)
+            expected += (
+                -dynamics.beta * params.risk_premia.relative_risk_aversion
+                + dynamics.vartheta2 * loading
+            ) * sigma**2
+            np.testing.assert_allclose(state.volatility_drift, expected, rtol=0.0, atol=2.0e-14)
+        else:
+            quadratic = equilibrium.coefficients(params.risk_premia.agent_horizon)[regime, 2]
+            np.testing.assert_allclose(
+                fitted[3], 2.0 * dynamics.vartheta2 * quadratic, rtol=0.0, atol=2.0e-10
+            )
+
+
+def test_induced_q_simulation_matches_frozen_canonical_replay() -> None:
+    """Freeze RNG ordering, shared shocks, atomic jumps, and the fixed Q clock."""
+
+    sample = simulate_regime_switch_logsv_terminal(
+        _equity_params(),
+        0.25,
+        initial_regime=Regime.STRESS,
+        nb_path=12,
+        nb_steps_per_year=16,
+        seed=2405,
+    )
+    expected_log_return = np.array(
+        [
+            0.25206743279672245,
+            0.02975041356977068,
+            -0.02977693732986204,
+            0.02984860526583684,
+            -0.06949354199644273,
+            0.03742854742393706,
+            -0.17070685323021778,
+            0.05303943376062875,
+            0.00938031920743862,
+            -0.07875865721749825,
+            -0.00215093092262483,
+            0.00521628028106579,
+        ]
+    )
+    expected_sigma = np.array(
+        [
+            0.2673122023101864,
+            0.08664019794326777,
+            0.29540743080334736,
+            0.21389304776175921,
+            0.2900213974297296,
+            0.1977909609263617,
+            0.35332538206498165,
+            0.10702367516598514,
+            0.08596977370091605,
+            0.33486649625160375,
+            0.11691849400901172,
+            0.1500424677570816,
+        ]
+    )
+    expected_qvar = np.array(
+        [
+            0.00797458173341974,
+            0.0031873555151374,
+            0.01341211747127344,
+            0.0072446492782667,
+            0.00600456478851687,
+            0.01128016965994743,
+            0.01415554379013085,
+            0.00475670500507588,
+            0.00639454520276119,
+            0.00651010418451535,
+            0.00677205839131207,
+            0.00525881590248569,
+        ]
+    )
+
+    np.testing.assert_allclose(
+        sample.log_forward_return, expected_log_return, rtol=0.0, atol=5.0e-13
+    )
+    np.testing.assert_allclose(sample.sigma, expected_sigma, rtol=0.0, atol=5.0e-13)
+    np.testing.assert_allclose(sample.qvar, expected_qvar, rtol=0.0, atol=5.0e-14)
+    np.testing.assert_array_equal(
+        sample.regime,
+        np.array([0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1], dtype=np.int8),
+    )
+
+
+def test_state_conditional_chain_outputs_follow_model_pricer_contract() -> None:
+    chain = _state_chain()
+    params = _equity_params()
+    pricer = RegimeSwitchLogSVPricer()
+    conditional = pricer.compute_state_conditional_prices_with_vols(chain, params, max_phi=401)
+
+    for regime in Regime:
+        prices, ivols = conditional.for_regime(regime)
+        recomputed_ivols = chain.compute_model_ivols_from_chain_data(model_prices=prices)
+        assert len(prices) == len(chain.ttms)
+        assert len(ivols) == len(chain.ttms)
+        for price_slice, ivol_slice, recomputed_slice, strikes in zip(
+            prices, ivols, recomputed_ivols, chain.strikes_ttms
+        ):
+            assert price_slice.shape == strikes.shape
+            assert ivol_slice.shape == strikes.shape
+            assert np.all(np.isfinite(price_slice))
+            assert np.all(np.isfinite(ivol_slice))
+            assert np.all(price_slice >= 0.0)
+            np.testing.assert_allclose(ivol_slice, recomputed_slice, rtol=0.0, atol=0.0)
+
+    growth_prices, _ = conditional.for_regime(Regime.GROWTH)
+    stress_prices, _ = conditional.for_regime(Regime.STRESS)
+    assert (
+        max(np.max(np.abs(growth - stress)) for growth, stress in zip(growth_prices, stress_prices))
+        > 1.0e-4
+    )
+
+    standard_growth = pricer.price_chain(chain, params, max_phi=401)
+    standard_stress = pricer.price_chain(chain, params, initial_regime=Regime.STRESS, max_phi=401)
+    for standard, expected in zip(standard_growth, growth_prices):
+        np.testing.assert_allclose(standard, expected, rtol=0.0, atol=0.0)
+    for standard, expected in zip(standard_stress, stress_prices):
+        np.testing.assert_allclose(standard, expected, rtol=0.0, atol=0.0)
+
+
+def test_state_conditional_prices_are_forward_homogeneous() -> None:
+    base = _state_chain()
+    scale = 3.7
+    scaled = OptionChain(
+        ttms=base.ttms.copy(),
+        forwards=scale * base.forwards,
+        discfactors=base.discfactors.copy(),
+        strikes_ttms=List(scale * np.asarray(strikes) for strikes in base.strikes_ttms),
+        optiontypes_ttms=List(
+            np.asarray(optiontypes).copy() for optiontypes in base.optiontypes_ttms
+        ),
+        ids=base.ids.copy(),
+    )
+    pricer = RegimeSwitchLogSVPricer()
+    base_conditional = pricer.compute_state_conditional_prices_with_vols(
+        base, _equity_params(), max_phi=401
+    )
+    scaled_conditional = pricer.compute_state_conditional_prices_with_vols(
+        scaled, _equity_params(), max_phi=401
+    )
+
+    for regime in Regime:
+        base_prices, base_ivols = base_conditional.for_regime(regime)
+        scaled_prices, scaled_ivols = scaled_conditional.for_regime(regime)
+        for base_price, scaled_price, base_ivol, scaled_ivol in zip(
+            base_prices, scaled_prices, base_ivols, scaled_ivols
+        ):
+            np.testing.assert_allclose(scaled_price, scale * base_price, rtol=2.0e-13, atol=2.0e-14)
+            np.testing.assert_allclose(scaled_ivol, base_ivol, rtol=0.0, atol=2.0e-13)
+
+
+def test_state_conditional_prices_satisfy_put_call_parity() -> None:
+    chain = _paired_chain()
+    conditional = RegimeSwitchLogSVPricer().compute_state_conditional_prices_with_vols(
+        chain, _equity_params(), max_phi=801
+    )
+    strikes = np.array([0.90, 1.00, 1.10])
+
+    for regime in Regime:
+        prices, _ = conditional.for_regime(regime)
+        calls, puts = prices[0][:3], prices[0][3:]
+        np.testing.assert_allclose(
+            calls - puts,
+            chain.discfactors[0] * (chain.forwards[0] - strikes),
+            rtol=0.0,
+            atol=2.0e-10,
+        )
+
+
+def test_invisible_switching_reduces_to_scalar_logsv_first_expansion() -> None:
+    dynamics = RegimeLogSvDynamics(
+        theta=0.2,
+        kappa1=2.0,
+        kappa2=5.0,
+        beta=0.0,
+        volvol=0.4,
+    )
+    params = RegimeSwitchLogSvParams(
+        sigma0=0.21,
+        regimes=(dynamics, dynamics),
+        transitions=(RegimeTransition(0.4, 0.0), RegimeTransition(0.7, 0.0)),
+        risk_premia=CrraRiskPremia(0.0, 1.0),
+    )
+    phi = np.array([-0.5 + value * 1j for value in (0.0, 0.5, 1.0, 2.0)])
+    regime_log_mgf = compute_regime_switch_log_mgf_grid(
+        params,
+        ttm=0.25,
+        phi_grid=phi,
+        expansion_order=scalar_afe.ExpansionOrder.FIRST,
+    )
+    zeros = np.zeros_like(phi)
+    _, scalar_log_mgf = scalar_afe.compute_logsv_a_mgf_grid(
+        ttm=0.25,
+        phi_grid=phi,
+        psi_grid=zeros,
+        theta_grid=zeros,
+        sigma0=params.sigma0,
+        theta=dynamics.theta,
+        kappa1=dynamics.kappa1,
+        kappa2=dynamics.kappa2,
+        beta=dynamics.beta,
+        volvol=dynamics.volvol,
+        expansion_order=scalar_afe.ExpansionOrder.FIRST,
+    )
+
+    np.testing.assert_allclose(
+        regime_log_mgf[Regime.GROWTH], scalar_log_mgf, rtol=2.0e-6, atol=5.0e-10
+    )
+    np.testing.assert_allclose(
+        regime_log_mgf[Regime.STRESS], scalar_log_mgf, rtol=2.0e-6, atol=5.0e-10
+    )
+
+
+def test_maturity_and_payoff_scope_fail_closed() -> None:
+    params = _equity_params()
+    pricer = RegimeSwitchLogSVPricer()
+    with pytest.raises(ValueError, match="odd integer"):
+        pricer.price_chain(_state_chain(), params, max_phi=401.0)
+
+    too_long = OptionChain.slice_to_chain(
+        ttm=params.risk_premia.agent_horizon + 0.01,
+        forward=1.0,
+        strikes=np.array([1.0]),
+        optiontypes=np.array(["C"]),
+        id="too-long",
+    )
+    with pytest.raises(ValueError, match="agent_horizon"):
+        pricer.price_chain(too_long, params, max_phi=101)
+
+    inverse = OptionChain.slice_to_chain(
+        ttm=0.1,
+        forward=1.0,
+        strikes=np.array([1.0]),
+        optiontypes=np.array(["IC"]),
+        id="inverse",
+    )
+    with pytest.raises(NotImplementedError, match="ordinary European"):
+        pricer.price_chain(inverse, params, max_phi=101)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("closure", list(EquilibriumClosure))
+def test_fourier_grid_refinement_is_small_for_both_initial_states(
+    closure: EquilibriumClosure,
+) -> None:
+    chain = OptionChain.slice_to_chain(
+        ttm=0.25,
+        forward=1.0,
+        strikes=np.array([0.9, 1.0, 1.1]),
+        optiontypes=np.array(["P", "C", "C"]),
+        id="3m",
+    )
+    params = _equity_params(closure)
+    pricer = RegimeSwitchLogSVPricer()
+    coarse = pricer.compute_state_conditional_prices_with_vols(chain, params, max_phi=1_601)
+    refined = pricer.compute_state_conditional_prices_with_vols(chain, params, max_phi=3_201)
+
+    for regime in Regime:
+        coarse_prices, _ = coarse.for_regime(regime)
+        refined_prices, _ = refined.for_regime(regime)
+        np.testing.assert_allclose(coarse_prices[0], refined_prices[0], rtol=0.0, atol=5.0e-6)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("initial_regime", list(Regime))
+@pytest.mark.parametrize("closure", list(EquilibriumClosure))
+def test_state_conditional_analytic_prices_match_induced_q_monte_carlo(
+    closure: EquilibriumClosure,
+    initial_regime: Regime,
+) -> None:
+    chain = OptionChain.slice_to_chain(
+        ttm=0.25,
+        forward=1.0,
+        strikes=np.array([0.90, 1.00, 1.10]),
+        optiontypes=np.array(["P", "C", "C"]),
+        id="3m",
+    )
+    params = _equity_params(closure)
+    pricer = RegimeSwitchLogSVPricer()
+    analytic = np.asarray(
+        pricer.price_chain(
+            chain,
+            params,
+            initial_regime=initial_regime,
+            max_phi=1_601,
+        )[0]
+    )
+    sample = simulate_regime_switch_logsv_terminal(
+        params,
+        ttm=chain.ttms[0],
+        initial_regime=initial_regime,
+        nb_path=40_000,
+        nb_steps_per_year=720,
+        seed=911 + 10 * closure.degree + int(initial_regime),
+    )
+    monte_carlo, standard_errors = compute_mc_vars_payoff(
+        x0=sample.log_forward_return,
+        sigma0=sample.sigma,
+        qvar0=sample.qvar,
+        ttm=chain.ttms[0],
+        forward=chain.forwards[0],
+        strikes_ttm=np.asarray(chain.strikes_ttms[0]),
+        optiontypes_ttm=np.asarray(chain.optiontypes_ttms[0]),
+        discfactor=chain.discfactors[0],
+    )
+    tolerance = 5.0 * standard_errors + 1.5e-4
+    assert np.all(np.abs(analytic - monte_carlo) <= tolerance)
+
+    forward_mean, forward_error = sample.forward_martingale
+    assert abs(forward_mean - 1.0) <= 5.0 * forward_error + 5.0e-4
+
+
+@pytest.mark.slow
+def test_public_mc_chain_prices_two_maturities_and_honours_state_override() -> None:
+    chain = _state_chain()
+    params = _equity_params()
+    pricer = RegimeSwitchLogSVPricer()
+    analytic = pricer.price_chain(
+        chain,
+        params,
+        initial_regime=Regime.STRESS,
+        max_phi=1_601,
+    )
+    monte_carlo, standard_errors = pricer.model_mc_price_chain(
+        chain,
+        params,
+        initial_regime=Regime.STRESS,
+        nb_path=25_000,
+        nb_steps_per_year=720,
+        seed=2405,
+    )
+
+    assert len(monte_carlo) == len(chain.ttms)
+    assert len(standard_errors) == len(chain.ttms)
+    for analytic_slice, mc_slice, error_slice in zip(analytic, monte_carlo, standard_errors):
+        assert np.all(np.abs(np.asarray(analytic_slice) - mc_slice) <= 6.0 * error_slice + 2.5e-4)

--- a/volatility_book/ch_lognormal_sv_risk_premia/acceptance_manifest.json
+++ b/volatility_book/ch_lognormal_sv_risk_premia/acceptance_manifest.json
@@ -1,0 +1,409 @@
+{
+  "schema_version": 1,
+  "manifest_id": "stochvolmodels.regime_logsv_risk_premia_chapter.acceptance",
+  "acceptance_status": "T3R_ADOPTION_CONTRACT",
+  "chapter": "volatility_book/ch_lognormal_sv_risk_premia",
+  "provenance": {
+    "hash_algorithm": "sha256",
+    "text_hash_rule": "Hashes are over the raw bytes of the named pre-adoption source; no newline normalization is applied.",
+    "commits": {
+      "frozen_chapter_snapshot": "062d239a820c79d1b62c8d975ab1b77003a67c04",
+      "package_regime_logsv_baseline": "a11fbf6e59573d40d8ce685dd99ade62fd0509b8",
+      "package_channel_scale_extension": "50cbe3a4890539638ee4e3218dd049b3d385bf62"
+    },
+    "files": [
+      {
+        "role": "frozen_monolith_oracle",
+        "path": "volatility_book/ch_lognormal_sv_risk_premia/regime_switch_logsv.py",
+        "sha256": "f197e10149cab121d1cdecec2a85b5311143d69dbde00311d4d8b90f1d9b9e5a",
+        "hash_scope": "raw bytes at frozen_chapter_snapshot"
+      },
+      {
+        "role": "frozen_independent_verifier",
+        "path": "volatility_book/ch_lognormal_sv_risk_premia/verify_regime_sv_equilibrium.py",
+        "sha256": "f37d878145f557f5bb37a41991958198fc869f8856e113c744b0bee67540f6b6",
+        "hash_scope": "raw bytes at frozen_chapter_snapshot"
+      },
+      {
+        "role": "source_provenance_ledger",
+        "path": "volatility_book/ch_lognormal_sv_risk_premia/source_provenance.json",
+        "sha256": "13a93e1a7c0d90b1a98d0ff9b4d137e09f13fdcc8a0e7cf123d3a4872b1b2d1e",
+        "hash_scope": "raw tracked bytes at package_channel_scale_extension"
+      },
+      {
+        "role": "pre_adoption_generator",
+        "path": "volatility_book/ch_lognormal_sv_risk_premia/generate_regime_sv_figures.py",
+        "sha256": "7807a942338d74cfcb05e85f0e4bf6dad6f4a7bc95c405cad1bf803a1e9d06c3",
+        "hash_scope": "raw bytes at frozen_chapter_snapshot; the adopted generator is expected to differ"
+      },
+      {
+        "role": "pre_adoption_note",
+        "path": "volatility_book/ch_lognormal_sv_risk_premia/notes/risk_premia_lognormal_sv.tex",
+        "sha256": "9854edf6311cc48806f3f68abc7489b8bd70c3349669d406a988d86af96a8218",
+        "hash_scope": "raw bytes at frozen_chapter_snapshot; the adopted note is expected to differ"
+      }
+    ]
+  },
+  "execution": {
+    "module": "volatility_book.ch_lognormal_sv_risk_premia.generate_regime_sv_figures",
+    "profiles": {
+      "smoke": {
+        "purpose": "Portable pipeline and schema check with reduced Monte Carlo workload.",
+        "output_directory": "outputs/volatility_book/ch_lognormal_sv_risk_premia/smoke",
+        "monte_carlo_paths": 4000,
+        "steps_per_year": 360,
+        "cited_or_report_quality": false
+      },
+      "canonical": {
+        "purpose": "Book-production analytics and report-quality validation.",
+        "output_directory": "outputs/volatility_book/ch_lognormal_sv_risk_premia/canonical",
+        "monte_carlo_paths": 120000,
+        "steps_per_year": 1440,
+        "cited_or_report_quality": true
+      }
+    },
+    "commands": {
+      "canonical_regeneration": [
+        "python",
+        "-m",
+        "volatility_book.ch_lognormal_sv_risk_premia.generate_regime_sv_figures",
+        "--profile",
+        "canonical"
+      ],
+      "smoke_regeneration": [
+        "python",
+        "-m",
+        "volatility_book.ch_lognormal_sv_risk_premia.generate_regime_sv_figures",
+        "--profile",
+        "smoke"
+      ],
+      "payload_only_rerender": [
+        "python",
+        "-m",
+        "volatility_book.ch_lognormal_sv_risk_premia.generate_regime_sv_figures",
+        "--payload",
+        "outputs/volatility_book/ch_lognormal_sv_risk_premia/canonical/numerical_payload.json",
+        "--output-dir",
+        "outputs/volatility_book/ch_lognormal_sv_risk_premia/canonical_rerender"
+      ],
+      "package_adoption_verification": [
+        "python",
+        "-m",
+        "volatility_book.ch_lognormal_sv_risk_premia.verify_regime_sv_package_adoption"
+      ],
+      "manifest_json": [
+        "python",
+        "-m",
+        "json.tool",
+        "volatility_book/ch_lognormal_sv_risk_premia/acceptance_manifest.json"
+      ]
+    },
+    "payload_rerender_guard": {
+      "environment_variable": "STOCHVOLMODELS_REGIME_SV_FORBID_RECOMPUTE",
+      "guard_value": "1",
+      "contract": "When set to 1, any numerical-computation path fails immediately; --payload rendering must still succeed."
+    }
+  },
+  "output_contract": {
+    "default_root": "outputs/volatility_book/ch_lognormal_sv_risk_premia",
+    "profile_directories": {
+      "smoke": "outputs/volatility_book/ch_lognormal_sv_risk_premia/smoke",
+      "canonical": "outputs/volatility_book/ch_lognormal_sv_risk_premia/canonical"
+    },
+    "gitignore_rule": "/outputs/",
+    "generated_artifacts_are_tracked": false,
+    "network_or_licensed_inputs": false,
+    "artifact_manifest_paths_are_output_relative": true,
+    "artifacts_relative_to_profile_directory": [
+      {
+        "path": "numerical_payload.json",
+        "role": "machine-readable numerical source for every report artifact",
+        "required": true
+      },
+      {
+        "path": "artifact_manifest.json",
+        "role": "profile, provenance, payload hash, and output-relative artifact hashes",
+        "required": true
+      },
+      {
+        "path": "figures/regime_sv_smiles.pdf",
+        "role": "book figure",
+        "required": true
+      },
+      {
+        "path": "figures/regime_sv_smiles.png",
+        "role": "preview image",
+        "required": true
+      },
+      {
+        "path": "figures/regime_sv_premia.pdf",
+        "role": "book figure",
+        "required": true
+      },
+      {
+        "path": "figures/regime_sv_premia.png",
+        "role": "preview image",
+        "required": true
+      },
+      {
+        "path": "figures/regime_sv_closure_comparison.pdf",
+        "role": "book figure",
+        "required": true
+      },
+      {
+        "path": "figures/regime_sv_closure_comparison.png",
+        "role": "preview image",
+        "required": true
+      },
+      {
+        "path": "figures/regime_sv_validation.pdf",
+        "role": "book figure",
+        "required": true
+      },
+      {
+        "path": "figures/regime_sv_validation.png",
+        "role": "preview image",
+        "required": true
+      },
+      {
+        "path": "tables/regime_sv_closure_comparison_table.tex",
+        "role": "generated book table",
+        "required": true
+      },
+      {
+        "path": "tables/regime_sv_validation_table.tex",
+        "role": "generated book table",
+        "required": true
+      }
+    ]
+  },
+  "numerical_payload_schema": {
+    "schema_version": 1,
+    "required_properties": [
+      "schema_version",
+      "profile",
+      "records"
+    ],
+    "record_contract": {
+      "required_properties": [
+        "axes",
+        "shape",
+        "values"
+      ],
+      "shape_rule": "The product of shape equals the number of row-major values, and every axis length agrees with its named dimension.",
+      "number_rule": "All numerical values are finite JSON numbers; NaN and infinity are forbidden."
+    },
+    "separation_of_concerns": "Numerical computation writes numerical_payload.json once; rendering reads that payload and does not recompute analytics."
+  },
+  "grids": {
+    "smile_log_moneyness": {
+      "start": -0.3,
+      "end": 0.2,
+      "count": 31
+    },
+    "smile_maturities_years": [
+      0.08333333333333333,
+      0.25,
+      0.5,
+      1.0
+    ],
+    "risk_aversion_utility_powers": [
+      -0.75,
+      -0.5,
+      -0.25,
+      0.0
+    ],
+    "channel_attribution": {
+      "ttm": 0.25,
+      "initial_regime": "growth",
+      "equilibrium_closure": "log_linear",
+      "scenarios": {
+        "all_zero": [0.0, 0.0, 0.0, 0.0],
+        "diffusive_only": [1.0, 1.0, 0.0, 0.0],
+        "timing_only": [0.0, 0.0, 1.0, 0.0],
+        "tail_only": [0.0, 0.0, 0.0, 1.0],
+        "full": [1.0, 1.0, 1.0, 1.0]
+      }
+    },
+    "premia_sigma": {
+      "start": 0.08,
+      "end": 0.36,
+      "count": 180
+    },
+    "premia_utility_power": {
+      "start": -0.9,
+      "end": 0.2,
+      "count": 180
+    },
+    "closure_comparison_log_moneyness": {
+      "start": -0.3,
+      "end": 0.2,
+      "count": 31
+    },
+    "closure_comparison_maturities_years": [
+      0.08333333333333333,
+      0.25,
+      0.5,
+      1.0
+    ],
+    "validation_log_moneyness": {
+      "start": -0.3,
+      "end": 0.2,
+      "count": 16
+    },
+    "validation_ttm": 0.25,
+    "equilibrium_horizon": {
+      "start": 0.0,
+      "end": 3.0,
+      "count": 151,
+      "monte_carlo_points": [1.0, 3.0]
+    },
+    "fourier": {
+      "pricing_points": 1601,
+      "refinement_points": 3201,
+      "expansion": "SECOND",
+      "log_polynomial_degree": 4,
+      "martingale_roots": [0.0, -1.0]
+    }
+  },
+  "seeds": {
+    "package_q_monte_carlo": {
+      "growth": 1227,
+      "stress": 1229,
+      "rule": "The same state seed is used separately for each equilibrium closure."
+    },
+    "frozen_physical_feynman_kac": {
+      "growth_base": 1301,
+      "stress_base": 1303,
+      "rule": "seed = state_base + int(10 * horizon)",
+      "resolved": {
+        "growth_1y": 1311,
+        "growth_3y": 1331,
+        "stress_1y": 1313,
+        "stress_3y": 1333
+      }
+    },
+    "frozen_verifier_q_monte_carlo": {
+      "rule": "seed = 911 + regime_index + 100 * equilibrium_degree",
+      "coarse_growth_offset": 1000
+    },
+    "random_generator": "numpy.random.default_rng"
+  },
+  "tolerances": {
+    "paper_jump_means_absolute": 1e-14,
+    "paper_transition_intensities_absolute": 1e-14,
+    "single_regime_riccati_residual_absolute": 2e-9,
+    "frozen_volatility_matrix_absolute": 2e-10,
+    "degree_one_equilibrium_ode_absolute": 2e-14,
+    "quadratic_q_drift_identity_absolute": 2e-14,
+    "cubic_q_drift_coefficient_absolute": 2e-10,
+    "transform_martingale_roots_absolute": 2e-11,
+    "fourier_refinement_price_absolute": 5e-6,
+    "q_option_monte_carlo": "absolute_error <= 5 * standard_error + 1.5e-4",
+    "q_forward_martingale": "absolute_error <= 5 * standard_error + 5e-4",
+    "complex_mgf_monte_carlo": "absolute_error <= 5 * standard_error + 1e-3",
+    "q_time_step_refinement": "absolute_error <= 5 * hypot(coarse_standard_error, fine_standard_error) + 2e-4",
+    "physical_feynman_kac_log_linear": "absolute_error <= 5 * standard_error + 5e-3 * monte_carlo_value",
+    "physical_feynman_kac_log_quadratic": "absolute_error <= 5 * standard_error + 1.5e-3 * monte_carlo_value",
+    "channel_selected_ivol_percent": {
+      "relative": 1e-7,
+      "absolute": 5e-10
+    },
+    "channel_complex_log_mgf": {
+      "relative": 1e-7,
+      "absolute": 5e-12
+    }
+  },
+  "oracle_contract": {
+    "authority": "Frozen chapter monolith at frozen_chapter_snapshot, cross-checked by package tests introduced at package_channel_scale_extension.",
+    "panel_c": {
+      "vector_count": 31,
+      "selected_indices": [0, 6, 12, 18, 24, 30],
+      "selected_log_moneyness": [-0.3, -0.2, -0.1, 0.0, 0.1, 0.2],
+      "canonical_hash_recipe": "SHA-256 of ASCII JSON containing the 31 values formatted as .15e strings, in grid order, with separators comma and colon and no terminal newline.",
+      "raw_hash_recipe": "SHA-256 of the C-contiguous little-endian float64 vector bytes.",
+      "complex_transform_probe": "phi = -0.5 + 2j; values are ordered growth then stress.",
+      "scenarios": {
+        "all_zero": {
+          "scales": [0.0, 0.0, 0.0, 0.0],
+          "selected_ivols_percent": [34.799145449632, 28.762816043292, 22.534731212228, 16.242068479341, 10.58290254489, 13.592731914187],
+          "ivols_decimal15_json_sha256": "9ce299dedf09e0b8caa4d7450f5ef0d9b19c903056a74fc0cd071ce5b91c93af",
+          "prices_decimal15_json_sha256": "cb738649e65aa14ca64c5b499d75fed7df0f962219e6bc89121d73c26f22ba39",
+          "ivols_raw_le_f8_sha256": "86a5361a8b590eed602c341e036bb4b390e97a08ad55516ebe4c8a1dbc295506",
+          "prices_raw_le_f8_sha256": "bcf74578418c2ada8fe82d39348805c66ee1a0cb08bbe647125205ad5035827c",
+          "complex_log_mgf": [[-0.019344416231497248, -0.004650502361071163], [-0.03751125270880886, 0.0020582735401356088]]
+        },
+        "diffusive_only": {
+          "scales": [1.0, 1.0, 0.0, 0.0],
+          "selected_ivols_percent": [35.1919131501, 29.27126440958, 23.089002999124, 16.712030832712, 10.913737351373, 13.605481975684],
+          "ivols_decimal15_json_sha256": "b834f2b13326db225bcb450d17efcccabe3a29e4a6ab2daafef5b7e6f67746ef",
+          "prices_decimal15_json_sha256": "665c5b7f76f5ad591157f208110182c2123e98238449f9a41bca14e64a0ba0de",
+          "ivols_raw_le_f8_sha256": "78067a9bbe08f3399d970a98655f140d0f825b781eb9a9d2303b92a8adc3ca26",
+          "prices_raw_le_f8_sha256": "36769d07fe1874c6bdc7359a32ee86cb530d59d9ba159b3e8cd9b97efd9f64ab",
+          "complex_log_mgf": [[-0.02038517727598558, -0.0048845276238280505], [-0.03909450899480648, 0.001638838458468522]]
+        },
+        "timing_only": {
+          "scales": [0.0, 0.0, 1.0, 0.0],
+          "selected_ivols_percent": [34.799446638392, 28.763167873213, 22.535123687118, 16.242473551049, 10.583168808267, 13.592785371068],
+          "ivols_decimal15_json_sha256": "b123afba60f72dfd2ddda4fd7faebb886277ed25ea6c9861a61ef41cdb1c0093",
+          "prices_decimal15_json_sha256": "51f4cc3e70c00f10463558eb22ce46f3b98ae4d480ac17867aa03c602e0f3a44",
+          "ivols_raw_le_f8_sha256": "13d2c1892772c7235b50b7b205463cd4eff84c65dd790c503463e5f82c0fe473",
+          "prices_raw_le_f8_sha256": "96ed665515baeac72669013e9cadcc739e44c418dae8d5972a706e6338af52a6",
+          "complex_log_mgf": [[-0.01934522939884087, -0.004650684817072648], [-0.03751212788443771, 0.002057660901379376]]
+        },
+        "tail_only": {
+          "scales": [0.0, 0.0, 0.0, 1.0],
+          "selected_ivols_percent": [47.176385634239, 38.563317155283, 29.472817366671, 20.385313375699, 12.446937125298, 13.021095772689],
+          "ivols_decimal15_json_sha256": "2f2264ed1a791f3017644b466d5fc510393e41e4fa424d13bec92392259c6f56",
+          "prices_decimal15_json_sha256": "85e52ac0d7bc6c6ff771362a8bb1a54ad4cfbb08c333ca30d4962d5e03a69453",
+          "ivols_raw_le_f8_sha256": "dedce4cbfe6ace3cd1423dde3e6e8144ddab60a6b7423776d4d7a2ca63e578ec",
+          "prices_raw_le_f8_sha256": "92ce2a81512b3a417220faaa03a56f2fd956d18f191d83aab9bb0733d825e274",
+          "complex_log_mgf": [[-0.03486054914022379, -0.022361192892172848], [-0.031762131135938995, -0.0015712614346930682]]
+        },
+        "full": {
+          "scales": [1.0, 1.0, 1.0, 1.0],
+          "selected_ivols_percent": [47.359678403215, 38.863951473492, 29.906520899408, 20.859939639867, 12.828313462224, 13.043665846078],
+          "ivols_decimal15_json_sha256": "585a0c1dc2160886b0205eedd8b64c589d5be655e7d58c8e3d4b292b18ec57d9",
+          "prices_decimal15_json_sha256": "b7233bb8ed8fcda4748b37d60208fd4f0f199c4e01485943b8bea96fb35afe4c",
+          "ivols_raw_le_f8_sha256": "cd835e7bb882d09e7c189996971e2891b35353edebcbdb6deb36645bb3b03b21",
+          "prices_raw_le_f8_sha256": "e75d3248eb63720d55d89e546f1618521d1fe909c92cc06805b87aa58d98b741",
+          "complex_log_mgf": [[-0.035904056514211774, -0.02259830761030641], [-0.033356228072906245, -0.001990430276935223]]
+        }
+      },
+      "transform_roots": {
+        "phi": [0.0, -1.0],
+        "expected_log_mgf": [0.0, 0.0],
+        "applies_to_every_scenario_and_initial_regime": true,
+        "absolute_tolerance": 2e-11
+      }
+    }
+  },
+  "stable_hash_policy": {
+    "raw_pdf_or_png_sha256_is_a_portable_numerical_golden": false,
+    "reason": "PDF metadata, renderer versions, fonts, and raster encoders may vary without changing numerical results.",
+    "portable_numerical_goldens": [
+      "oracle_contract.panel_c selected vectors",
+      "oracle_contract.panel_c decimal15 JSON hashes",
+      "oracle_contract.panel_c complex transform probes",
+      "transform roots and declared numerical tolerances"
+    ],
+    "run_specific_artifact_hashes": "artifact_manifest.json records the actual payload, figure, and table hashes for one execution."
+  },
+  "scope": {
+    "package_production_analytics": [
+      "stochvolmodels.models.regime_logsv",
+      "stochvolmodels.models.regime_logsv_simulation",
+      "stochvolmodels.pricers.regime_switch_logsv_pricer"
+    ],
+    "package_api_status": "provisional deep-module production analytics",
+    "frozen_oracle_boundary": "The frozen monolith and verifier remain independent chapter oracles; they are not the production pricing path.",
+    "channel_scale_boundary": "Non-unit channel scales are analytic non-equilibrium diagnostics. Package Q Monte Carlo remains the consistently induced full-equilibrium measure.",
+    "excluded": [
+      "Student-t terminal-distribution work completed in T2",
+      "the untracked valuation-under-SV and Hawkes verification scripts named by historical comments",
+      "empirical calibration or external market-data acquisition",
+      "JOSS timing or submission work",
+      "tracked generated figures, tables, payloads, or PDFs"
+    ]
+  }
+}

--- a/volatility_book/ch_lognormal_sv_risk_premia/generate_regime_sv_figures.py
+++ b/volatility_book/ch_lognormal_sv_risk_premia/generate_regime_sv_figures.py
@@ -1,0 +1,639 @@
+"""Generate the regime-switching LogSV report figures and validation table."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib
+import numpy as np
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+from regime_switch_logsv import (
+    GROWTH,
+    STRESS,
+    RegimeSwitchLogSvParams,
+    RiskPremiaScales,
+    mc_price_slice,
+    price_slice,
+    risk_neutral_state,
+    simulate_equilibrium_feynman_kac,
+    simulate_terminal_q,
+    solve_equilibrium,
+)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+NOTES_DIR = SCRIPT_DIR / "notes"
+FIGURE_DIR = NOTES_DIR / "figures"
+
+COLORS = {
+    "blue": "#3264A8",
+    "red": "#C43C39",
+    "green": "#2A8C62",
+    "gold": "#D19A2A",
+    "purple": "#7A5AA6",
+    "gray": "#6F7782",
+    "black": "#222222",
+}
+
+
+def _setup_style() -> None:
+    plt.rcParams.update(
+        {
+            "figure.figsize": (10.5, 7.2),
+            "font.size": 10,
+            "axes.titlesize": 11,
+            "axes.labelsize": 10,
+            "legend.fontsize": 8.5,
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+            "axes.grid": True,
+            "grid.alpha": 0.22,
+            "grid.linewidth": 0.6,
+            "lines.linewidth": 2.0,
+            "savefig.bbox": "tight",
+        }
+    )
+
+
+def _save_figure(figure: plt.Figure, stem: str) -> None:
+    FIGURE_DIR.mkdir(parents=True, exist_ok=True)
+    figure.savefig(FIGURE_DIR / f"{stem}.pdf")
+    figure.savefig(FIGURE_DIR / f"{stem}.png", dpi=220)
+    plt.close(figure)
+
+
+def _smile(
+    params: RegimeSwitchLogSvParams,
+    ttm: float,
+    log_moneyness: np.ndarray,
+    *,
+    scales: RiskPremiaScales = RiskPremiaScales(),
+    equilibrium_degree: int = 1,
+) -> np.ndarray:
+    equilibrium = solve_equilibrium(params, degree=equilibrium_degree)
+    strikes = np.exp(log_moneyness)
+    optiontypes = np.where(strikes < 1.0, "P", "C")
+    return price_slice(
+        params,
+        equilibrium,
+        ttm,
+        strikes,
+        optiontypes=optiontypes,
+        scales=scales,
+        degree=4,
+        max_phi=1_601,
+    ).implied_vols
+
+
+def make_smile_figure() -> None:
+    log_moneyness = np.linspace(-0.30, 0.20, 31)
+    baseline = RegimeSwitchLogSvParams.equity_baseline(
+        gamma=-0.5, initial_regime=GROWTH, agent_horizon=3.0
+    )
+    figure, axes = plt.subplots(2, 2, figsize=(10.5, 7.2), sharex=True)
+
+    maturity_colors = [COLORS["purple"], COLORS["blue"], COLORS["green"], COLORS["gold"]]
+    for ttm, label, color in zip(
+        (1.0 / 12.0, 0.25, 0.5, 1.0),
+        ("1 month", "3 months", "6 months", "1 year"),
+        maturity_colors,
+    ):
+        axes[0, 0].plot(
+            log_moneyness,
+            100.0 * _smile(baseline, ttm, log_moneyness),
+            label=label,
+            color=color,
+        )
+    axes[0, 0].set_title("A. Equilibrium smile term structure")
+    axes[0, 0].set_ylabel("Black implied volatility (%)")
+    axes[0, 0].legend()
+
+    gamma_colors = [COLORS["red"], COLORS["purple"], COLORS["blue"], COLORS["green"]]
+    for gamma, color in zip((-0.75, -0.5, -0.25, 0.0), gamma_colors):
+        params = RegimeSwitchLogSvParams.equity_baseline(
+            gamma=gamma, initial_regime=GROWTH, agent_horizon=3.0
+        )
+        axes[0, 1].plot(
+            log_moneyness,
+            100.0 * _smile(params, 0.25, log_moneyness),
+            label=rf"$1-\gamma={1.0 - gamma:.2f}$",
+            color=color,
+        )
+    axes[0, 1].set_title("B. Risk-aversion sensitivity, 3 months")
+    axes[0, 1].legend()
+
+    channel_specs = (
+        (
+            "Reference P channels",
+            RiskPremiaScales(0.0, 0.0, 0.0, 0.0),
+            COLORS["gray"],
+            "--",
+        ),
+        (
+            "Diffusive only",
+            RiskPremiaScales(1.0, 1.0, 0.0, 0.0),
+            COLORS["blue"],
+            "-",
+        ),
+        (
+            "Timing only",
+            RiskPremiaScales(0.0, 0.0, 1.0, 0.0),
+            COLORS["green"],
+            "-",
+        ),
+        (
+            "Tail tilt only",
+            RiskPremiaScales(0.0, 0.0, 0.0, 1.0),
+            COLORS["red"],
+            "-",
+        ),
+        ("Full equilibrium", RiskPremiaScales(), COLORS["black"], "-"),
+    )
+    for label, scales, color, linestyle in channel_specs:
+        axes[1, 0].plot(
+            log_moneyness,
+            100.0 * _smile(baseline, 0.25, log_moneyness, scales=scales),
+            label=label,
+            color=color,
+            linestyle=linestyle,
+        )
+    axes[1, 0].set_title("C. Risk-premium channel attribution, 3 months")
+    axes[1, 0].set_xlabel(r"Log-moneyness $\log(K/F)$")
+    axes[1, 0].set_ylabel("Black implied volatility (%)")
+    axes[1, 0].legend()
+
+    for regime, label, color in (
+        (GROWTH, "Initial growth regime", COLORS["blue"]),
+        (STRESS, "Initial stress regime", COLORS["red"]),
+    ):
+        params = RegimeSwitchLogSvParams.equity_baseline(
+            gamma=-0.5, initial_regime=regime, agent_horizon=3.0
+        )
+        axes[1, 1].plot(
+            log_moneyness,
+            100.0 * _smile(params, 0.25, log_moneyness),
+            label=label,
+            color=color,
+        )
+    axes[1, 1].set_title("D. Initial-regime dependence, 3 months")
+    axes[1, 1].set_xlabel(r"Log-moneyness $\log(K/F)$")
+    axes[1, 1].legend()
+
+    figure.suptitle(
+        "Quadratic-preserving regime-switching LogSV implied-volatility skews",
+        y=1.01,
+        fontsize=13,
+    )
+    figure.tight_layout()
+    _save_figure(figure, "regime_sv_smiles")
+
+
+def make_premia_figure() -> None:
+    params = RegimeSwitchLogSvParams.equity_baseline(
+        gamma=-0.5, initial_regime=GROWTH, agent_horizon=3.0
+    )
+    quadratic_equilibrium = solve_equilibrium(params, degree=1)
+    cubic_equilibrium = solve_equilibrium(params, degree=2)
+    sigma_grid = np.linspace(0.08, 0.36, 180)
+    figure, axes = plt.subplots(2, 2, figsize=(10.5, 7.2))
+
+    for regime, label, color in (
+        (GROWTH, r"Crash $1\to2$", COLORS["red"]),
+        (STRESS, r"Recovery $2\to1$", COLORS["blue"]),
+    ):
+        _, intensity, _, _, _, _ = risk_neutral_state(
+            params, quadratic_equilibrium, params.agent_horizon, sigma_grid, regime
+        )
+        axes[0, 0].plot(sigma_grid, intensity, label=rf"$\mathbb{{Q}}$: {label}", color=color)
+        axes[0, 0].axhline(
+            params.transition_intensities[regime],
+            color=color,
+            linestyle="--",
+            alpha=0.65,
+            label=rf"$\mathbb{{P}}$: {label}",
+        )
+    axes[0, 0].set_title("A. State-dependent transition intensities")
+    axes[0, 0].set_xlabel(r"Instantaneous volatility $\sigma$")
+    axes[0, 0].set_ylabel("Annual transition intensity")
+    axes[0, 0].legend(ncol=2)
+
+    gamma_grid = np.linspace(-0.9, 0.2, 180)
+    crash_means = []
+    recovery_means = []
+    for gamma in gamma_grid:
+        trial = RegimeSwitchLogSvParams.equity_baseline(gamma=gamma, agent_horizon=3.0)
+        tilt = gamma - 1.0
+        for regime, output in ((GROWTH, crash_means), (STRESS, recovery_means)):
+            ell = trial.jump_mgf(regime, tilt)
+            output.append(trial.jump_mgf(regime, tilt + 1.0) / ell - 1.0)
+    axes[0, 1].plot(
+        1.0 - gamma_grid,
+        100.0 * np.asarray(crash_means),
+        label=r"Mean crash under $\mathbb{Q}$",
+        color=COLORS["red"],
+    )
+    axes[0, 1].plot(
+        1.0 - gamma_grid,
+        100.0 * np.asarray(recovery_means),
+        label=r"Mean recovery under $\mathbb{Q}$",
+        color=COLORS["blue"],
+    )
+    axes[0, 1].axhline(-25.0, color=COLORS["red"], linestyle="--", alpha=0.6)
+    axes[0, 1].axhline(15.0, color=COLORS["blue"], linestyle="--", alpha=0.6)
+    axes[0, 1].set_title("B. Esscher tail tilt from risk aversion")
+    axes[0, 1].set_xlabel(r"Relative risk aversion $1-\gamma$")
+    axes[0, 1].set_ylabel("Expected arithmetic transition jump (%)")
+    axes[0, 1].legend()
+
+    for regime, label, color in (
+        (GROWTH, "Growth", COLORS["blue"]),
+        (STRESS, "Stress", COLORS["red"]),
+    ):
+        quadratic_drift, _, _, _, _, _ = risk_neutral_state(
+            params, quadratic_equilibrium, params.agent_horizon, sigma_grid, regime
+        )
+        cubic_drift, _, _, _, _, _ = risk_neutral_state(
+            params, cubic_equilibrium, params.agent_horizon, sigma_grid, regime
+        )
+        spec = params.regimes[regime]
+        physical = (spec.kappa1 + spec.kappa2 * sigma_grid) * (spec.theta - sigma_grid)
+        axes[1, 0].plot(
+            sigma_grid,
+            quadratic_drift,
+            color=color,
+            label=rf"Quadratic $\mathbb{{Q}}$, {label.lower()}",
+        )
+        axes[1, 0].plot(
+            sigma_grid,
+            cubic_drift,
+            color=color,
+            linestyle=":",
+            label=rf"Full cubic $\mathbb{{Q}}$, {label.lower()}",
+        )
+        axes[1, 0].plot(
+            sigma_grid,
+            physical,
+            color=color,
+            linestyle="--",
+            alpha=0.55,
+            label=rf"$\mathbb{{P}}$, {label.lower()}",
+        )
+    axes[1, 0].axhline(0.0, color=COLORS["gray"], linewidth=0.8)
+    axes[1, 0].set_title("C. Consistent quadratic and full-cubic Q drifts")
+    axes[1, 0].set_xlabel(r"Instantaneous volatility $\sigma$")
+    axes[1, 0].set_ylabel(r"Drift $b(\sigma)$")
+    axes[1, 0].legend(ncol=2)
+
+    ratio_axis = axes[1, 1].twinx()
+    for regime, label, color in (
+        (GROWTH, "Growth loading", COLORS["blue"]),
+        (STRESS, "Stress loading", COLORS["red"]),
+    ):
+        _, _, _, _, loading, log_ratio = risk_neutral_state(
+            params, quadratic_equilibrium, params.agent_horizon, sigma_grid, regime
+        )
+        axes[1, 1].plot(sigma_grid, loading, color=color, label=label)
+        ratio_axis.plot(
+            sigma_grid,
+            10_000.0 * log_ratio,
+            color=color,
+            linestyle="--",
+            label=rf"$\log(g_j/g_i)$, {label.split()[0].lower()}",
+        )
+    axes[1, 1].axhline(0.0, color=COLORS["gray"], linewidth=0.8)
+    axes[1, 1].set_title("D. Continuous and discrete value loadings")
+    axes[1, 1].set_xlabel(r"Instantaneous volatility $\sigma$")
+    axes[1, 1].set_ylabel(r"Continuous loading $\psi_i$")
+    ratio_axis.set_ylabel(r"Discrete loading $10^4\log(g_j/g_i)$")
+    ratio_axis.grid(False)
+    ratio_axis.spines["right"].set_visible(True)
+    handles, labels = axes[1, 1].get_legend_handles_labels()
+    extra_handles, extra_labels = ratio_axis.get_legend_handles_labels()
+    axes[1, 1].legend(handles + extra_handles, labels + extra_labels, ncol=2)
+
+    figure.suptitle(
+        "Equilibrium risk-premium mechanisms and drift closures", y=1.01, fontsize=13
+    )
+    figure.tight_layout()
+    _save_figure(figure, "regime_sv_premia")
+
+
+def _write_closure_comparison_table(
+    rows: list[tuple[str, str, float, float, float]],
+) -> None:
+    NOTES_DIR.mkdir(parents=True, exist_ok=True)
+    lines = [
+        r"\begin{tabular}{llrrr}",
+        r"\toprule",
+        (
+            r"Initial regime & Maturity & Quadratic skew (\%) & Cubic skew (\%) "
+            r"& Difference (vol bp) \\"
+        ),
+        r"\midrule",
+    ]
+    for regime, maturity, quadratic, cubic, difference in rows:
+        lines.append(
+            f"{regime} & {maturity} & {quadratic:.4f} & {cubic:.4f} & {difference:.3f} \\\\"
+        )
+    lines.extend([r"\bottomrule", r"\end{tabular}"])
+    (NOTES_DIR / "regime_sv_closure_comparison_table.tex").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8"
+    )
+
+
+def make_closure_comparison_figure() -> None:
+    """Compare two internally consistent equilibrium closures in implied volatility."""
+
+    log_moneyness = np.linspace(-0.30, 0.20, 31)
+    maturities = (
+        (1.0 / 12.0, "1 month", COLORS["purple"]),
+        (0.25, "3 months", COLORS["blue"]),
+        (0.5, "6 months", COLORS["green"]),
+        (1.0, "1 year", COLORS["gold"]),
+    )
+    figure, axes = plt.subplots(2, 2, figsize=(10.5, 7.2), sharex=True)
+    table_rows: list[tuple[str, str, float, float, float]] = []
+
+    for column, (regime, regime_label, regime_color) in enumerate(
+        (
+            (GROWTH, "Growth", COLORS["blue"]),
+            (STRESS, "Stress", COLORS["red"]),
+        )
+    ):
+        params = RegimeSwitchLogSvParams.equity_baseline(
+            gamma=-0.5, initial_regime=regime, agent_horizon=3.0
+        )
+        quadratic_3m = _smile(
+            params, 0.25, log_moneyness, equilibrium_degree=1
+        )
+        cubic_3m = _smile(params, 0.25, log_moneyness, equilibrium_degree=2)
+        axes[0, column].plot(
+            log_moneyness,
+            100.0 * quadratic_3m,
+            color=regime_color,
+            marker="o",
+            markevery=3,
+            markersize=3.5,
+            label="Log-linear equilibrium / quadratic Q",
+        )
+        axes[0, column].plot(
+            log_moneyness,
+            100.0 * cubic_3m,
+            color=COLORS["black"],
+            linestyle="--",
+            label="Log-quadratic equilibrium / full cubic Q",
+        )
+        axes[0, column].set_title(f"{chr(65 + column)}. {regime_label}: 3-month smiles")
+        axes[0, column].set_ylabel("Black implied volatility (%)")
+        axes[0, column].legend()
+
+        for ttm, maturity_label, color in maturities:
+            quadratic = _smile(
+                params, ttm, log_moneyness, equilibrium_degree=1
+            )
+            cubic = _smile(params, ttm, log_moneyness, equilibrium_degree=2)
+            difference_bp = 10_000.0 * (cubic - quadratic)
+            axes[1, column].plot(
+                log_moneyness,
+                difference_bp,
+                color=color,
+                label=maturity_label,
+            )
+            left_index = int(np.argmin(np.abs(log_moneyness + 0.20)))
+            right_index = int(np.argmin(np.abs(log_moneyness - 0.20)))
+            quadratic_skew = quadratic[left_index] - quadratic[right_index]
+            cubic_skew = cubic[left_index] - cubic[right_index]
+            table_rows.append(
+                (
+                    regime_label,
+                    maturity_label,
+                    100.0 * quadratic_skew,
+                    100.0 * cubic_skew,
+                    10_000.0 * (cubic_skew - quadratic_skew),
+                )
+            )
+        axes[1, column].axhline(0.0, color=COLORS["gray"], linewidth=0.8)
+        axes[1, column].set_title(
+            f"{chr(67 + column)}. {regime_label}: full cubic minus quadratic"
+        )
+        axes[1, column].set_xlabel(r"Log-moneyness $\log(K/F)$")
+        axes[1, column].set_ylabel("Implied-volatility difference (vol bp)")
+        axes[1, column].legend(ncol=2)
+
+    figure.suptitle(
+        "Implied-volatility skew: comparison of equilibrium closures", y=1.01, fontsize=13
+    )
+    figure.tight_layout()
+    _save_figure(figure, "regime_sv_closure_comparison")
+    _write_closure_comparison_table(table_rows)
+
+
+def _write_validation_table(rows: list[tuple[str, str, float, float, float]]) -> None:
+    NOTES_DIR.mkdir(parents=True, exist_ok=True)
+    lines = [
+        r"\begin{tabular}{llrrr}",
+        r"\toprule",
+        r"Check & Initial regime & Analytic & Monte Carlo & MC s.e. \\",
+        r"\midrule",
+    ]
+    for check, regime, analytic, monte_carlo, error in rows:
+        lines.append(f"{check} & {regime} & {analytic:.6f} & {monte_carlo:.6f} & {error:.6f} \\\\")
+    lines.extend([r"\bottomrule", r"\end{tabular}"])
+    (NOTES_DIR / "regime_sv_validation_table.tex").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8"
+    )
+
+
+def make_validation_figure(quick: bool) -> None:
+    n_paths = 35_000 if quick else 120_000
+    steps_per_year = 720 if quick else 1_440
+    ttm = 0.25
+    log_moneyness = np.linspace(-0.30, 0.20, 16)
+    strikes = np.exp(log_moneyness)
+    optiontypes = np.where(strikes < 1.0, "P", "C")
+    figure, axes = plt.subplots(2, 2, figsize=(10.5, 7.2))
+    table_rows: list[tuple[str, str, float, float, float]] = []
+
+    for column, (equilibrium_degree, closure_label, short_label) in enumerate(
+        (
+            (1, "Log-linear equilibrium / quadratic Q", "quadratic Q"),
+            (2, "Log-quadratic equilibrium / full cubic Q", "full cubic Q"),
+        )
+    ):
+        for regime, label, color, seed in (
+            (GROWTH, "Growth", COLORS["blue"], 1_227),
+            (STRESS, "Stress", COLORS["red"], 1_229),
+        ):
+            params = RegimeSwitchLogSvParams.equity_baseline(
+                gamma=-0.5, initial_regime=regime, agent_horizon=3.0
+            )
+            equilibrium = solve_equilibrium(params, degree=equilibrium_degree)
+            analytic = price_slice(
+                params,
+                equilibrium,
+                ttm,
+                strikes,
+                optiontypes=optiontypes,
+                degree=4,
+                max_phi=1_601,
+            )
+            sample = simulate_terminal_q(
+                params,
+                equilibrium,
+                ttm,
+                n_paths=n_paths,
+                steps_per_year=steps_per_year,
+                seed=seed,
+            )
+            monte_carlo, standard_errors, _ = mc_price_slice(
+                sample, params, ttm, strikes, optiontypes
+            )
+            axes[0, column].plot(
+                log_moneyness,
+                10_000.0 * analytic.prices,
+                color=color,
+                label=f"Analytic, {label.lower()}",
+            )
+            axes[0, column].errorbar(
+                log_moneyness,
+                10_000.0 * monte_carlo,
+                yerr=19_600.0 * standard_errors,
+                color=color,
+                fmt="o",
+                markersize=3.5,
+                capsize=2,
+                linestyle="none",
+                label=f"MC 95% CI, {label.lower()}",
+            )
+            martingale, martingale_error = sample.forward_martingale
+            table_rows.append(
+                (
+                    rf"$E^{{\mathbb{{Q}}}}[S_T/F_0]$, {short_label}",
+                    label,
+                    1.0,
+                    martingale,
+                    martingale_error,
+                )
+            )
+            atm = int(np.argmin(np.abs(strikes - 1.0)))
+            table_rows.append(
+                (
+                    f"3m near-ATM, {short_label}",
+                    label,
+                    analytic.prices[atm],
+                    monte_carlo[atm],
+                    standard_errors[atm],
+                )
+            )
+
+        axes[0, column].set_title(f"{chr(65 + column)}. {closure_label}")
+        axes[0, column].set_xlabel(r"Log-moneyness $\log(K/F)$")
+        axes[0, column].set_ylabel("OTM option price (bp of forward)")
+        axes[0, column].legend(ncol=2)
+
+    params = RegimeSwitchLogSvParams.equity_baseline(
+        gamma=-0.5, initial_regime=GROWTH, agent_horizon=3.0
+    )
+    equilibria = {
+        "Log-linear coefficient": solve_equilibrium(params, degree=1),
+        "Log-quadratic coefficient": solve_equilibrium(params, degree=2),
+    }
+    horizon_grid = np.linspace(0.0, 3.0, 151)
+    for column, (regime, label, seed) in enumerate(
+        (
+            (GROWTH, "Growth", 1_301),
+            (STRESS, "Stress", 1_303),
+        )
+    ):
+        sigma = params.regimes[regime].theta
+        for (coefficient_label, equilibrium), color, linestyle in zip(
+            equilibria.items(),
+            (COLORS["blue"], COLORS["black"]),
+            ("-", "--"),
+        ):
+            analytic_curve = np.exp(
+                [equilibrium.log_g_hat(horizon, sigma, regime) for horizon in horizon_grid]
+            )
+            axes[1, column].plot(
+                horizon_grid,
+                analytic_curve,
+                color=color,
+                linestyle=linestyle,
+                label=coefficient_label,
+            )
+        mc_horizons = np.array([1.0, 3.0])
+        mc_values = []
+        mc_errors = []
+        for horizon in mc_horizons:
+            value, error = simulate_equilibrium_feynman_kac(
+                params,
+                horizon,
+                sigma,
+                regime,
+                n_paths=n_paths,
+                steps_per_year=steps_per_year,
+                seed=seed + int(10 * horizon),
+            )
+            mc_values.append(value)
+            mc_errors.append(error)
+            if horizon == 3.0:
+                for coefficient_label, equilibrium in equilibria.items():
+                    analytic_value = np.exp(
+                        equilibrium.log_g_hat(horizon, sigma, regime)
+                    )
+                    table_rows.append(
+                        (
+                            f"$g(0,\\theta)$, 3y, {coefficient_label.split()[0].lower()}",
+                            label,
+                            analytic_value,
+                            value,
+                            error,
+                        )
+                    )
+        axes[1, column].errorbar(
+            mc_horizons,
+            mc_values,
+            yerr=1.96 * np.asarray(mc_errors),
+            color=COLORS["red"],
+            fmt="o",
+            capsize=3,
+            label="Physical-measure MC 95% CI",
+        )
+        axes[1, column].set_title(
+            f"{chr(67 + column)}. Equilibrium closures versus P Monte Carlo: {label.lower()}"
+        )
+        axes[1, column].set_xlabel("Representative-agent horizon (years)")
+        axes[1, column].set_ylabel(r"Risk-premium coefficient $\widehat g$")
+        axes[1, column].legend()
+
+    figure.suptitle("Independent Monte Carlo validation of both closures", y=1.01, fontsize=13)
+    figure.tight_layout()
+    _save_figure(figure, "regime_sv_validation")
+    _write_validation_table(table_rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--quick",
+        action="store_true",
+        help="use fewer Monte Carlo paths for the validation panel",
+    )
+    args = parser.parse_args()
+    _setup_style()
+    make_smile_figure()
+    make_premia_figure()
+    make_closure_comparison_figure()
+    make_validation_figure(args.quick)
+    print(f"Wrote report figures to {FIGURE_DIR}")
+    print(f"Wrote validation table to {NOTES_DIR / 'regime_sv_validation_table.tex'}")
+    print(
+        "Wrote closure comparison table to "
+        f"{NOTES_DIR / 'regime_sv_closure_comparison_table.tex'}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/volatility_book/ch_lognormal_sv_risk_premia/generate_regime_sv_figures.py
+++ b/volatility_book/ch_lognormal_sv_risk_premia/generate_regime_sv_figures.py
@@ -1,31 +1,21 @@
-"""Generate the regime-switching LogSV report figures and validation table."""
+"""Compute or rerender the package-owned regime-switching LogSV chapter artifacts."""
 
 from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from typing import Any, Sequence
 
 import matplotlib
 import numpy as np
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
-from regime_switch_logsv import (
-    GROWTH,
-    STRESS,
-    RegimeSwitchLogSvParams,
-    RiskPremiaScales,
-    mc_price_slice,
-    price_slice,
-    risk_neutral_state,
-    simulate_equilibrium_feynman_kac,
-    simulate_terminal_q,
-    solve_equilibrium,
-)
 
-SCRIPT_DIR = Path(__file__).resolve().parent
-NOTES_DIR = SCRIPT_DIR / "notes"
-FIGURE_DIR = NOTES_DIR / "figures"
+try:
+    from . import regime_sv_chapter as chapter
+except ImportError:  # pragma: no cover - direct script execution
+    import regime_sv_chapter as chapter
 
 COLORS = {
     "blue": "#3264A8",
@@ -57,104 +47,81 @@ def _setup_style() -> None:
     )
 
 
-def _save_figure(figure: plt.Figure, stem: str) -> None:
-    FIGURE_DIR.mkdir(parents=True, exist_ok=True)
-    figure.savefig(FIGURE_DIR / f"{stem}.pdf")
-    figure.savefig(FIGURE_DIR / f"{stem}.png", dpi=220)
+def _record(payload: dict[str, Any], name: str) -> dict[str, Any]:
+    try:
+        return payload["records"][name]
+    except KeyError as error:
+        raise ValueError(f"numerical payload is missing record {name!r}") from error
+
+
+def _save_figure(figure: plt.Figure, figure_dir: Path, stem: str) -> list[Path]:
+    figure_dir.mkdir(parents=True, exist_ok=True)
+    pdf_path = figure_dir / f"{stem}.pdf"
+    png_path = figure_dir / f"{stem}.png"
+    figure.savefig(pdf_path, metadata={"CreationDate": None, "ModDate": None})
+    figure.savefig(png_path, dpi=220, metadata={"Software": "stochvolmodels"})
     plt.close(figure)
+    return [pdf_path, png_path]
 
 
-def _smile(
-    params: RegimeSwitchLogSvParams,
-    ttm: float,
-    log_moneyness: np.ndarray,
-    *,
-    scales: RiskPremiaScales = RiskPremiaScales(),
-    equilibrium_degree: int = 1,
-) -> np.ndarray:
-    equilibrium = solve_equilibrium(params, degree=equilibrium_degree)
-    strikes = np.exp(log_moneyness)
-    optiontypes = np.where(strikes < 1.0, "P", "C")
-    return price_slice(
-        params,
-        equilibrium,
-        ttm,
-        strikes,
-        optiontypes=optiontypes,
-        scales=scales,
-        degree=4,
-        max_phi=1_601,
-    ).implied_vols
+def _render_smiles(payload: dict[str, Any], figure_dir: Path) -> list[Path]:
+    term_record = _record(payload, "smiles.term_structure_implied_volatility")
+    term = chapter.record_array(term_record)
+    log_moneyness = np.asarray(chapter.record_axis(term_record, "log_moneyness"))
 
+    risk_record = _record(payload, "smiles.risk_aversion_implied_volatility")
+    risk = chapter.record_array(risk_record)
+    utility_powers = chapter.record_axis(risk_record, "utility_power")
 
-def make_smile_figure() -> None:
-    log_moneyness = np.linspace(-0.30, 0.20, 31)
-    baseline = RegimeSwitchLogSvParams.equity_baseline(
-        gamma=-0.5, initial_regime=GROWTH, agent_horizon=3.0
-    )
+    channel_record = _record(payload, "smiles.channel_implied_volatility")
+    channels = chapter.record_array(channel_record)
+    channel_names = chapter.record_axis(channel_record, "scenario")
+
+    regime_record = _record(payload, "smiles.initial_regime_implied_volatility")
+    regimes = chapter.record_array(regime_record)
+
     figure, axes = plt.subplots(2, 2, figsize=(10.5, 7.2), sharex=True)
-
-    maturity_colors = [COLORS["purple"], COLORS["blue"], COLORS["green"], COLORS["gold"]]
-    for ttm, label, color in zip(
-        (1.0 / 12.0, 0.25, 0.5, 1.0),
-        ("1 month", "3 months", "6 months", "1 year"),
-        maturity_colors,
-    ):
-        axes[0, 0].plot(
-            log_moneyness,
-            100.0 * _smile(baseline, ttm, log_moneyness),
-            label=label,
-            color=color,
-        )
+    maturity_labels = ("1 month", "3 months", "6 months", "1 year")
+    maturity_colors = (
+        COLORS["purple"],
+        COLORS["blue"],
+        COLORS["green"],
+        COLORS["gold"],
+    )
+    for curve, label, color in zip(term, maturity_labels, maturity_colors):
+        axes[0, 0].plot(log_moneyness, 100.0 * curve, label=label, color=color)
     axes[0, 0].set_title("A. Equilibrium smile term structure")
     axes[0, 0].set_ylabel("Black implied volatility (%)")
     axes[0, 0].legend()
 
-    gamma_colors = [COLORS["red"], COLORS["purple"], COLORS["blue"], COLORS["green"]]
-    for gamma, color in zip((-0.75, -0.5, -0.25, 0.0), gamma_colors):
-        params = RegimeSwitchLogSvParams.equity_baseline(
-            gamma=gamma, initial_regime=GROWTH, agent_horizon=3.0
-        )
+    gamma_colors = (
+        COLORS["red"],
+        COLORS["purple"],
+        COLORS["blue"],
+        COLORS["green"],
+    )
+    for utility_power, curve, color in zip(utility_powers, risk[:, 0], gamma_colors):
         axes[0, 1].plot(
             log_moneyness,
-            100.0 * _smile(params, 0.25, log_moneyness),
-            label=rf"$1-\gamma={1.0 - gamma:.2f}$",
+            100.0 * curve,
+            label=rf"$1-\gamma={1.0 - float(utility_power):.2f}$",
             color=color,
         )
     axes[0, 1].set_title("B. Risk-aversion sensitivity, 3 months")
     axes[0, 1].legend()
 
-    channel_specs = (
-        (
-            "Reference P channels",
-            RiskPremiaScales(0.0, 0.0, 0.0, 0.0),
-            COLORS["gray"],
-            "--",
-        ),
-        (
-            "Diffusive only",
-            RiskPremiaScales(1.0, 1.0, 0.0, 0.0),
-            COLORS["blue"],
-            "-",
-        ),
-        (
-            "Timing only",
-            RiskPremiaScales(0.0, 0.0, 1.0, 0.0),
-            COLORS["green"],
-            "-",
-        ),
-        (
-            "Tail tilt only",
-            RiskPremiaScales(0.0, 0.0, 0.0, 1.0),
-            COLORS["red"],
-            "-",
-        ),
-        ("Full equilibrium", RiskPremiaScales(), COLORS["black"], "-"),
-    )
-    for label, scales, color, linestyle in channel_specs:
+    channel_styles = {
+        "all_zero": ("Zero-premium reference", COLORS["gray"], "--"),
+        "diffusive_only": ("Diffusive only", COLORS["blue"], "-"),
+        "timing_only": ("Timing only", COLORS["green"], "-"),
+        "tail_only": ("Tail tilt only", COLORS["red"], "-"),
+        "full": ("Full equilibrium", COLORS["black"], "-"),
+    }
+    for name, curve in zip(channel_names, channels[:, 0]):
+        label, color, linestyle = channel_styles[str(name)]
         axes[1, 0].plot(
             log_moneyness,
-            100.0 * _smile(baseline, 0.25, log_moneyness, scales=scales),
+            100.0 * curve,
             label=label,
             color=color,
             linestyle=linestyle,
@@ -164,19 +131,11 @@ def make_smile_figure() -> None:
     axes[1, 0].set_ylabel("Black implied volatility (%)")
     axes[1, 0].legend()
 
-    for regime, label, color in (
-        (GROWTH, "Initial growth regime", COLORS["blue"]),
-        (STRESS, "Initial stress regime", COLORS["red"]),
+    for curve, label, color in (
+        (regimes[0], "Initial growth regime", COLORS["blue"]),
+        (regimes[1], "Initial stress regime", COLORS["red"]),
     ):
-        params = RegimeSwitchLogSvParams.equity_baseline(
-            gamma=-0.5, initial_regime=regime, agent_horizon=3.0
-        )
-        axes[1, 1].plot(
-            log_moneyness,
-            100.0 * _smile(params, 0.25, log_moneyness),
-            label=label,
-            color=color,
-        )
+        axes[1, 1].plot(log_moneyness, 100.0 * curve, label=label, color=color)
     axes[1, 1].set_title("D. Initial-regime dependence, 3 months")
     axes[1, 1].set_xlabel(r"Log-moneyness $\log(K/F)$")
     axes[1, 1].legend()
@@ -187,28 +146,43 @@ def make_smile_figure() -> None:
         fontsize=13,
     )
     figure.tight_layout()
-    _save_figure(figure, "regime_sv_smiles")
+    return _save_figure(figure, figure_dir, "regime_sv_smiles")
 
 
-def make_premia_figure() -> None:
-    params = RegimeSwitchLogSvParams.equity_baseline(
-        gamma=-0.5, initial_regime=GROWTH, agent_horizon=3.0
+def _render_premia(payload: dict[str, Any], figure_dir: Path) -> list[Path]:
+    intensity_record = _record(payload, "premia.transition_intensity")
+    intensity = chapter.record_array(intensity_record)
+    sigma = np.asarray(chapter.record_axis(intensity_record, "sigma"))
+    physical_intensity = chapter.record_array(
+        _record(payload, "premia.physical_transition_intensity")
     )
-    quadratic_equilibrium = solve_equilibrium(params, degree=1)
-    cubic_equilibrium = solve_equilibrium(params, degree=2)
-    sigma_grid = np.linspace(0.08, 0.36, 180)
-    figure, axes = plt.subplots(2, 2, figsize=(10.5, 7.2))
 
-    for regime, label, color in (
-        (GROWTH, r"Crash $1\to2$", COLORS["red"]),
-        (STRESS, r"Recovery $2\to1$", COLORS["blue"]),
-    ):
-        _, intensity, _, _, _, _ = risk_neutral_state(
-            params, quadratic_equilibrium, params.agent_horizon, sigma_grid, regime
+    jump_record = _record(payload, "premia.jump_arithmetic_mean")
+    jump_mean = chapter.record_array(jump_record)
+    utility_power = np.asarray(chapter.record_axis(jump_record, "utility_power"))
+    physical_jump_mean = chapter.record_array(
+        _record(payload, "premia.physical_jump_arithmetic_mean")
+    )
+
+    q_drift = chapter.record_array(_record(payload, "premia.risk_neutral_drift"))
+    p_drift = chapter.record_array(_record(payload, "premia.physical_drift"))
+    loading = chapter.record_array(_record(payload, "premia.volatility_loading"))
+    log_ratio = chapter.record_array(_record(payload, "premia.log_timing_ratio"))
+
+    figure, axes = plt.subplots(2, 2, figsize=(10.5, 7.2))
+    transition_specs = (
+        (0, r"Crash $1\to2$", COLORS["red"]),
+        (1, r"Recovery $2\to1$", COLORS["blue"]),
+    )
+    for regime, label, color in transition_specs:
+        axes[0, 0].plot(
+            sigma,
+            intensity[regime],
+            label=rf"$\mathbb{{Q}}$: {label}",
+            color=color,
         )
-        axes[0, 0].plot(sigma_grid, intensity, label=rf"$\mathbb{{Q}}$: {label}", color=color)
         axes[0, 0].axhline(
-            params.transition_intensities[regime],
+            physical_intensity[regime],
             color=color,
             linestyle="--",
             alpha=0.65,
@@ -219,62 +193,55 @@ def make_premia_figure() -> None:
     axes[0, 0].set_ylabel("Annual transition intensity")
     axes[0, 0].legend(ncol=2)
 
-    gamma_grid = np.linspace(-0.9, 0.2, 180)
-    crash_means = []
-    recovery_means = []
-    for gamma in gamma_grid:
-        trial = RegimeSwitchLogSvParams.equity_baseline(gamma=gamma, agent_horizon=3.0)
-        tilt = gamma - 1.0
-        for regime, output in ((GROWTH, crash_means), (STRESS, recovery_means)):
-            ell = trial.jump_mgf(regime, tilt)
-            output.append(trial.jump_mgf(regime, tilt + 1.0) / ell - 1.0)
     axes[0, 1].plot(
-        1.0 - gamma_grid,
-        100.0 * np.asarray(crash_means),
+        1.0 - utility_power,
+        100.0 * jump_mean[0],
         label=r"Mean crash under $\mathbb{Q}$",
         color=COLORS["red"],
     )
     axes[0, 1].plot(
-        1.0 - gamma_grid,
-        100.0 * np.asarray(recovery_means),
+        1.0 - utility_power,
+        100.0 * jump_mean[1],
         label=r"Mean recovery under $\mathbb{Q}$",
         color=COLORS["blue"],
     )
-    axes[0, 1].axhline(-25.0, color=COLORS["red"], linestyle="--", alpha=0.6)
-    axes[0, 1].axhline(15.0, color=COLORS["blue"], linestyle="--", alpha=0.6)
+    axes[0, 1].axhline(
+        100.0 * physical_jump_mean[0],
+        color=COLORS["red"],
+        linestyle="--",
+        alpha=0.6,
+    )
+    axes[0, 1].axhline(
+        100.0 * physical_jump_mean[1],
+        color=COLORS["blue"],
+        linestyle="--",
+        alpha=0.6,
+    )
     axes[0, 1].set_title("B. Esscher tail tilt from risk aversion")
     axes[0, 1].set_xlabel(r"Relative risk aversion $1-\gamma$")
     axes[0, 1].set_ylabel("Expected arithmetic transition jump (%)")
     axes[0, 1].legend()
 
     for regime, label, color in (
-        (GROWTH, "Growth", COLORS["blue"]),
-        (STRESS, "Stress", COLORS["red"]),
+        (0, "Growth", COLORS["blue"]),
+        (1, "Stress", COLORS["red"]),
     ):
-        quadratic_drift, _, _, _, _, _ = risk_neutral_state(
-            params, quadratic_equilibrium, params.agent_horizon, sigma_grid, regime
-        )
-        cubic_drift, _, _, _, _, _ = risk_neutral_state(
-            params, cubic_equilibrium, params.agent_horizon, sigma_grid, regime
-        )
-        spec = params.regimes[regime]
-        physical = (spec.kappa1 + spec.kappa2 * sigma_grid) * (spec.theta - sigma_grid)
         axes[1, 0].plot(
-            sigma_grid,
-            quadratic_drift,
+            sigma,
+            q_drift[0, regime],
             color=color,
             label=rf"Quadratic $\mathbb{{Q}}$, {label.lower()}",
         )
         axes[1, 0].plot(
-            sigma_grid,
-            cubic_drift,
+            sigma,
+            q_drift[1, regime],
             color=color,
             linestyle=":",
             label=rf"Full cubic $\mathbb{{Q}}$, {label.lower()}",
         )
         axes[1, 0].plot(
-            sigma_grid,
-            physical,
+            sigma,
+            p_drift[regime],
             color=color,
             linestyle="--",
             alpha=0.55,
@@ -288,16 +255,13 @@ def make_premia_figure() -> None:
 
     ratio_axis = axes[1, 1].twinx()
     for regime, label, color in (
-        (GROWTH, "Growth loading", COLORS["blue"]),
-        (STRESS, "Stress loading", COLORS["red"]),
+        (0, "Growth loading", COLORS["blue"]),
+        (1, "Stress loading", COLORS["red"]),
     ):
-        _, _, _, _, loading, log_ratio = risk_neutral_state(
-            params, quadratic_equilibrium, params.agent_horizon, sigma_grid, regime
-        )
-        axes[1, 1].plot(sigma_grid, loading, color=color, label=label)
+        axes[1, 1].plot(sigma, loading[regime], color=color, label=label)
         ratio_axis.plot(
-            sigma_grid,
-            10_000.0 * log_ratio,
+            sigma,
+            10_000.0 * log_ratio[regime],
             color=color,
             linestyle="--",
             label=rf"$\log(g_j/g_i)$, {label.split()[0].lower()}",
@@ -314,16 +278,155 @@ def make_premia_figure() -> None:
     axes[1, 1].legend(handles + extra_handles, labels + extra_labels, ncol=2)
 
     figure.suptitle(
-        "Equilibrium risk-premium mechanisms and drift closures", y=1.01, fontsize=13
+        "Equilibrium risk-premium mechanisms and drift closures",
+        y=1.01,
+        fontsize=13,
     )
     figure.tight_layout()
-    _save_figure(figure, "regime_sv_premia")
+    return _save_figure(figure, figure_dir, "regime_sv_premia")
 
 
-def _write_closure_comparison_table(
-    rows: list[tuple[str, str, float, float, float]],
-) -> None:
-    NOTES_DIR.mkdir(parents=True, exist_ok=True)
+def _render_closure_comparison(payload: dict[str, Any], figure_dir: Path) -> list[Path]:
+    iv_record = _record(payload, "closure.implied_volatility")
+    ivols = chapter.record_array(iv_record)
+    log_moneyness = np.asarray(chapter.record_axis(iv_record, "log_moneyness"))
+    maturities = chapter.record_axis(iv_record, "maturity_years")
+    difference = chapter.record_array(_record(payload, "closure.implied_volatility_difference_bp"))
+    maturity_3m = int(np.flatnonzero(np.isclose(maturities, 0.25))[0])
+    maturity_labels = ("1 month", "3 months", "6 months", "1 year")
+    maturity_colors = (
+        COLORS["purple"],
+        COLORS["blue"],
+        COLORS["green"],
+        COLORS["gold"],
+    )
+
+    figure, axes = plt.subplots(2, 2, figsize=(10.5, 7.2), sharex=True)
+    for column, (regime_label, regime_color) in enumerate(
+        (("Growth", COLORS["blue"]), ("Stress", COLORS["red"]))
+    ):
+        axes[0, column].plot(
+            log_moneyness,
+            100.0 * ivols[0, column, maturity_3m],
+            color=regime_color,
+            marker="o",
+            markevery=3,
+            markersize=3.5,
+            label="Log-linear equilibrium / quadratic Q",
+        )
+        axes[0, column].plot(
+            log_moneyness,
+            100.0 * ivols[1, column, maturity_3m],
+            color=COLORS["black"],
+            linestyle="--",
+            label="Log-quadratic equilibrium / full cubic Q",
+        )
+        axes[0, column].set_title(f"{chr(65 + column)}. {regime_label}: 3-month smiles")
+        axes[0, column].set_ylabel("Black implied volatility (%)")
+        axes[0, column].legend()
+
+        for curve, label, color in zip(difference[column], maturity_labels, maturity_colors):
+            axes[1, column].plot(log_moneyness, curve, color=color, label=label)
+        axes[1, column].axhline(0.0, color=COLORS["gray"], linewidth=0.8)
+        axes[1, column].set_title(f"{chr(67 + column)}. {regime_label}: full cubic minus quadratic")
+        axes[1, column].set_xlabel(r"Log-moneyness $\log(K/F)$")
+        axes[1, column].set_ylabel("Implied-volatility difference (vol bp)")
+        axes[1, column].legend(ncol=2)
+
+    figure.suptitle(
+        "Implied-volatility skew: comparison of equilibrium closures",
+        y=1.01,
+        fontsize=13,
+    )
+    figure.tight_layout()
+    return _save_figure(figure, figure_dir, "regime_sv_closure_comparison")
+
+
+def _render_validation(payload: dict[str, Any], figure_dir: Path) -> list[Path]:
+    analytic_record = _record(payload, "validation.analytic_prices")
+    analytic = chapter.record_array(analytic_record)
+    log_moneyness = np.asarray(chapter.record_axis(analytic_record, "log_moneyness"))
+    monte_carlo = chapter.record_array(_record(payload, "validation.mc_prices"))
+    errors = chapter.record_array(_record(payload, "validation.mc_standard_errors"))
+    coefficient_record = _record(payload, "validation.equilibrium_coefficients")
+    coefficients = chapter.record_array(coefficient_record)
+    horizon = np.asarray(chapter.record_axis(coefficient_record, "horizon_years"))
+    fk_record = _record(payload, "validation.physical_feynman_kac")
+    physical_fk = chapter.record_array(fk_record)
+    fk_horizons = np.asarray(chapter.record_axis(fk_record, "horizon_years"))
+
+    figure, axes = plt.subplots(2, 2, figsize=(10.5, 7.2))
+    closure_labels = (
+        "Log-linear equilibrium / quadratic Q",
+        "Log-quadratic equilibrium / full cubic Q",
+    )
+    for column, closure_label in enumerate(closure_labels):
+        for regime, label, color in (
+            (0, "Growth", COLORS["blue"]),
+            (1, "Stress", COLORS["red"]),
+        ):
+            axes[0, column].plot(
+                log_moneyness,
+                10_000.0 * analytic[column, regime],
+                color=color,
+                label=f"Analytic, {label.lower()}",
+            )
+            axes[0, column].errorbar(
+                log_moneyness,
+                10_000.0 * monte_carlo[column, regime],
+                yerr=19_600.0 * errors[column, regime],
+                color=color,
+                fmt="o",
+                markersize=3.5,
+                capsize=2,
+                linestyle="none",
+                label=f"MC 95% CI, {label.lower()}",
+            )
+        axes[0, column].set_title(f"{chr(65 + column)}. {closure_label}")
+        axes[0, column].set_xlabel(r"Log-moneyness $\log(K/F)$")
+        axes[0, column].set_ylabel("OTM option price (bp of forward)")
+        axes[0, column].legend(ncol=2)
+
+    for column, regime_label in enumerate(("Growth", "Stress")):
+        axes[1, column].plot(
+            horizon,
+            coefficients[0, column],
+            color=COLORS["blue"],
+            label="Log-linear coefficient",
+        )
+        axes[1, column].plot(
+            horizon,
+            coefficients[1, column],
+            color=COLORS["black"],
+            linestyle="--",
+            label="Log-quadratic coefficient",
+        )
+        axes[1, column].errorbar(
+            fk_horizons,
+            physical_fk[column, :, 0],
+            yerr=1.96 * physical_fk[column, :, 1],
+            color=COLORS["red"],
+            fmt="o",
+            capsize=3,
+            label="Physical-measure MC 95% CI",
+        )
+        axes[1, column].set_title(
+            f"{chr(67 + column)}. Equilibrium closures versus P Monte Carlo: {regime_label.lower()}"
+        )
+        axes[1, column].set_xlabel("Representative-agent horizon (years)")
+        axes[1, column].set_ylabel(r"Risk-premium coefficient $\widehat g$")
+        axes[1, column].legend()
+
+    figure.suptitle("Independent Monte Carlo validation of both closures", y=1.01, fontsize=13)
+    figure.tight_layout()
+    return _save_figure(figure, figure_dir, "regime_sv_validation")
+
+
+def _write_closure_table(payload: dict[str, Any], table_dir: Path) -> Path:
+    record = _record(payload, "closure.table")
+    values = chapter.record_array(record)
+    regimes = chapter.record_axis(record, "regime")
+    maturities = chapter.record_axis(record, "maturity")
     lines = [
         r"\begin{tabular}{llrrr}",
         r"\toprule",
@@ -333,306 +436,134 @@ def _write_closure_comparison_table(
         ),
         r"\midrule",
     ]
-    for regime, maturity, quadratic, cubic, difference in rows:
-        lines.append(
-            f"{regime} & {maturity} & {quadratic:.4f} & {cubic:.4f} & {difference:.3f} \\\\"
-        )
+    for regime_index, regime in enumerate(regimes):
+        for maturity_index, maturity in enumerate(maturities):
+            quadratic, cubic, difference = values[regime_index, maturity_index]
+            lines.append(
+                f"{regime} & {maturity} & {quadratic:.4f} & {cubic:.4f} & {difference:.3f} \\\\"
+            )
     lines.extend([r"\bottomrule", r"\end{tabular}"])
-    (NOTES_DIR / "regime_sv_closure_comparison_table.tex").write_text(
-        "\n".join(lines) + "\n", encoding="utf-8"
-    )
+    table_dir.mkdir(parents=True, exist_ok=True)
+    target = table_dir / "regime_sv_closure_comparison_table.tex"
+    target.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+    return target
 
 
-def make_closure_comparison_figure() -> None:
-    """Compare two internally consistent equilibrium closures in implied volatility."""
-
-    log_moneyness = np.linspace(-0.30, 0.20, 31)
-    maturities = (
-        (1.0 / 12.0, "1 month", COLORS["purple"]),
-        (0.25, "3 months", COLORS["blue"]),
-        (0.5, "6 months", COLORS["green"]),
-        (1.0, "1 year", COLORS["gold"]),
-    )
-    figure, axes = plt.subplots(2, 2, figsize=(10.5, 7.2), sharex=True)
-    table_rows: list[tuple[str, str, float, float, float]] = []
-
-    for column, (regime, regime_label, regime_color) in enumerate(
-        (
-            (GROWTH, "Growth", COLORS["blue"]),
-            (STRESS, "Stress", COLORS["red"]),
-        )
-    ):
-        params = RegimeSwitchLogSvParams.equity_baseline(
-            gamma=-0.5, initial_regime=regime, agent_horizon=3.0
-        )
-        quadratic_3m = _smile(
-            params, 0.25, log_moneyness, equilibrium_degree=1
-        )
-        cubic_3m = _smile(params, 0.25, log_moneyness, equilibrium_degree=2)
-        axes[0, column].plot(
-            log_moneyness,
-            100.0 * quadratic_3m,
-            color=regime_color,
-            marker="o",
-            markevery=3,
-            markersize=3.5,
-            label="Log-linear equilibrium / quadratic Q",
-        )
-        axes[0, column].plot(
-            log_moneyness,
-            100.0 * cubic_3m,
-            color=COLORS["black"],
-            linestyle="--",
-            label="Log-quadratic equilibrium / full cubic Q",
-        )
-        axes[0, column].set_title(f"{chr(65 + column)}. {regime_label}: 3-month smiles")
-        axes[0, column].set_ylabel("Black implied volatility (%)")
-        axes[0, column].legend()
-
-        for ttm, maturity_label, color in maturities:
-            quadratic = _smile(
-                params, ttm, log_moneyness, equilibrium_degree=1
-            )
-            cubic = _smile(params, ttm, log_moneyness, equilibrium_degree=2)
-            difference_bp = 10_000.0 * (cubic - quadratic)
-            axes[1, column].plot(
-                log_moneyness,
-                difference_bp,
-                color=color,
-                label=maturity_label,
-            )
-            left_index = int(np.argmin(np.abs(log_moneyness + 0.20)))
-            right_index = int(np.argmin(np.abs(log_moneyness - 0.20)))
-            quadratic_skew = quadratic[left_index] - quadratic[right_index]
-            cubic_skew = cubic[left_index] - cubic[right_index]
-            table_rows.append(
-                (
-                    regime_label,
-                    maturity_label,
-                    100.0 * quadratic_skew,
-                    100.0 * cubic_skew,
-                    10_000.0 * (cubic_skew - quadratic_skew),
-                )
-            )
-        axes[1, column].axhline(0.0, color=COLORS["gray"], linewidth=0.8)
-        axes[1, column].set_title(
-            f"{chr(67 + column)}. {regime_label}: full cubic minus quadratic"
-        )
-        axes[1, column].set_xlabel(r"Log-moneyness $\log(K/F)$")
-        axes[1, column].set_ylabel("Implied-volatility difference (vol bp)")
-        axes[1, column].legend(ncol=2)
-
-    figure.suptitle(
-        "Implied-volatility skew: comparison of equilibrium closures", y=1.01, fontsize=13
-    )
-    figure.tight_layout()
-    _save_figure(figure, "regime_sv_closure_comparison")
-    _write_closure_comparison_table(table_rows)
-
-
-def _write_validation_table(rows: list[tuple[str, str, float, float, float]]) -> None:
-    NOTES_DIR.mkdir(parents=True, exist_ok=True)
+def _write_validation_table(payload: dict[str, Any], table_dir: Path) -> Path:
+    record = _record(payload, "validation.table")
+    values = chapter.record_array(record)
+    metadata = record.get("row_metadata")
+    if not isinstance(metadata, list) or len(metadata) != values.shape[0]:
+        raise ValueError("validation.table has invalid row_metadata")
     lines = [
         r"\begin{tabular}{llrrr}",
         r"\toprule",
-        r"Check & Initial regime & Analytic & Monte Carlo & MC s.e. \\",
+        r"Check & Initial regime & Analytic & Monte Carlo & MC s.e. \\ ",
         r"\midrule",
     ]
-    for check, regime, analytic, monte_carlo, error in rows:
-        lines.append(f"{check} & {regime} & {analytic:.6f} & {monte_carlo:.6f} & {error:.6f} \\\\")
+    for row, row_metadata in zip(values, metadata):
+        analytic, monte_carlo, error = row
+        lines.append(
+            f"{row_metadata['check']} & {row_metadata['regime']} & {analytic:.6f} "
+            f"& {monte_carlo:.6f} & {error:.6f} \\\\"
+        )
     lines.extend([r"\bottomrule", r"\end{tabular}"])
-    (NOTES_DIR / "regime_sv_validation_table.tex").write_text(
-        "\n".join(lines) + "\n", encoding="utf-8"
+    table_dir.mkdir(parents=True, exist_ok=True)
+    target = table_dir / "regime_sv_validation_table.tex"
+    target.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+    return target
+
+
+def render_artifacts(payload: dict[str, Any], output_directory: Path | str) -> list[Path]:
+    """Render all figures and tables using only an already validated payload."""
+
+    chapter.validate_numerical_payload(payload)
+    output = chapter.validate_output_directory(output_directory)
+    figure_dir = output / "figures"
+    table_dir = output / "tables"
+    _setup_style()
+    artifacts = []
+    artifacts.extend(_render_smiles(payload, figure_dir))
+    artifacts.extend(_render_premia(payload, figure_dir))
+    artifacts.extend(_render_closure_comparison(payload, figure_dir))
+    artifacts.extend(_render_validation(payload, figure_dir))
+    artifacts.append(_write_closure_table(payload, table_dir))
+    artifacts.append(_write_validation_table(payload, table_dir))
+    return artifacts
+
+
+def run_pipeline(
+    *,
+    profile: chapter.ChapterProfile | str | None = None,
+    output_directory: Path | str | None = None,
+    payload_path: Path | str | None = None,
+) -> tuple[Path, Path]:
+    """Compute or rerender a payload and return its output and manifest paths."""
+
+    mode = "computed"
+    if payload_path is None:
+        selected = chapter.as_profile(profile or chapter.ChapterProfile.SMOKE)
+        output = chapter.validate_output_directory(
+            output_directory or chapter.default_output_directory(selected)
+        )
+        payload = chapter.build_numerical_payload(selected)
+    else:
+        mode = "rerendered"
+        payload = chapter.load_numerical_payload(payload_path)
+        selected = chapter.as_profile(payload["profile"])
+        if profile is not None and chapter.as_profile(profile) is not selected:
+            raise ValueError("--profile must agree with the profile stored in --payload")
+        output = chapter.validate_output_directory(
+            output_directory or chapter.default_output_directory(selected)
+        )
+
+    target_payload = chapter.write_numerical_payload(
+        payload,
+        output / chapter.PAYLOAD_FILENAME,
     )
-
-
-def make_validation_figure(quick: bool) -> None:
-    n_paths = 35_000 if quick else 120_000
-    steps_per_year = 720 if quick else 1_440
-    ttm = 0.25
-    log_moneyness = np.linspace(-0.30, 0.20, 16)
-    strikes = np.exp(log_moneyness)
-    optiontypes = np.where(strikes < 1.0, "P", "C")
-    figure, axes = plt.subplots(2, 2, figsize=(10.5, 7.2))
-    table_rows: list[tuple[str, str, float, float, float]] = []
-
-    for column, (equilibrium_degree, closure_label, short_label) in enumerate(
-        (
-            (1, "Log-linear equilibrium / quadratic Q", "quadratic Q"),
-            (2, "Log-quadratic equilibrium / full cubic Q", "full cubic Q"),
-        )
-    ):
-        for regime, label, color, seed in (
-            (GROWTH, "Growth", COLORS["blue"], 1_227),
-            (STRESS, "Stress", COLORS["red"], 1_229),
-        ):
-            params = RegimeSwitchLogSvParams.equity_baseline(
-                gamma=-0.5, initial_regime=regime, agent_horizon=3.0
-            )
-            equilibrium = solve_equilibrium(params, degree=equilibrium_degree)
-            analytic = price_slice(
-                params,
-                equilibrium,
-                ttm,
-                strikes,
-                optiontypes=optiontypes,
-                degree=4,
-                max_phi=1_601,
-            )
-            sample = simulate_terminal_q(
-                params,
-                equilibrium,
-                ttm,
-                n_paths=n_paths,
-                steps_per_year=steps_per_year,
-                seed=seed,
-            )
-            monte_carlo, standard_errors, _ = mc_price_slice(
-                sample, params, ttm, strikes, optiontypes
-            )
-            axes[0, column].plot(
-                log_moneyness,
-                10_000.0 * analytic.prices,
-                color=color,
-                label=f"Analytic, {label.lower()}",
-            )
-            axes[0, column].errorbar(
-                log_moneyness,
-                10_000.0 * monte_carlo,
-                yerr=19_600.0 * standard_errors,
-                color=color,
-                fmt="o",
-                markersize=3.5,
-                capsize=2,
-                linestyle="none",
-                label=f"MC 95% CI, {label.lower()}",
-            )
-            martingale, martingale_error = sample.forward_martingale
-            table_rows.append(
-                (
-                    rf"$E^{{\mathbb{{Q}}}}[S_T/F_0]$, {short_label}",
-                    label,
-                    1.0,
-                    martingale,
-                    martingale_error,
-                )
-            )
-            atm = int(np.argmin(np.abs(strikes - 1.0)))
-            table_rows.append(
-                (
-                    f"3m near-ATM, {short_label}",
-                    label,
-                    analytic.prices[atm],
-                    monte_carlo[atm],
-                    standard_errors[atm],
-                )
-            )
-
-        axes[0, column].set_title(f"{chr(65 + column)}. {closure_label}")
-        axes[0, column].set_xlabel(r"Log-moneyness $\log(K/F)$")
-        axes[0, column].set_ylabel("OTM option price (bp of forward)")
-        axes[0, column].legend(ncol=2)
-
-    params = RegimeSwitchLogSvParams.equity_baseline(
-        gamma=-0.5, initial_regime=GROWTH, agent_horizon=3.0
+    render_payload = chapter.load_numerical_payload(target_payload)
+    rendered = render_artifacts(render_payload, output)
+    manifest = chapter.write_artifact_manifest(
+        output,
+        profile=selected,
+        mode=mode,
+        payload_path=target_payload,
+        artifacts=[target_payload, *rendered],
     )
-    equilibria = {
-        "Log-linear coefficient": solve_equilibrium(params, degree=1),
-        "Log-quadratic coefficient": solve_equilibrium(params, degree=2),
-    }
-    horizon_grid = np.linspace(0.0, 3.0, 151)
-    for column, (regime, label, seed) in enumerate(
-        (
-            (GROWTH, "Growth", 1_301),
-            (STRESS, "Stress", 1_303),
-        )
-    ):
-        sigma = params.regimes[regime].theta
-        for (coefficient_label, equilibrium), color, linestyle in zip(
-            equilibria.items(),
-            (COLORS["blue"], COLORS["black"]),
-            ("-", "--"),
-        ):
-            analytic_curve = np.exp(
-                [equilibrium.log_g_hat(horizon, sigma, regime) for horizon in horizon_grid]
-            )
-            axes[1, column].plot(
-                horizon_grid,
-                analytic_curve,
-                color=color,
-                linestyle=linestyle,
-                label=coefficient_label,
-            )
-        mc_horizons = np.array([1.0, 3.0])
-        mc_values = []
-        mc_errors = []
-        for horizon in mc_horizons:
-            value, error = simulate_equilibrium_feynman_kac(
-                params,
-                horizon,
-                sigma,
-                regime,
-                n_paths=n_paths,
-                steps_per_year=steps_per_year,
-                seed=seed + int(10 * horizon),
-            )
-            mc_values.append(value)
-            mc_errors.append(error)
-            if horizon == 3.0:
-                for coefficient_label, equilibrium in equilibria.items():
-                    analytic_value = np.exp(
-                        equilibrium.log_g_hat(horizon, sigma, regime)
-                    )
-                    table_rows.append(
-                        (
-                            f"$g(0,\\theta)$, 3y, {coefficient_label.split()[0].lower()}",
-                            label,
-                            analytic_value,
-                            value,
-                            error,
-                        )
-                    )
-        axes[1, column].errorbar(
-            mc_horizons,
-            mc_values,
-            yerr=1.96 * np.asarray(mc_errors),
-            color=COLORS["red"],
-            fmt="o",
-            capsize=3,
-            label="Physical-measure MC 95% CI",
-        )
-        axes[1, column].set_title(
-            f"{chr(67 + column)}. Equilibrium closures versus P Monte Carlo: {label.lower()}"
-        )
-        axes[1, column].set_xlabel("Representative-agent horizon (years)")
-        axes[1, column].set_ylabel(r"Risk-premium coefficient $\widehat g$")
-        axes[1, column].legend()
-
-    figure.suptitle("Independent Monte Carlo validation of both closures", y=1.01, fontsize=13)
-    figure.tight_layout()
-    _save_figure(figure, "regime_sv_validation")
-    _write_validation_table(table_rows)
+    return output, manifest
 
 
-def main() -> None:
+def _parse_arguments(arguments: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--quick",
-        action="store_true",
-        help="use fewer Monte Carlo paths for the validation panel",
+        "--profile",
+        choices=[item.value for item in chapter.ChapterProfile],
+        help="numerical workload; defaults to smoke for a computed run",
     )
-    args = parser.parse_args()
-    _setup_style()
-    make_smile_figure()
-    make_premia_figure()
-    make_closure_comparison_figure()
-    make_validation_figure(args.quick)
-    print(f"Wrote report figures to {FIGURE_DIR}")
-    print(f"Wrote validation table to {NOTES_DIR / 'regime_sv_validation_table.tex'}")
-    print(
-        "Wrote closure comparison table to "
-        f"{NOTES_DIR / 'regime_sv_closure_comparison_table.tex'}"
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="artifact directory; explicit paths are used directly without a profile suffix",
     )
+    parser.add_argument(
+        "--payload",
+        type=Path,
+        help="rerender this numerical payload without invoking any numerical analytics",
+    )
+    return parser.parse_args(arguments)
+
+
+def main(arguments: Sequence[str] | None = None) -> None:
+    """Command-line entry point."""
+
+    parsed = _parse_arguments(arguments)
+    output, manifest = run_pipeline(
+        profile=parsed.profile,
+        output_directory=parsed.output_dir,
+        payload_path=parsed.payload,
+    )
+    print(f"Wrote regime-SV chapter artifacts to {output}")
+    print(f"Wrote artifact manifest to {manifest}")
 
 
 if __name__ == "__main__":

--- a/volatility_book/ch_lognormal_sv_risk_premia/notes/risk_premia_lognormal_sv.tex
+++ b/volatility_book/ch_lognormal_sv_risk_premia/notes/risk_premia_lognormal_sv.tex
@@ -1,0 +1,944 @@
+% !TeX program = pdflatex
+% ---------------------------------------------------------------------------
+% Equilibrium Risk Premia and Valuation under the Log-Normal SV Model
+% Standalone working note, Zurich, August 2026.
+%
+% Provenance: this document is a corrected and extended version of the draft
+% chapter ValuationUnderSV.tex. Blocks are marked as follows:
+%   %% [CORRECTED vs chapter Eq (...)] - fixes an error in the draft
+%   %% [NEW] - content added beyond the draft
+% All equations were verified symbolically and numerically
+% (verify_valuation_under_sv.py in this folder).
+% v2 (2026-08-23): added Section on the Hawkes-model equilibrium (companion to
+% Liu-Packham-Sepp) verified in verify_hawkes_equilibrium.py, and the discussion
+% subsection on variance versus skew premia.
+% v3 (2026-08-23): added Section on the regime-switching log-normal SV model
+% (synthesis with the transition-tied jumps of the goal-based-allocation paper),
+% derived and benchmarked in verify_regime_sv_equilibrium.py.
+% v4 (2026-08-23): reconciled the regime notation and equity jump calibration
+% with Sepp (2026), retained the induced cubic Q volatility drift, added the
+% degree-four option transform, Monte Carlo validation, and smile sensitivities.
+% v5 (2026-08-23): added the internally consistent log-linear equilibrium closure
+% that preserves the quadratic Q drift, explained its relation to IJTAF, and
+% compared its implied-volatility skews with the full-cubic closure.
+% v6 (2026-08-23): clarified the exact and approximate senses in which the
+% log-linear regime closure is consistent with the CRRA equilibrium framework.
+% The economic-mechanism paragraph in Section 8 is an AI-drafted sketch and is
+% marked for rewriting by the author, per the project drafting rule.
+% ---------------------------------------------------------------------------
+\documentclass[11pt]{article}
+\usepackage[a4paper, margin=2.6cm]{geometry}
+\usepackage{amsmath, amssymb, amsthm}
+\usepackage{booktabs,float,graphicx}
+\usepackage[round]{natbib}
+\usepackage[colorlinks=true, linkcolor=blue, citecolor=blue]{hyperref}
+\graphicspath{{figures/}}
+
+\newtheorem{theorem}{Theorem}
+\newtheorem{proposition}{Proposition}
+\newtheorem{lemma}{Lemma}
+\theoremstyle{remark}
+\newtheorem{remark}{Remark}
+
+\newcommand{\E}{\mathbb{E}}
+\newcommand{\PP}{\mathbb{P}}
+\newcommand{\QQ}{\mathbb{Q}}
+
+\title{Equilibrium Risk Premia and Valuation\\ under the Log-Normal Stochastic Volatility Model\\[1ex] \large Working note}
+\author{Artur Sepp}
+\date{Zurich, August 2026}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+\sloppy
+\noindent
+The log-normal stochastic volatility (SV) model with quadratic drift of \cite{SeppRakhmonov2024} specifies the market prices of equity and volatility risk as linear functions of the volatility. This specification is postulated for tractability rather than derived from economic primitives. We derive both risk premia in a production-economy equilibrium in which a representative agent with constant relative risk aversion (CRRA) holds the market portfolio. Under a local log-linear closure, both market prices of risk are proportional to volatility with coefficients $\bar\lambda_{0}=(1-\gamma)-\beta a^{(1)}$ and $\bar\lambda_{1}=-\varepsilon a^{(1)}$, where $a^{(1)}$ solves a scalar Riccati equation in closed form. Companion derivations for the bivariate Hawkes jump model and for a regime-switching extension show that the same equilibrium generates a common direct jump tilt $\gamma-1$. The regime-switching PDE for the value coefficients remains linear. Its log-linear closure gives four nonlinear ordinary differential equations and preserves the quadratic risk-neutral volatility drift, while its log-quadratic closure gives six equations and induces a cubic drift. A common degree-four transform yields semi-analytic option prices for both closures. We solve and simulate each internally consistent measure and find very small implied-volatility-skew differences for the equity illustration.
+\end{abstract}
+
+\section{Introduction}\label{sec:intro}
+
+This note derives the equity and volatility risk premia of the log-normal SV model in general equilibrium. We follow the production-economy approach of \cite{CIR1985}: a representative CRRA agent allocates wealth to the stock index, a derivative security, and the money market account, and market clearing forces the agent to hold the index. The risk premia are outputs of the market-clearing conditions, not inputs. \cite{Heston1993} used the same argument to justify the volatility risk premium $\lambda V$ in the square-root model, and \cite{Lewis2000} develops it for general SV models. \cite{Bick1990} and \cite{HeLeland1993} characterize which price processes are consistent with such an equilibrium.
+
+The note makes five points. First, the equilibrium delivers the market prices of risk in the factorized form $\lambda_{0}=(1-\gamma)\sigma-\beta(\sigma)\psi$ and $\lambda_{1}=-a(\sigma)\psi$, where $\psi$ is the logarithmic gradient of the value-function coefficient with respect to volatility. Second, the local log-linear solution makes both prices exactly proportional to $\sigma_{t}$ and provides closed-form coefficients. Third, this closure preserves the quadratic-drift LogSV class, whereas the more accurate log-quadratic equilibrium loading induces a cubic risk-neutral drift; the two statements refer to different approximation orders. Fourth, the Hawkes extension generates a common direct jump tilt $\xi^{+}=\xi^{-}=\gamma-1$. Fifth, the regime-switching LogSV model with the transition-tied jumps of \cite{Sepp2026gba} combines diffusive, regime-timing, and tail premia and remains semi-analytic after polynomial projection.
+
+The note proceeds as follows. Section \ref{sec:model} states the model and the economy. Section \ref{sec:hjb} derives the Hamilton-Jacobi-Bellman (HJB) equation and the first-order conditions. Section \ref{sec:premia} imposes market clearing and derives the risk premia and the linear equation for the value-function coefficient. Section \ref{sec:pricing} states the equilibrium valuation equation. Section \ref{sec:lognormal} solves the log-normal case with the closed-form Riccati solution. Section \ref{sec:linearity} states the endogenous linear market prices of risk and the parameter mapping under the risk-neutral measure. Section \ref{sec:hawkes} extends the derivation to the bivariate Hawkes jump model and identifies its measure-change family with the equilibrium kernel. Section \ref{sec:regime} combines the two settings in a regime-switching log-normal SV model, derives both consistent equilibrium closures, and compares their implied-volatility skews. Section \ref{sec:discussion} discusses the horizon dependence of the premia, the economic mechanism, and the division of labor between diffusive and jump risk premia.
+
+\section{Model and economy}\label{sec:model}
+
+We specify the joint dynamics of the price process $S_{t}$ and the volatility process $\sigma_{t}$ under the statistical measure $\PP$ using the beta formulation of \cite{KarasinskiSepp2012}:
+\begin{equation}\label{eq:sv}
+\begin{split}
+dS_{t} &= \mu_{t} S_{t} dt+ \sigma_{t}S_{t} dW^{(0)}_{t}, \quad S_0=S, \\
+d\sigma_{t}&=b(\sigma_{t}) dt + \beta(\sigma_{t}) dW^{(0)}_{t} + a(\sigma_{t}) dW^{(1)}_{t} , \quad \sigma_{0}=\sigma,
+\end{split}
+\end{equation}
+where $W^{(0)}_{t}$ and $W^{(1)}_{t}$ are independent Brownian motions, $\mu_{t}$ is the statistical drift, $b(\sigma)$ is the drift function of the volatility, $\beta(\sigma)$ is the volatility beta function, and $a(\sigma)$ is the residual volatility-of-volatility function. The beta function specifies the covariation between returns and volatility changes:
+\begin{equation}\label{eq:covar}
+\left\langle  \frac{dS_{t}}{S_{t}},\, d\sigma_{t} \right\rangle =  \sigma_{t} \beta(\sigma_{t})\, dt.
+\end{equation}
+The formulation \eqref{eq:sv} is equivalent to a classic two-factor SV model with correlated Brownian drivers. Given a volatility function $v(\sigma)$ and correlation $\rho$, we recover \eqref{eq:sv} by setting $\beta(\sigma)=\rho v(\sigma)$ and $a(\sigma)=\sqrt{1-\rho^{2}}\,v(\sigma)$.
+
+%% [NEW] problem statement was missing in the draft
+The economy consists of three assets: the stock index $S_{t}$ in unit net supply, the money market account $B_{t}$ with $dB_{t}=rB_{t}dt$ in zero net supply, and a derivative security in zero net supply with value function $U(t, S_{t}, \sigma_{t})$ and maturity $T_{U}$. A representative agent allocates the fractions $x_{t}$, $y_{t}$ and $z_{t}=1-x_{t}-y_{t}$ of wealth $\Pi_{t}$ to the index, the derivative, and the account, respectively. The agent maximizes the expected utility of terminal wealth at horizon $T$, $T \geq T_{U}$, with CRRA preferences:
+\begin{equation}\label{eq:objective}
+J(t, \Pi, \sigma) = \sup_{ \{x_{s}, y_{s}\}_{s \in [t,T]} } \E\left[ \left. \frac{\Pi_{T}^{\gamma}}{\gamma} \right| \Pi_{t}=\Pi, \sigma_{t}=\sigma \right], \quad \gamma<1, \ \gamma \neq 0,
+\end{equation}
+so that the relative risk aversion equals $1-\gamma$. There is no intermediate consumption. In equilibrium the agent holds the net supply of each asset, which requires $x^{*}=1$, $y^{*}=0$ and $z^{*}=0$, and the drifts $\mu_{t}$ and $\mu^{U}_{t}$ adjust to make these allocations optimal.
+
+Table \ref{tab:notation} collects the notation used throughout the note.
+\begin{table}[h]
+\centering
+\begin{tabular}{ll}
+\hline
+$b(\sigma)$, $\beta(\sigma)$, $a(\sigma)$ & drift, beta, and residual volatility functions of $\sigma_{t}$ \\
+$\gamma$ & CRRA utility power, risk aversion $1-\gamma$ \\
+$J(t,\Pi,\sigma)$, $g(t,\sigma)$ & value function and its volatility coefficient, Eq \eqref{eq:ansatz} \\
+$\psi(t,\sigma)=g_{\sigma}/g$ & risk-premium loading \\
+$\lambda_{0}$, $\lambda_{1}$ & market prices of risk of $W^{(0)}$ and $W^{(1)}$ \\
+$\varphi = \beta\lambda_{0} + a\lambda_{1}$ & drift adjustment of $\sigma_{t}$ under $\QQ$ \\
+$\kappa_{1},\kappa_{2},\theta,\beta,\varepsilon$ & log-normal model parameters, Eq \eqref{eq:lnsv} \\
+$\vartheta^{2}=\beta^{2}+\varepsilon^{2}$, $\bar\kappa = \kappa_{1}+\kappa_{2}\theta$ & total variance of volatility, linearized mean reversion \\
+$\tau=T-t$, $v = \sigma-\theta$ & time to horizon, mean-adjusted volatility \\
+\hline
+\end{tabular}
+\caption{Notation.}
+\label{tab:notation}
+\end{table}
+
+\section{Wealth dynamics and the HJB equation}\label{sec:hjb}
+
+Applying It\^{o}'s lemma to $U(t,S_{t},\sigma_{t})$ under the dynamics \eqref{eq:sv}, we obtain
+\begin{equation}\label{eq:dU}
+dU_{t} = \mu^{U}_{t} U_{t}\, dt+ \left[\sigma_{t}S_{t}\partial_{S}U + \beta(\sigma_{t})\partial_{\sigma}U\right] dW^{(0)}_{t}+ a(\sigma_{t})\, \partial_{\sigma}U\, dW^{(1)}_{t},
+\end{equation}
+where the drift rate $\mu^{U}_{t}$ is given by
+%% [CORRECTED vs chapter Eq (vru2)]: the gamma term carries S^2
+\begin{equation}\label{eq:muU}
+\mu^{U} U = \partial_{t} U + \mu S \partial_{S} U + \frac{1}{2}\sigma^{2} S^{2} \partial^{2}_{SS} U  +  b(\sigma) \partial_{\sigma} U + \frac{1}{2}\left[ \beta^{2}(\sigma) + a^{2}(\sigma) \right] \partial^{2}_{\sigma\sigma} U + \sigma\beta(\sigma)S\,\partial^{2}_{S\sigma} U.
+\end{equation}
+
+Since $y_{t}$ is the fraction of wealth in the derivative, the number of derivative units is $y_{t}\Pi_{t}/U_{t}$, and the per-dollar exposures of the derivative to the two Brownian drivers are
+%% [CORRECTED vs chapter Eq (log3)]: exposures are normalized by U
+\begin{equation}\label{eq:deltas}
+\Delta_{0} = \frac{\sigma S\,\partial_{S}U + \beta(\sigma)\,\partial_{\sigma}U}{U}, \qquad
+\Delta_{1} = \frac{a(\sigma)\,\partial_{\sigma}U}{U}.
+\end{equation}
+The self-financing wealth process then follows
+\begin{equation}\label{eq:wealth}
+d\Pi_{t} = \left[(\mu_{t}-r)x_{t} + (\mu^{U}_{t} - r) y_{t} + r\right] \Pi_{t}\, dt
++ \left[ \sigma_{t}x_{t}  + y_{t} \Delta_{0} \right] \Pi_{t}\, dW^{(0)}_{t} + y_{t} \Delta_{1} \Pi_{t}\, dW^{(1)}_{t}.
+\end{equation}
+
+The value function \eqref{eq:objective} satisfies the HJB equation
+\begin{equation}\label{eq:hjb}
+\max_{x, y} \left\{ \partial_{t} J + \mathcal{L}^{(x,y)}(J)\right\} = 0, \quad J(T,\Pi,\sigma)=\frac{\Pi^{\gamma}}{\gamma},
+\end{equation}
+with the controlled generator
+\begin{equation}\label{eq:generator}
+\begin{split}
+\mathcal{L}^{(x,y)}(J) & =  \left[(\mu-r)x + (\mu^{U} - r)y + r\right]\Pi J_{\Pi} + b(\sigma)J_{\sigma} +\frac{1}{2}\left[\beta^{2}(\sigma) + a^{2}(\sigma)\right]J_{\sigma\sigma}\\
+& + \frac{1}{2}\left[ \left(\sigma x + y\Delta_{0}\right)^{2} + y^{2}\Delta_{1}^{2}\right]\Pi^{2} J_{\Pi\Pi}
++ \left[ \beta(\sigma) \left(\sigma x + y\Delta_{0}\right)  + a(\sigma)\, y \Delta_{1} \right] \Pi J_{\Pi\sigma}.
+\end{split}
+\end{equation}
+Differentiating \eqref{eq:generator} in $x$ and $y$ and evaluating at the market-clearing allocations $x^{*}=1$ and $y^{*}=0$ yields the two first-order conditions
+\begin{equation}\label{eq:focs}
+\begin{split}
+& (\mu-r) J_{\Pi} + \sigma^{2}\Pi J_{\Pi\Pi}+ \beta(\sigma)\, \sigma  J_{\Pi\sigma} = 0,\\
+& (\mu^{U} - r) J_{\Pi} + \sigma \Delta_{0} \Pi J_{\Pi\Pi}+  \left[ \beta(\sigma) \Delta_{0} + a(\sigma)\Delta_{1} \right] J_{\Pi\sigma} = 0.
+\end{split}
+\end{equation}
+
+\section{Equilibrium risk premia}\label{sec:premia}
+
+We introduce the risk-aversion and hedging coefficients of the value function,
+\begin{equation}\label{eq:AB}
+A = - \frac{\Pi J_{\Pi \Pi}}{J_{\Pi}}, \qquad B= -\frac{J_{\Pi\sigma}}{J_{\Pi}}.
+\end{equation}
+The first condition in \eqref{eq:focs} determines the equity risk premium:
+\begin{equation}\label{eq:equity_premium}
+\mu-r = \sigma^{2}A + \beta(\sigma)\, \sigma B.
+\end{equation}
+Substituting \eqref{eq:equity_premium} and \eqref{eq:deltas} into the second condition in \eqref{eq:focs} and multiplying by $U$, we obtain the drift restriction on the derivative:
+%% [CORRECTED vs chapter Eqs (log12), (log14)]: the left-hand side carries U
+\begin{equation}\label{eq:U_premium}
+U (\mu^{U} - r)  = (\mu-r)\,S\partial_{S}U + \varphi\, \partial_{\sigma}U,
+\qquad
+\varphi = \sigma\beta(\sigma) A + \left[ \beta^{2}(\sigma)  + a^{2}(\sigma) \right]B.
+\end{equation}
+
+Substituting the equilibrium premium \eqref{eq:equity_premium} back into \eqref{eq:generator} at $x^{*}=1$, $y^{*}=0$ reduces the HJB equation to
+\begin{equation}\label{eq:Jpde}
+\partial_{t} J + r\Pi J_{\Pi} - \frac{1}{2}\sigma^{2}\Pi^{2} J_{\Pi\Pi} +  b(\sigma)J_{\sigma} +\frac{1}{2}\left[\beta^{2}(\sigma) + a^{2}(\sigma)\right]J_{\sigma\sigma} = 0.
+\end{equation}
+For CRRA preferences we apply the multiplicative ansatz
+\begin{equation}\label{eq:ansatz}
+J(t,\Pi,\sigma) = g(t, \sigma)\, \frac{\Pi^{\gamma}}{\gamma},
+\end{equation}
+where we call $g(t,\sigma)$ the risk-premium coefficient. The ansatz gives $A = 1-\gamma$ and $B = -\psi(t,\sigma)$ with the risk-premium loading
+\begin{equation}\label{eq:psi}
+\psi (t, \sigma) = \frac{g_{\sigma}(t, \sigma) }{g(t, \sigma) },
+\end{equation}
+and \eqref{eq:Jpde} becomes a linear equation for $g$:
+\begin{equation}\label{eq:gpde}
+g_{t} +  b(\sigma)g_{\sigma} +\frac{1}{2}\left[\beta^{2}(\sigma) + a^{2}(\sigma)\right]g_{\sigma\sigma} +  \left[\gamma r  - \frac{1}{2} \gamma (\gamma-1) \sigma^{2} \right]g  = 0, \quad g(T, \sigma) = 1.
+\end{equation}
+
+\begin{remark}[No Merton distortion]\label{rem:linearity}
+%% [NEW]
+In the Merton problem with an exogenous drift $\mu$, optimizing over $x$ produces the nonlinear term $\frac{\gamma}{2(1-\gamma)}\left(\frac{\mu-r}{\sigma}\right)^{2}g$ in the equation for $g$, see \cite{Merton1971}. Here market clearing pins $x^{*}=1$ before the premium is known, and the premium \eqref{eq:equity_premium} adjusts to support this allocation. As a result, Eq \eqref{eq:gpde} is linear and contains no risk-premia inputs: the premia are outputs computed from its solution.
+\end{remark}
+
+%% [NEW] probabilistic representation and existence
+By the Feynman-Kac theorem, the solution of \eqref{eq:gpde} admits the representation
+\begin{equation}\label{eq:FK}
+g(t,\sigma) = e^{\gamma r (T-t)}\, \E\left[ \left. \exp\left( \frac{1}{2}\gamma(1-\gamma) \int_{t}^{T} \sigma^{2}_{s}\, ds \right) \right| \sigma_{t}=\sigma \right],
+\end{equation}
+where the expectation is taken under $\PP$. The representation identifies $g$ with the moment generating function of the quadratic variation evaluated at the transform variable $\Psi = -\frac{1}{2}\gamma(1-\gamma)$, so the analytics developed for the quadratic variation in \cite{SeppRakhmonov2024} apply to $g$ directly.
+
+\begin{proposition}[Existence]\label{prop:existence}
+%% [NEW]
+Let the volatility follow the log-normal dynamics \eqref{eq:lnsv} below. For $\gamma < 0$, the expectation \eqref{eq:FK} is finite for all $T$. For $0<\gamma<1$, it is finite for all $T$ provided that
+\begin{equation}\label{eq:existence}
+\kappa_{2} > \vartheta \sqrt{ \gamma(1-\gamma)}.
+\end{equation}
+\end{proposition}
+\begin{proof}
+For $\gamma<0$ the integrand exponent is negative, so the expectation is bounded by one. For $0<\gamma<1$ the claim follows from the supersolution argument in the proof of the existence theorem for the quadratic-variation moment generating function in \cite{SeppRakhmonov2024}, applied under $\PP$ with $-\Psi_{R} = \frac{1}{2}\gamma(1-\gamma)$.
+\end{proof}
+
+The market prices of risk of the two Brownian drivers follow from \eqref{eq:equity_premium} and from decomposing $\varphi$ in \eqref{eq:U_premium}:
+%% [NEW] per-Brownian decomposition replaces the scalar lambda^sigma of the draft
+\begin{equation}\label{eq:mprs}
+\lambda_{0} = \frac{\mu-r}{\sigma} = (1 - \gamma)\sigma  - \beta(\sigma)\, \psi (t, \sigma),
+\qquad
+\lambda_{1} = -a(\sigma)\, \psi (t, \sigma),
+\end{equation}
+so that $\varphi = \beta(\sigma)\lambda_{0} + a(\sigma)\lambda_{1}$. The change of measure to the risk-neutral measure $\QQ$ is
+\begin{equation}\label{eq:girsanov}
+\left.\frac{d\QQ}{d\PP}\right|_{\mathcal{F}_t}=\mathcal{E}\left(-\int_0^t \lambda_0(s)\,dW^{(0)}_s-\int_0^t\lambda_1(s)\,dW^{(1)}_s\right),
+\end{equation}
+where $\mathcal{E}(\cdot)$ denotes the stochastic exponential. The residual price of risk $\lambda_{1}$ is proportional to the loading $\psi$ alone: the agent prices the orthogonal volatility shocks only through the sensitivity of the value function to the volatility state. For log utility, $\gamma \to 0$, the coefficient $g$ becomes independent of $\sigma$, so $\psi=0$, $\lambda_{0} = \sigma$ and $\lambda_{1} = 0$.
+
+\section{Equilibrium valuation equation}\label{sec:pricing}
+
+Equating the drift restriction \eqref{eq:U_premium} with the It\^{o} drift \eqref{eq:muU} yields the valuation equation for any derivative in zero net supply:
+%% [CORRECTED vs chapter Eq (log24)]: the cross term carries S
+\begin{equation}\label{eq:pricing_pde}
+\begin{split}
+&\partial_{t} U  + r S\partial_{S}U + \frac{1}{2} \sigma^{2} S^{2}\partial^{2}_{SS}U+ \left[b(\sigma) -\varphi (t, \sigma) \right]\partial_{\sigma}U \\
+&\quad + \frac{1}{2}\left[\beta^{2}(\sigma) + a^{2}(\sigma)\right]\partial^{2}_{\sigma\sigma}U + \sigma\beta(\sigma) S\, \partial^{2}_{S\sigma}U - rU = 0.
+\end{split}
+\end{equation}
+Equation \eqref{eq:pricing_pde} is the Feynman-Kac equation for the $\QQ$-dynamics
+\begin{equation}\label{eq:Qdynamics}
+\begin{split}
+dS_{t} &= r S_{t}\, dt+ \sigma_{t}S_{t}\, d\hat{W}^{(0)}_{t}, \\
+d\sigma_{t}&=\left[ b(\sigma_{t}) - \varphi(t, \sigma_{t}) \right] dt + \beta(\sigma_{t})\, d\hat{W}^{(0)}_{t} + a(\sigma_{t})\, d\hat{W}^{(1)}_{t},
+\end{split}
+\end{equation}
+where $\hat{W}^{(0)}_{t}$ and $\hat{W}^{(1)}_{t}$ are independent Brownian motions under $\QQ$ defined by the change of measure \eqref{eq:girsanov}. The computation of the premia therefore reduces to three steps: solve the linear equation \eqref{eq:gpde} for $g$, compute the loading $\psi = g_{\sigma}/g$, and evaluate $\lambda_{0}$, $\lambda_{1}$ and $\varphi$ from \eqref{eq:mprs}.
+
+\section{Solution for the log-normal volatility model}\label{sec:lognormal}
+
+We specialize to the log-normal volatility dynamics with quadratic drift:
+\begin{equation}\label{eq:lnsv}
+d\sigma_t=(\kappa_1+\kappa_2\sigma_t)(\theta-\sigma_t)\, dt+\beta\sigma_t\, dW^{(0)}_t+\varepsilon\sigma_t\, dW^{(1)}_t,
+\end{equation}
+so that $b(\sigma) = (\kappa_1+\kappa_2\sigma)(\theta-\sigma)$, $\beta(\sigma)=\beta\sigma$ and $a(\sigma)=\varepsilon\sigma$, with the total variance of the volatility denoted by $\vartheta^{2}=\beta^{2}+\varepsilon^{2}$. To remove the interest-rate term, we factor $g = e^{\gamma r (T-t)}\, \hat{g}$, and Eq \eqref{eq:gpde} becomes
+%% [CORRECTED vs chapter Eq (lsv2)]: the gamma-r term is factored out explicitly
+\begin{equation}\label{eq:gpde_ln}
+\hat{g}_{t} +   (\kappa_1+\kappa_2\sigma)(\theta-\sigma)\, \hat{g}_{\sigma} +\frac{1}{2} \vartheta^{2} \sigma^{2}\, \hat{g}_{\sigma\sigma} - \frac{1}{2} \gamma (\gamma-1) \sigma^{2}\, \hat{g}  = 0, \quad \hat{g}(T, \sigma) = 1.
+\end{equation}
+
+We change variables to the mean-adjusted volatility $v=\sigma - \theta$ and time to horizon $\tau=T-t$. Expanding the drift around $\theta$ gives $(\kappa_1+\kappa_2\sigma)(\theta-\sigma) = -\bar\kappa v - \kappa_2 v^{2}$ with the linearized mean-reversion speed $\bar\kappa = \kappa_{1}+\kappa_{2}\theta$, and Eq \eqref{eq:gpde_ln} becomes
+%% [CORRECTED vs chapter Eq (lsv3)]: the linear drift coefficient is -(kappa_1+kappa_2*theta),
+%% not (kappa_1-kappa_2*theta); the latter is the coefficient of the expansion around sigma=0
+\begin{equation}\label{eq:gpde_v}
+- \hat{g}_{\tau} -   \left[\bar\kappa\, v + \kappa_2 v^{2}\right]\hat{g}_{v} +\frac{1}{2} \vartheta^{2} (v+\theta)^{2}\, \hat{g}_{vv} - \frac{1}{2} \gamma (\gamma-1) (v+\theta)^{2} \hat{g}  = 0, \quad \hat{g}(0, v) = 1.
+\end{equation}
+The coefficient $\bar\kappa$ agrees with the linearized mean reversion $\kappa^{(1)} = \kappa_{1}+\kappa_{2}\theta$ in the operator representation of \cite{SeppRakhmonov2024}.
+
+We first seek a local log-linear closure
+\begin{equation}\label{eq:affine}
+\hat{g}(\tau, v) = \exp \left\{ a^{(0)}(\tau) + a^{(1)}(\tau)\, v \right\} + O(v^{2}), \quad a^{(0)}(0)=a^{(1)}(0)=0,
+%% [CORRECTED vs chapter Eq (lsv4)]: initial conditions are a0(0)=0 and a1(0)=0
+\end{equation}
+where the $O(v^{2})$ terms collect the discarded powers. This degree-one log-polynomial is a useful closed-form leading approximation; it is not the ``FIRST'' affine expansion terminology of \cite{SeppRakhmonov2024}, whose exponent has degree two. Collecting the terms of orders $v^{0}$ and $v^{1}$ yields the system
+\begin{equation}\label{eq:odes}
+\begin{split}
+& a^{(0)}_{\tau}  = \frac{1}{2} \vartheta^{2} \theta^{2} \left(a^{(1)}\right)^{2} - \frac{1}{2} \theta^{2}  \gamma (\gamma-1),\\
+&  a^{(1)}_{\tau}  =  \vartheta^{2} \theta \left(a^{(1)}\right)^{2} -\bar\kappa\,  a^{(1)}  - \theta \gamma (\gamma-1).
+\end{split}
+\end{equation}
+The equation for $a^{(1)}$ is a scalar Riccati equation with constant coefficients, and it admits a closed-form solution.
+
+\begin{lemma}[Closed-form solution]\label{lem:riccati}
+%% [NEW]: the draft solved only for the steady state
+Define the discriminant and the roots
+\begin{equation}\label{eq:roots}
+d= \sqrt{ \bar\kappa^{2}+4\vartheta^{2} \theta^{2} \gamma (\gamma-1) }, \qquad
+r_{\pm} = \frac{\bar\kappa \pm d}{2\vartheta^{2} \theta},
+\end{equation}
+and assume $d^{2}>0$. Then the solution of \eqref{eq:odes} is
+\begin{equation}\label{eq:riccati_solution}
+a^{(1)}(\tau) = \frac{ r_{+} r_{-} \left(1 - e^{-d \tau}\right)}{r_{+} - r_{-}\, e^{-d \tau}},
+\qquad
+a^{(0)}(\tau) = \frac{\theta}{2}\, a^{(1)}(\tau) + \frac{\theta \bar\kappa}{2} \left[ r_{-}\tau + \frac{1}{\vartheta^{2}\theta} \ln \frac{r_{+}-r_{-}}{r_{+}-r_{-}e^{-d\tau}} \right].
+\end{equation}
+As $\tau \to \infty$, the loading converges to the steady state $a^{(1)}_{\infty} = r_{-}$.
+\end{lemma}
+\begin{proof}
+Direct substitution verifies that $a^{(1)}$ in \eqref{eq:riccati_solution} solves the Riccati equation with $a^{(1)}(0)=0$. For $a^{(0)}$, the identity $a^{(0)}_{\tau} = \frac{\theta}{2}\left[ a^{(1)}_{\tau} + \bar\kappa a^{(1)} \right]$ follows from \eqref{eq:odes}, and integrating $a^{(1)}$ in closed form gives the stated expression.
+\end{proof}
+
+\begin{remark}[Branch selection and validity]\label{rem:branch}
+%% [CORRECTED vs chapter Eqs (lsv8), (lsv9)] and [NEW] justification
+The steady state $r_{-}$ is the attracting fixed point of the Riccati flow started at $a^{(1)}(0)=0$, while $r_{+}$ is repelling. The root $r_{-}$ also vanishes in the two limits without volatility risk compensation, $\gamma \to 0$ and $\gamma \to 1$, while $r_{+}$ does not, which confirms the selection on economic grounds. For $0<\gamma<1$ the discriminant is positive if $\bar\kappa^{2} \geq 4\vartheta^{2}\theta^{2}\gamma(1-\gamma)$, for which $\bar\kappa \geq \vartheta\theta$ is sufficient since $\gamma(1-\gamma) \leq 1/4$. For $\gamma<0$ the discriminant is always positive.
+\end{remark}
+
+\section{Endogenous linear market prices of risk}\label{sec:linearity}
+
+%% [NEW] this section is the main addition relative to the draft
+Under the log-linear closure, the loading $\psi = \hat{g}_{v}/\hat{g} = a^{(1)}(\tau)$ does not depend on the volatility state. Substituting $\beta(\sigma)=\beta\sigma$ and $a(\sigma)=\varepsilon\sigma$ into \eqref{eq:mprs}, both market prices of risk become exactly proportional to the volatility:
+\begin{equation}\label{eq:linear_mprs}
+\lambda_{0}(t) = \bar\lambda_{0}(\tau)\, \sigma_{t}, \quad \bar\lambda_{0}(\tau) = (1-\gamma) - \beta\, a^{(1)}(\tau),
+\qquad
+\lambda_{1}(t) = \bar\lambda_{1}(\tau)\, \sigma_{t}, \quad \bar\lambda_{1}(\tau) = -\varepsilon\, a^{(1)}(\tau).
+\end{equation}
+The linear specification $\lambda_{i} = \bar\lambda_{i}\sigma$, which \cite{SeppRakhmonov2024} adopt with reference to \cite{BakshiKapadia2003}, is therefore not an auxiliary assumption in this economy: it is the form the equilibrium delivers. The equity risk premium equals $\mu - r = \bar\lambda_{0}\sigma^{2}$, which is proportional to the instantaneous variance.
+
+The drift adjustment becomes $\varphi = \left[ (1-\gamma)\beta - \vartheta^{2} a^{(1)} \right]\sigma^{2}$, so the $\QQ$-drift of the volatility retains the quadratic form:
+\begin{equation}\label{eq:Qdrift}
+b(\sigma) - \varphi = \kappa_{1}\theta - \left(\kappa_{1}-\kappa_{2}\theta\right)\sigma - \hat\kappa_{2}\, \sigma^{2},
+\qquad
+\hat\kappa_{2} = \kappa_{2} + (1-\gamma)\beta - \vartheta^{2} a^{(1)},
+\end{equation}
+which agrees with $\hat\kappa_{2} = \kappa_{2}+\beta\bar\lambda_{0}+\varepsilon\bar\lambda_{1}$ under \eqref{eq:linear_mprs}. The remaining risk-neutral parameters follow from the mapping in \cite{SeppRakhmonov2024}:
+\begin{equation}\label{eq:Qparams}
+\hat \theta =  \frac{ - (\kappa_1-\kappa_2\theta) + \sqrt{(\kappa_1-\kappa_2\theta)^{2}+4\theta\kappa_{1}\hat\kappa_2}}{2\hat\kappa_2}, \qquad
+\hat \kappa_1 = \frac{ (\kappa_1-\kappa_2\theta) +  \sqrt{(\kappa_1-\kappa_2\theta)^{2}+4\theta\kappa_{1}\hat\kappa_2}}{2},
+\end{equation}
+so that the $\QQ$-dynamics are $d\sigma_{t} = (\hat\kappa_{1}+\hat\kappa_{2}\sigma_{t})(\hat\theta - \sigma_{t})dt + \beta\sigma_{t}d\hat{W}^{(0)}_{t}+\varepsilon\sigma_{t}d\hat{W}^{(1)}_{t}$. The equilibrium thereby preserves the invariance of the model class under the change of measure, with all $\QQ$-parameters stated in terms of the $\PP$-parameters and the risk aversion $1-\gamma$.\footnote{A reference implementation of the premia $\bar\lambda_{0}$, $\bar\lambda_{1}$ and the parameter mapping \eqref{eq:Qdrift}-\eqref{eq:Qparams} is planned for the \texttt{stochvolmodels} package, which implements the log-normal SV model of \cite{SeppRakhmonov2024}.}
+
+\section{Equilibrium jump risk premia in the Hawkes model}\label{sec:hawkes}
+
+%% [NEW] companion section: makes the correspondence with the jump-premia paper precise.
+%% Verified end-to-end in verify_hawkes_equilibrium.py: the PIDE residual of the
+%% exponential-affine ansatz is machine zero (the ansatz is exact here), the kernel
+%% satisfies E[M_T]=1 in Monte Carlo, and x*=1 maximizes expected utility.
+We extend the equilibrium derivation to the bivariate Hawkes jump model of \cite{LiuPackhamSepp2026}, where the jump risk premia are specified through a parametric change of measure with two external tilt parameters $\chi^{+}$ and $\chi^{-}$ calibrated to option prices. We show that the CRRA equilibrium generates exactly this family and restricts the direct jump tilts to a common value set by the risk aversion.
+
+\subsection{Model and economy}
+
+The price process under $\PP$ carries a diffusive component and two self- and cross-exciting jump components:
+\begin{equation}\label{eq:hawkes_dS}
+\begin{split}
+\frac{dS_{t}}{S_{t-}} &= \mu_{t}\, dt + \sigma\, dW_{t} + \left[ (e^{j^{+}}-1)\, dN^{(1)}_{t} - \lambda^{+}_{t} m^{+} dt \right] + \left[ (e^{j^{-}}-1)\, dN^{(2)}_{t} - \lambda^{-}_{t} m^{-} dt \right],\\
+d\lambda^{+}_{t} &= \kappa^{+}(\theta^{+}-\lambda^{+}_{t})\, dt + \beta_{11}\, j^{+} dN^{(1)}_{t} + \beta_{12}\, j^{-} dN^{(2)}_{t},\\
+d\lambda^{-}_{t} &= \kappa^{-}(\theta^{-}-\lambda^{-}_{t})\, dt + \beta_{21}\, j^{+} dN^{(1)}_{t} + \beta_{22}\, j^{-} dN^{(2)}_{t},
+\end{split}
+\end{equation}
+where $N^{(1)}_{t}$ and $N^{(2)}_{t}$ count positive and negative jumps with intensities $\lambda^{+}_{t}$ and $\lambda^{-}_{t}$, the jump sizes $j^{\pm}$ have densities $\varpi^{\pm}$, and $W_{t}$ is an independent Brownian motion. We write the moment functions of the jump sizes as
+\begin{equation}\label{eq:hawkes_ell}
+\ell^{\pm}(c) = \E\left[ e^{c\, j^{\pm}} \right], \qquad m^{\pm} = \ell^{\pm}(1) - 1,
+\end{equation}
+so that $\ell^{\pm}(c) = \mathcal{L}^{(\pm)}(-c)$ in the Laplace-transform notation of \cite{LiuPackhamSepp2026}. The intensities $\lambda^{\pm}_{t}$ do not clash with the market prices of risk $\lambda_{0}$, $\lambda_{1}$ of the volatility model, which do not appear in this section. The economy is that of Section \ref{sec:model}: the index in unit supply, the money market account at rate $r$, derivatives in zero net supply, and a representative CRRA agent with horizon $T$. The drift $\mu_{t}$ is endogenous. At the fraction $x_{t}$ in the index, wealth follows
+\begin{equation}\label{eq:hawkes_wealth}
+\frac{d\Pi_{t}}{\Pi_{t-}} = \left[ r + x_{t}(\mu_{t}-r) - x_{t}\lambda^{+}_{t}m^{+} - x_{t}\lambda^{-}_{t}m^{-} \right] dt + x_{t}\sigma\, dW_{t} + x_{t}(e^{j^{+}}-1)\, dN^{(1)}_{t} + x_{t}(e^{j^{-}}-1)\, dN^{(2)}_{t}.
+\end{equation}
+
+\subsection{HJB equation and equilibrium premia}
+
+The value function $J(t,\Pi,\lambda^{+},\lambda^{-})$ satisfies the HJB equation
+\begin{equation}\label{eq:hawkes_hjb}
+\begin{split}
+0 = \max_{x} \Big\{ &\partial_{t}J + \left[ r + x(\mu-r) - x\lambda^{+}m^{+} - x\lambda^{-}m^{-} \right]\Pi J_{\Pi} + \frac{1}{2}x^{2}\sigma^{2}\Pi^{2}J_{\Pi\Pi} \\
+&+ \kappa^{+}(\theta^{+}-\lambda^{+})J_{\lambda^{+}} + \kappa^{-}(\theta^{-}-\lambda^{-})J_{\lambda^{-}} \\
+&+ \lambda^{+} \E\left[ J\!\left(t, \left(1+x(e^{j^{+}}-1)\right)\Pi,\, \lambda^{+}+\beta_{11}j^{+},\, \lambda^{-}+\beta_{21}j^{+}\right) - J \right] \\
+&+ \lambda^{-} \E\left[ J\!\left(t, \left(1+x(e^{j^{-}}-1)\right)\Pi,\, \lambda^{+}+\beta_{12}j^{-},\, \lambda^{-}+\beta_{22}j^{-}\right) - J \right] \Big\}.
+\end{split}
+\end{equation}
+We apply the CRRA ansatz with an exponential-affine coefficient in the intensities:
+\begin{equation}\label{eq:hawkes_ansatz}
+J = g(t,\lambda^{+},\lambda^{-})\, \frac{\Pi^{\gamma}}{\gamma}, \qquad
+g = \exp\left\{ q_{0}(t) + \psi^{+}(t)\,\lambda^{+} + \psi^{-}(t)\,\lambda^{-} \right\},
+\end{equation}
+where $\psi^{\pm} = \partial_{\lambda^{\pm}} \ln g$ are the risk-premium loadings on the two intensities, the exact analogues of $\psi = g_{\sigma}/g$ in the volatility model. The loadings define the effective jump tilts and the compensator gaps
+\begin{equation}\label{eq:hawkes_chi}
+\chi^{\pm} = (\gamma-1) + \psi^{+}\beta_{1i} + \psi^{-}\beta_{2i}, \qquad
+\Delta^{\pm} = \ell^{\pm}(1+\chi^{\pm}) - \ell^{\pm}(\chi^{\pm}),
+\end{equation}
+with $i=1$ for positive and $i=2$ for negative jumps. Differentiating \eqref{eq:hawkes_hjb} in $x$ and evaluating at the market-clearing allocation $x^{*}=1$, where $\left(1+x(e^{j}-1)\right)^{\gamma-1}$ becomes $e^{(\gamma-1)j}$, yields the equilibrium equity premium:
+\begin{equation}\label{eq:hawkes_premium}
+\mu_{t} - r = (1-\gamma)\sigma^{2} + \lambda^{+}_{t}\left( m^{+} - \Delta^{+} \right) + \lambda^{-}_{t}\left( m^{-} - \Delta^{-} \right).
+\end{equation}
+In the jump-risk-premia notation of \cite{LiuPackhamSepp2026}, where the premia are the differences between risk-neutral and statistical jump compensators, Eq \eqref{eq:hawkes_premium} reads $\mu-r = (1-\gamma)\sigma^{2} - \gamma^{+}_{t} - \gamma^{-}_{t}$: the equity premium is the diffusive premium minus the two jump premia. The equilibrium thereby predicts that the statistical drift is affine in the intensities rather than constant.
+
+Substituting \eqref{eq:hawkes_premium} back into \eqref{eq:hawkes_hjb} at $x^{*}=1$ reduces the HJB equation to a linear equation for $g$. The exponential-affine form \eqref{eq:hawkes_ansatz} solves this equation exactly, because the generator maps exponential-affine functions into themselves with affine coefficients. This contrasts with the volatility model, where a finite log-polynomial ansatz is a local closure. The loadings solve the system, in time to horizon $\tau = T-t$,
+\begin{equation}\label{eq:hawkes_odes}
+\begin{split}
+\partial_{\tau}\psi^{+} &= -\kappa^{+}\psi^{+} + (1-\gamma)\,\ell^{+}(1+\chi^{+}) + \gamma\, \ell^{+}(\chi^{+}) - 1, \qquad \psi^{+}(0)=0,\\
+\partial_{\tau}\psi^{-} &= -\kappa^{-}\psi^{-} + (1-\gamma)\,\ell^{-}(1+\chi^{-}) + \gamma\, \ell^{-}(\chi^{-}) - 1, \qquad \psi^{-}(0)=0,\\
+\partial_{\tau}q_{0} &= \gamma r + \frac{1}{2}\gamma(1-\gamma)\sigma^{2} + \kappa^{+}\theta^{+}\psi^{+} + \kappa^{-}\theta^{-}\psi^{-}, \qquad q_{0}(0)=0.
+\end{split}
+\end{equation}
+The system belongs to the same class as the transform ODEs of the moment generating function in \cite{LiuPackhamSepp2026}, a moment function of an affine argument plus a linear term, so the same Runge-Kutta machinery applies. The moment functions in \eqref{eq:hawkes_odes} are finite provided the tilted exponents stay inside the domains of $\ell^{\pm}$, which is the equilibrium analogue of the admissibility condition on $(\chi^{+},\chi^{-})$ in \cite{LiuPackhamSepp2026}.
+
+\subsection{Identification of the measure change}
+
+For the terminal-wealth value function, the pricing kernel is the marginal utility of wealth, $\zeta_{t} = J_{\Pi}(t,\Pi_{t},\lambda^{+}_{t},\lambda^{-}_{t}) = g\, \Pi_{t}^{\gamma-1}$. Combining the equations \eqref{eq:hawkes_premium} and \eqref{eq:hawkes_odes} shows that the drift of $\zeta_{t}$ equals $-r\zeta_{t}$, so the money market account is priced consistently and the density process
+\begin{equation}\label{eq:hawkes_kernel}
+M_{t} = e^{r t}\, \frac{\zeta_{t}}{\zeta_{0}}
+\end{equation}
+is a $\PP$-martingale defining $\QQ$. On a positive jump, $M_{t}$ multiplies by $e^{(\gamma-1)j^{+}}\, g(\lambda^{+}+\beta_{11}j^{+}, \lambda^{-}+\beta_{21}j^{+})/g = e^{\chi^{+} j^{+}}$, and on a negative jump by $e^{\chi^{-} j^{-}}$. The Brownian component carries the constant Girsanov shift $\varphi = (1-\gamma)\sigma$. The induced risk-neutral dynamics are therefore exactly the $\QQ$-family of \cite{LiuPackhamSepp2026}: the intensities scale as $\lambda^{\pm,\QQ}_{t} = \ell^{\pm}(\chi^{\pm})\,\lambda^{\pm}_{t}$ and the jump-size densities are exponentially tilted, $\varpi^{\pm,\QQ}(j) \propto e^{\chi^{\pm} j}\, \varpi^{\pm}(j)$. The identification with their density-process parametrization is
+\begin{equation}\label{eq:hawkes_identification}
+\xi^{+} = \xi^{-} = \gamma - 1, \qquad q_{1}^{\pm} = \psi^{\pm}, \qquad \varphi(t) = (1-\gamma)\sigma,
+\end{equation}
+so their internal intensity loadings correspond to the value-function loadings and their direct tilts correspond to the common marginal-utility exponent. Their state-dependent Brownian premium reduces to a constant under the equilibrium drift. The Brownian price of risk carries no hedging correction, in contrast with $\lambda_{0}$ in the volatility model, because the Brownian shock does not move the investment opportunity set.
+
+Three consequences follow. First, a single risk-aversion parameter restricts the direct tilts to a common value, $\xi^{+}=\xi^{-}=\gamma-1$, while the calibration in \cite{LiuPackhamSepp2026} leaves $(\chi^{+},\chi^{-})$ free. Consistency of the calibrated tilts with a common $\xi$ is therefore a direct test of single-parameter CRRA pricing. Rejections measure tail-specific pricing beyond the preferences of the representative agent. Second, the effective tilts $\chi^{+}$ and $\chi^{-}$ differ from each other even under a single $\gamma$, through the loadings $\psi^{\pm}$ and the asymmetric excitation matrix in \eqref{eq:hawkes_chi}, so part of any measured asymmetry is preference-free clustering compensation. Third, the limits behave correctly: for $\gamma \to 1$ the loadings vanish and $\QQ = \PP$, and for log utility, $\gamma \to 0$, the loadings vanish and $\chi^{\pm} = -1$, the pure num\'{e}raire tilt with Esscher parameter one in the sense of \cite{GerberShiu1994}, with $\varphi = \sigma$.
+
+\section{Equilibrium premia in the regime-switching log-normal SV model}\label{sec:regime}
+
+We combine the quadratic-drift LogSV model with the transition-tied jump model of
+\cite{Sepp2026gba}.  Regime 1 is growth and regime 2 is stress.  A transition
+$1\to2$ is a crash and $2\to1$ is a recovery; there is no separate Poisson jump
+process.  This distinction is important because the pricing kernel changes the
+transition clock and its mark distribution jointly.
+
+\subsection{Physical dynamics and return convention}
+
+Let $N^{[ij]}(dt,dz)$ be the marked transition measure with $\PP$-compensator
+$1_{\{\chi_{t-}=i\}}\lambda^{[ij]}F^{[i]}(dz)dt$, and put $h(z)=e^{z}-1$.
+The compensated-return convention of \cite{Sepp2026gba} is
+\begin{equation}\label{eq:regime_sv}
+\begin{split}
+\frac{dS_t}{S_{t-}}={}&\bar\mu^{[i]}dt+\sigma_t dW_t^{(0)}
+ +\int h(z)\left(N^{[ij]}(dt,dz)-\lambda^{[ij]}F^{[i]}(dz)dt\right),\\
+d\sigma_t={}&b^{[i]}(\sigma_t)dt+\beta^{[i]}\sigma_t dW_t^{(0)}
+ +\varepsilon^{[i]}\sigma_t dW_t^{(1)},\\
+b^{[i]}(\sigma)={}&(\kappa_1^{[i]}+\kappa_2^{[i]}\sigma)
+(\theta^{[i]}-\sigma),
+\end{split}
+\end{equation}
+The adjacent parenthesized factors in the last line are multiplied.
+Volatility is continuous when the regime changes; the parameters, including its
+attractor, switch after the price jump.  Equivalently, the raw between-transition
+price drift is
+\begin{equation}\label{eq:regime_drift_convention}
+\mu^{[i]}=\bar\mu^{[i]}-\lambda^{[ij]}\alpha^{[i]},
+\qquad \alpha^{[i]}=\E[h(J^{[i]})]=\ell^{[i]}(1)-1.
+\end{equation}
+The crash and recovery marks follow the paper's mean convention,
+\begin{equation}\label{eq:regime_jump_laws}
+J^{[1]}\sim-\operatorname{Exp}(1/\eta^{[1]}),\qquad
+J^{[2]}\sim+\operatorname{Exp}(1/\eta^{[2]}),
+\end{equation}
+so $\eta^{[i]}$ is the mean absolute log jump, not the exponential rate, and
+\begin{equation}\label{eq:regime_jump_mgf}
+\ell^{[1]}(c)=\frac{1}{1+\eta^{[1]}c},\qquad
+\ell^{[2]}(c)=\frac{1}{1-\eta^{[2]}c}.
+\end{equation}
+
+Let $g_i^H(t,\sigma)$ be the value coefficient for one fixed representative-agent
+terminal date $H$.  With
+$\psi_i^H=\partial_\sigma\log g_i^H$,
+$\rho_i^H=g_j^H/g_i^H$, and
+$\Delta_i=\ell^{[i]}(\gamma)-\ell^{[i]}(\gamma-1)$, the market-clearing
+condition gives the two equivalent premium formulas
+\begin{equation}\label{eq:regime_premium}
+\begin{split}
+\mu^{[i]}-r={}&(1-\gamma)\sigma^2-\beta^{[i]}\sigma^2\psi_i^H
+-\lambda^{[ij]}\rho_i^H\Delta_i,\\
+\bar\mu^{[i]}-r={}&(1-\gamma)\sigma^2-\beta^{[i]}\sigma^2\psi_i^H
++\lambda^{[ij]}\left(\alpha^{[i]}-\rho_i^H\Delta_i\right).
+\end{split}
+\end{equation}
+The first line prices the raw between-transition drift; the second uses the total
+expected-return convention reported in the allocation paper.  Mixing the two
+conventions would omit the physical jump compensator.
+
+\subsection{Coupled equilibrium coefficient and log-quadratic closure}
+
+Substitution of \eqref{eq:regime_premium} into the HJB equation gives the linear
+coupled PDE
+\begin{equation}\label{eq:regime_system}
+g_{i,t}^H+b^{[i]}g_{i,\sigma}^H
++\frac12\vartheta_i^2\sigma^2g_{i,\sigma\sigma}^H
++\left[\gamma r+\frac12\gamma(1-\gamma)\sigma^2\right]g_i^H
++\lambda^{[ij]}\left(\Lambda_i g_j^H-g_i^H\right)=0,
+\end{equation}
+where $g_i^H(H,\sigma)=1$,
+$\vartheta_i^2=(\beta^{[i]})^2+(\varepsilon^{[i]})^2$, and
+\begin{equation}\label{eq:regime_Lambda}
+\Lambda_i=(1-\gamma)\ell^{[i]}(\gamma)
++\gamma\ell^{[i]}(\gamma-1).
+\end{equation}
+After removing the rate term and writing $h=H-t$, its Feynman--Kac representation is
+\begin{equation}\label{eq:regime_FK}
+\widehat g_i(h,\sigma)=\E_i^{\PP}\left[
+\exp\left\{\frac12\gamma(1-\gamma)\int_0^h\sigma_s^2ds\right\}
+\prod_{0<s\le h:\,\Delta\chi_s\ne0}\Lambda_{\chi_{s-}}
+\,\middle|\,\sigma_0=\sigma\right].
+\end{equation}
+Every derivative maturity $T\le H$ uses this same $g^H$.  Re-solving the agent
+problem with $H=T$ for each option would generate maturity-specific probability
+measures rather than one equilibrium measure.
+
+For $v_i=\sigma-\theta^{[i]}$ we use the published-FIRST, degree-two log expansion
+\begin{equation}\label{eq:regime_ansatz}
+\widehat g_i(h,\sigma)=\exp B_i(h,v_i),\qquad
+B_i=a_i^{(0)}+a_i^{(1)}v_i+a_i^{(2)}v_i^2.
+\end{equation}
+At the same physical volatility, $v_j=v_i+\delta_i$ with
+$\delta_i=\theta^{[i]}-\theta^{[j]}$.  Hence
+$D_i^B=B_j(h,v_i+\delta_i)-B_i(h,v_i)=d_0^i+d_1^iv_i+d_2^iv_i^2$, where
+\begin{equation}\label{eq:regime_dcoef}
+\begin{split}
+d_0^i&=a_j^{(0)}+a_j^{(1)}\delta_i+a_j^{(2)}\delta_i^2-a_i^{(0)},\\
+d_1^i&=a_j^{(1)}+2a_j^{(2)}\delta_i-a_i^{(1)},\qquad
+d_2^i=a_j^{(2)}-a_i^{(2)}.
+\end{split}
+\end{equation}
+Taylor projection of $e^{D_i^B}$ through $v_i^2$ gives six nonlinear ODEs:
+\begin{equation}\label{eq:regime_odes}
+\begin{split}
+\partial_h a_i^{(0)}={}&\frac12\vartheta_i^2(\theta^{[i]})^2s_i
++\frac12\gamma(1-\gamma)(\theta^{[i]})^2
++\lambda^{[ij]}\left(\Lambda_i e^{d_0^i}-1\right),\\
+\partial_h a_i^{(1)}={}&-\bar\kappa_i a_i^{(1)}
++\vartheta_i^2\theta^{[i]}s_i
++2\vartheta_i^2(\theta^{[i]})^2a_i^{(1)}a_i^{(2)}
++\gamma(1-\gamma)\theta^{[i]}
++\lambda^{[ij]}\Lambda_i e^{d_0^i}d_1^i,\\
+\partial_h a_i^{(2)}={}&-2\bar\kappa_i a_i^{(2)}-\kappa_2^{[i]}a_i^{(1)}
++\frac12\vartheta_i^2s_i
++4\vartheta_i^2\theta^{[i]}a_i^{(1)}a_i^{(2)}
++2\vartheta_i^2(\theta^{[i]})^2(a_i^{(2)})^2\\
+&+\frac12\gamma(1-\gamma)
++\lambda^{[ij]}\Lambda_i e^{d_0^i}
+\left(d_2^i+\frac12(d_1^i)^2\right),
+\end{split}
+\end{equation}
+where $s_i=(a_i^{(1)})^2+2a_i^{(2)}$,
+$\bar\kappa_i=\kappa_1^{[i]}+\kappa_2^{[i]}\theta^{[i]}$, and all coefficients
+start from zero.  The PDE \eqref{eq:regime_system} is linear in $g_i$, but the
+coefficient system \eqref{eq:regime_odes} is nonlinear.  The local single-regime
+Riccati formula of Lemma \ref{lem:riccati} is the only literal closed form; the
+regime solution is a semi-analytic finite-ODE approximation.
+
+\subsection{Quadratic-preserving closure and relation to IJTAF}
+
+There is a second, internally consistent approximation at the preceding Taylor
+order.  It must be re-solved from the equilibrium PDE; it is not obtained by
+deleting the cubic drift from the degree-two solution.  Define
+\begin{equation}\label{eq:regime_linear_ansatz}
+B_i^{\mathrm L}(h,v_i)=\widetilde a_i^{(0)}(h)
++\widetilde a_i^{(1)}(h)v_i,
+\qquad
+\widehat g_i^{\mathrm L}=\exp B_i^{\mathrm L}.
+\end{equation}
+At a common volatility, its regime difference is
+\begin{equation}\label{eq:regime_linear_difference}
+D_i^{\mathrm L}=B_j^{\mathrm L}(h,v_i+\delta_i)-B_i^{\mathrm L}(h,v_i)
+=\widetilde d_0^i+\widetilde d_1^iv_i,
+\end{equation}
+where
+$\widetilde d_0^i=\widetilde a_j^{(0)}+\widetilde a_j^{(1)}\delta_i
+-\widetilde a_i^{(0)}$ and
+$\widetilde d_1^i=\widetilde a_j^{(1)}-\widetilde a_i^{(1)}$.
+Projection of \eqref{eq:regime_system} through degree one gives four coupled
+nonlinear ODEs:
+\begin{equation}\label{eq:regime_linear_odes}
+\begin{split}
+\partial_h\widetilde a_i^{(0)}={}&
+\frac12\vartheta_i^2(\theta^{[i]})^2(\widetilde a_i^{(1)})^2
++\frac12\gamma(1-\gamma)(\theta^{[i]})^2
++\lambda^{[ij]}\left(\Lambda_i e^{\widetilde d_0^i}-1\right),\\
+\partial_h\widetilde a_i^{(1)}={}&
+-\bar\kappa_i\widetilde a_i^{(1)}
++\vartheta_i^2\theta^{[i]}(\widetilde a_i^{(1)})^2
++\gamma(1-\gamma)\theta^{[i]}
++\lambda^{[ij]}\Lambda_i e^{\widetilde d_0^i}\widetilde d_1^i,
+\end{split}
+\end{equation}
+with zero initial conditions.  Unlike the scalar single-regime Riccati equation,
+this regime-switching system is semi-analytic rather than a literal closed form.
+
+\paragraph{CRRA consistency.}
+The adjective ``log-linear'' describes the approximation to $\log \widehat g_i$;
+it does not replace CRRA preferences by CARA preferences.  The utility function
+$u(\Pi)=\Pi^\gamma/\gamma$, relative risk aversion $1-\gamma$, homothetic value
+ansatz $J_i=g_i^H\Pi^\gamma/\gamma$, and market-clearing identities are unchanged.
+Equations \eqref{eq:regime_linear_odes} solve exactly the degree-one projection of
+the CRRA coefficient PDE, while substitution into the unprojected PDE leaves a
+local residual beginning at $v_i^2$.  Closure $\mathrm L$ is therefore an
+internally consistent \emph{approximate CRRA equilibrium}, not an exact global
+solution of \eqref{eq:regime_system}.  Internal consistency additionally requires
+the same $B_i^{\mathrm L}$ to determine $\psi_i^{\mathrm L}$, the Brownian market
+prices of risk, $\rho_i^{\mathrm L}$, the marked transition compensator, the option
+transform, and Monte Carlo dynamics.  Re-solving degree one and using it throughout
+preserves that consistency; deleting only the cubic term from closure $\mathrm F$
+does not.
+
+The resulting equilibrium loading is state independent,
+$\psi_i^{\mathrm L}=\widetilde a_i^{(1)}$, so both Brownian market prices of risk
+are linear in volatility:
+\begin{equation}\label{eq:regime_linear_mpr}
+\lambda_{0,i}^{\mathrm L}
+=\left[(1-\gamma)-\beta^{[i]}\widetilde a_i^{(1)}\right]\sigma,
+\qquad
+\lambda_{1,i}^{\mathrm L}
+=-\varepsilon^{[i]}\widetilde a_i^{(1)}\sigma.
+\end{equation}
+Its induced volatility drift is exactly quadratic,
+\begin{equation}\label{eq:regime_quadratic_Q_drift}
+b_i^{\QQ,\mathrm L}
+=-\bar\kappa_i v_i-\kappa_2^{[i]}v_i^2
+-\beta^{[i]}(1-\gamma)(\theta^{[i]}+v_i)^2
++\vartheta_i^2\widetilde a_i^{(1)}(\theta^{[i]}+v_i)^2.
+\end{equation}
+The transition clock must simultaneously use
+$\rho_i^{\mathrm L}=\exp(\widetilde d_0^i+\widetilde d_1^iv_i)$.
+The direct Esscher tilt and the conditional risk-neutral jump-size law are the
+same as under the log-quadratic closure; only the re-solved continuous loading and
+regime-timing ratio differ.
+
+There is no contradiction with IJTAF.  \cite{SeppRakhmonov2024} treat the linear
+Brownian market prices of risk as model inputs, so their Girsanov drift adjustment
+is quadratic.  Their degree-two
+and degree-four coefficients belong to the option-pricing transform and never feed
+back into the density kernel.  Here $B_i$ is an equilibrium value coefficient and
+$\psi_i=\partial_\sigma B_i$ enters the Girsanov kernel itself.  A degree-two $B_i$
+makes $\psi_i$ affine and $\sigma^2\psi_i$ cubic.  Degree one is precisely the
+equilibrium approximation order at which the endogenous Brownian premia stay
+linear and the quadratic-drift LogSV class remains invariant.
+
+\begin{table}[htbp]
+\centering
+\small
+\begin{tabular}{lll}
+\toprule
+Property & Log-linear closure $\mathrm L$ & Log-quadratic closure $\mathrm F$\\
+\midrule
+Degree of $B_i$ & 1 & 2\\
+Equilibrium ODEs & 4 & 6\\
+First omitted local power & $v_i^2$ & $v_i^3$\\
+$\psi_i=\partial_\sigma B_i$ & constant & affine\\
+Brownian premia & linear in $\sigma$ & quadratic in $\sigma$\\
+$\QQ$ volatility drift & quadratic & cubic\\
+$\log\rho_i$ & linear in $v_i$ & quadratic in $v_i$\\
+Option-transform degree & 4 & 4\\
+\bottomrule
+\end{tabular}
+\caption{The two internally consistent equilibrium closures compared in the
+replication.  The label $\mathrm F$ denotes the full induced cubic dynamics, not
+an additional Taylor truncation of the stochastic drift.}
+\label{tab:regime_closures}
+\end{table}
+
+\subsection{Exact induced risk-neutral dynamics and the cubic term}
+
+At a marked transition $i\to j$ the marginal-utility density jumps by
+$\rho_i^H(t,\sigma)e^{(\gamma-1)z}$.  The full marked compensator under the
+fixed-horizon equilibrium measure is therefore
+\begin{equation}\label{eq:regime_Q_kernel}
+\nu_{ij}^{\QQ,H}(t,\sigma,dz)=
+\lambda^{[ij]}\rho_i^H(t,\sigma)e^{(\gamma-1)z}F^{[i]}(dz).
+\end{equation}
+It implies
+\begin{equation}\label{eq:regime_Q}
+q_{ij}^{\QQ,H}=\lambda^{[ij]}\rho_i^H\ell^{[i]}(\gamma-1),
+\qquad
+F_i^{\QQ}(dz)=\frac{e^{(\gamma-1)z}}{\ell^{[i]}(\gamma-1)}F^{[i]}(dz),
+\end{equation}
+and the exponential means become
+\begin{equation}\label{eq:regime_Q_eta}
+\eta_1^{\QQ}=\frac{\eta^{[1]}}{1-(1-\gamma)\eta^{[1]}},
+\qquad
+\eta_2^{\QQ}=\frac{\eta^{[2]}}{1+(1-\gamma)\eta^{[2]}}.
+\end{equation}
+Thus the chain is no longer independent of volatility under $\QQ$: its clock
+depends on $t$ and $\sigma_t$ through $\rho_i^H$.
+
+In compensated form, the exact induced dynamics are
+\begin{equation}\label{eq:regime_Q_dynamics}
+\begin{split}
+\frac{dS_t}{S_{t-}}={}&r\,dt+\sigma_t dW_t^{(0),\QQ}
++\int h(z)\left(N^{[ij]}(dt,dz)-\nu_{ij}^{\QQ,H}(t,\sigma_t,dz)dt\right),\\
+d\sigma_t={}&b_i^{\QQ,H}(t,\sigma_t)dt
++\beta^{[i]}\sigma_t dW_t^{(0),\QQ}
++\varepsilon^{[i]}\sigma_t dW_t^{(1),\QQ},\\
+b_i^{\QQ,H}(t,\sigma)={}&b^{[i]}(\sigma)
+-\beta^{[i]}(1-\gamma)\sigma^2+\vartheta_i^2\sigma^2\psi_i^H(t,\sigma).
+\end{split}
+\end{equation}
+For the log-quadratic equilibrium approximation,
+$\psi_i^H=a_i^{(1)}+2a_i^{(2)}v_i$, and hence
+\begin{equation}\label{eq:regime_cubic_drift}
+b_i^{\QQ,H}=-\bar\kappa_i v_i-\kappa_2^{[i]}v_i^2
+-\beta^{[i]}(1-\gamma)(\theta^{[i]}+v_i)^2
++\vartheta_i^2(\theta^{[i]}+v_i)^2
+\left(a_i^{(1)}+2a_i^{(2)}v_i\right).
+\end{equation}
+The coefficient of $v_i^3$ is exactly
+$2\vartheta_i^2a_i^{(2)}$.  The cubic term is absent from the primitive
+$\PP$-dynamics but present in the full induced $\QQ$-dynamics whenever
+$a_i^{(2)}\ne0$.  Calling its unmatched action a PDE residual does not remove it
+from the stochastic model.  Deleting only this term while retaining the degree-two
+$B_i$, Brownian loadings, and timing ratio would mix two different density kernels
+and is not an equilibrium approximation.  Our full-cubic Monte Carlo retains
+\eqref{eq:regime_cubic_drift}.  The quadratic-preserving Monte Carlo instead uses
+the separately solved \eqref{eq:regime_linear_odes},
+\eqref{eq:regime_quadratic_Q_drift}, and $\rho_i^{\mathrm L}$ everywhere.
+The difference between the two induced drifts is
+\begin{equation}\label{eq:regime_drift_closure_difference}
+b_i^{\QQ,\mathrm F}-b_i^{\QQ,\mathrm L}
+=\vartheta_i^2\sigma^2\left[
+(a_i^{(1)}-\widetilde a_i^{(1)})+2a_i^{(2)}v_i\right].
+\end{equation}
+It is a total closure difference: even at $v_i=0$ the two re-solved linear
+coefficients need not coincide.
+
+\subsection{Semi-analytic option transform}
+
+Let $X_t=\log(S_t/\mathcal B_t)$ be the log price relative to the money-market
+account, let an option expire at $T\le H$, and set $u=T-t$.  For the transform
+$\E^{\QQ}[e^{-\Phi(X_T-X_t)}]$, write
+\begin{equation}\label{eq:regime_option_ansatz}
+G_i(u,x,v_i;\Phi)=e^{-\Phi x}\exp C_i(u,v_i;\Phi),
+\qquad C_i(0,v_i;\Phi)=0.
+\end{equation}
+At backward option time $s\in[0,u]$, the remaining agent horizon is
+$h_A=H-T+s$.  Put
+$D_i^C=C_j(s,v_i+\delta_i;\Phi)-C_i(s,v_i;\Phi)$ and let $\mathcal P_m$
+denote Taylor projection through degree $m$.  For closure
+$c\in\{\mathrm L,\mathrm F\}$, use $B_i=B_i^c$,
+$D_i^B=B_j^c-B_i^c$, and $b_i^{\QQ,H}=b_i^{\QQ,c}$ consistently.
+Direct collection of the corresponding full generator gives
+\begin{equation}\label{eq:regime_option_ode}
+\begin{split}
+\partial_s C_i=\mathcal P_m\Big[&
+\left(b_i^{\QQ,H}(h_A,v_i)-\Phi\beta^{[i]}\sigma^2\right)C_i'
++\frac12\vartheta_i^2\sigma^2\left(C_i''+(C_i')^2\right)
++\frac12\Phi(\Phi+1)\sigma^2\\
+&+\lambda^{[ij]}e^{D_i^B(h_A,v_i)}
+\left\{\ell^{[i]}(\gamma-1-\Phi)e^{D_i^C}
++\Phi\Delta_i-\ell^{[i]}(\gamma-1)\right\}\Big],
+\end{split}
+\end{equation}
+where $\sigma=\theta^{[i]}+v_i$.  We use $m=4$, the published-SECOND degree-four
+log transform, with either equilibrium closure.  The identities
+$C_i(\Phi=0)=C_i(\Phi=-1)=0$ verify normalization and the discounted-stock
+martingale.  Fourier inversion uses the line $\Phi=-1/2+iy$.  The implementation
+collects \eqref{eq:regime_option_ode} directly as polynomials.  Under closure
+$\mathrm F$, matched degree-three and degree-four contributions from the cubic
+drift are retained; only higher powers enter the residual.  Under closure
+$\mathrm L$, the exact quadratic $\QQ$ drift enters the same degree-four transform.
+
+\subsection{Equity illustration, implied skews, and verification}
+
+Table \ref{tab:regime_calibration} uses the transition intensities and jump sizes
+from the equity illustration of \cite{Sepp2026gba}.  The reported $-25\%$ crash and
+$+15\%$ recovery are expected arithmetic transition returns, implying
+$\eta^{[1]}=1/3$ and $\eta^{[2]}=3/23$.  The remaining response coefficients are
+the SPY LogSV illustration distributed with the package, combined with the paper's
+growth/stress volatility levels.  This hybrid is an illustration, not a calibration.
+\begin{table}[htbp]
+\centering
+\small
+\begin{tabular}{lrr}
+\toprule
+Parameter & Growth / crash & Stress / recovery\\
+\midrule
+$\theta^{[i]}$ & $15.0\%$ & $22.5\%$\\
+$\lambda^{[ij]}$ & $0.10$ & $1.00$\\
+$\E[e^{J^{[i]}}-1]$ & $-25.0\%$ & $+15.0\%$\\
+$\eta^{[i]}$ & $1/3$ & $3/23$\\
+$\kappa_1^{[i]}$ & $2.6949$ & $2.6949$\\
+$\kappa_2^{[i]}$ & $10.0107$ & $10.0107$\\
+$\beta^{[i]}$ & $-1.5082$ & $-1.5082$\\
+$\varepsilon^{[i]}$ & $0.8503$ & $0.8503$\\
+\bottomrule
+\end{tabular}
+\caption{Parameters used in the equity illustration.  The fixed agent horizon is
+$H=3$ years, $\gamma=-0.5$ (relative risk aversion $1.5$), $r=0$, the initial
+regime is growth, and $\sigma_0=15\%$.}
+\label{tab:regime_calibration}
+\end{table}
+For the paper's crash law, the required jump moments exist for $\gamma>-2$, while
+positivity of $\Lambda_1$ strengthens admissibility to $\gamma>-1$.  This is why
+the old $\gamma=-2$ stress experiment cannot be combined with the equity jump
+calibration.  At the baseline state the equilibrium tilt doubles the crash intensity
+from $0.10$ to approximately $0.20$ and changes the expected crash from $-25\%$ to
+$-40\%$; the recovery intensity changes from $1.00$ to approximately $0.84$ and its
+mean jump from $+15\%$ to $+12.24\%$.
+
+Figure \ref{fig:regime_smiles} uses the quadratic-preserving closure and shows the
+resulting implied-volatility skews.  Higher risk aversion raises and steepens the
+left wing because it makes crash marks more severe under $\QQ$.  The channel
+experiment shows that the Esscher tail tilt is the dominant left-wing premium in
+this calibration; diffusive and timing premia mainly shift the center and term
+structure.  These channel-isolation curves are martingale counterfactuals, not
+separate equilibria.  Starting in stress raises the right wing through the recovery
+transition, while starting in growth produces the familiar index downside skew.
+\begin{figure}[H]
+\centering
+\includegraphics[width=\textwidth]{regime_sv_smiles}
+\caption{Quadratic-preserving equilibrium implied-volatility term structure,
+risk-aversion sensitivity, premium-channel attribution, and initial-regime
+dependence.  Strikes are normalized by the forward.}
+\label{fig:regime_smiles}
+\end{figure}
+
+Figure \ref{fig:regime_premia} separates the mechanisms in the measure change.  The
+timing loading is modest for the baseline, while the tail tilt moves crash severity
+strongly with risk aversion.  Panel C compares the two separately solved $\QQ$
+drifts with the physical drift; the quadratic curve is not obtained by deleting a
+term from the full-cubic curve.
+\begin{figure}[H]
+\centering
+\includegraphics[width=\textwidth]{regime_sv_premia}
+\caption{Equilibrium transition, tail, volatility-drift, and value-loading channels.
+Panels A and D use the quadratic-preserving closure; Panel C overlays both closures.}
+\label{fig:regime_premia}
+\end{figure}
+
+Figure \ref{fig:regime_closure_comparison} makes the implied-volatility comparison
+direct.  The three-month level curves are visually indistinguishable.  Across the
+displayed strikes, the full-cubic minus quadratic-preserving difference is below
+about $0.5$ volatility basis points at three months and $1.4$ volatility basis
+points at one year for either initial regime.  Table
+\ref{tab:regime_closure_skews} reports the fixed-moneyness skew
+$\sigma_{\mathrm{IV}}(-0.20)-\sigma_{\mathrm{IV}}(+0.20)$; its closure difference
+stays below one volatility basis point at all four maturities.  This is a numerical
+finding for the displayed equity parameters, not a general identity.  Moreover,
+the gap measures total closure sensitivity rather than the isolated cubic term,
+because $\widetilde a_i^{(1)}$, $a_i^{(1)}$, and the transition timing ratios are
+re-solved consistently.
+\begin{figure}[H]
+\centering
+\includegraphics[width=\textwidth]{regime_sv_closure_comparison}
+\caption{Comparison of consistent equilibrium closures.  Panels A and B show
+three-month implied-volatility smiles under the log-linear equilibrium closure,
+which preserves a quadratic risk-neutral volatility drift, and the log-quadratic
+closure with its full induced cubic drift.  Panels C and D report
+$10^4(\sigma_{\mathrm{IV}}^{\mathrm F}-\sigma_{\mathrm{IV}}^{\mathrm L})$ for four
+maturities.  Physical parameters, preferences, jumps, agent horizon, and the
+degree-four option transform are identical.}
+\label{fig:regime_closure_comparison}
+\end{figure}
+\begin{table}[H]
+\centering
+\small
+\input{regime_sv_closure_comparison_table.tex}
+\caption{Fixed-moneyness implied-volatility skew comparison.  The skew columns are
+percentage-volatility points; the last column is full cubic minus
+quadratic-preserving in volatility basis points.}
+\label{tab:regime_closure_skews}
+\end{table}
+The replication performs six independent checks: the explicit degree-one ODE
+identity; the exact quadratic and derived cubic drift coefficients; the scalar
+Riccati residual;
+an exact frozen-volatility two-state matrix exponential; physical-measure Monte
+Carlo of \eqref{eq:regime_FK}; and full-$\QQ$ Monte Carlo of
+\eqref{eq:regime_Q_dynamics} for both closures and both initial regimes.  Following the event semantics
+of the GoalBasedAllocation implementation, a regime jump changes the price and the
+parameter state simultaneously.  Under $\QQ$ the event probability is evaluated
+pathwise as $1-e^{-q_{ij}^{\QQ,H}(t,\sigma)\,dt}$ because the equilibrium clock is
+state- and time-dependent.  The simulation preserves the common Brownian increment
+in price and volatility.  It uses the exact quadratic drift under closure
+$\mathrm L$ and retains the exact induced cubic under closure $\mathrm F$.  For both,
+the 1,601-point Fourier grid is checked against a 3,201-point refinement.  The
+physical-measure comparison quantifies each polynomial-closure error rather than
+mistaking it for Monte Carlo sampling error.  Option prices under each measure
+generated by its own approximate coefficient agree with their corresponding
+full-dynamics Monte Carlo within the stated confidence tolerance.
+\begin{figure}[H]
+\centering
+\includegraphics[width=\textwidth]{regime_sv_validation}
+\caption{Independent Monte Carlo checks of both equilibrium closures and their
+degree-four option transforms.  Each analytic option curve is compared with Monte
+Carlo under its own induced measure.  Error bars are 95\% Monte Carlo intervals.}
+\label{fig:regime_validation}
+\end{figure}
+\begin{table}[H]
+\centering
+\small
+\input{regime_sv_validation_table.tex}
+\caption{Selected report-quality Monte Carlo checks.}
+\label{tab:regime_validation}
+\end{table}
+The book-local scripts \texttt{regime\_switch\_logsv.py},
+\texttt{verify\_regime\_sv\_equilibrium.py}, and
+\texttt{generate\_regime\_sv\_figures.py} reproduce the dynamics, checks, figures,
+and table without changing the public pricing library.
+
+\section{Discussion}\label{sec:discussion}
+
+\subsection{Horizon dependence of the premia}
+%% [NEW]
+The loading depends on the time to the fixed representative-agent terminal date
+$H$: it is $\widetilde a_i^{(1)}(H-t)$ under the log-linear closure and
+$a_i^{(1)}(H-t)+2a_i^{(2)}(H-t)v_i$ under the log-quadratic closure.  Hence the
+equilibrium premia are horizon-dependent and a priced derivative must expire no
+later than $H$.  At $H$ the loading vanishes because $g^H(H,\sigma)=1$.  All
+derivative maturities must nevertheless use the same $g^H$: changing $H$ with each
+expiry changes the density process itself.  In the single-regime long-horizon limit
+the log-linear loading converges to $a^{(1)}_{\infty}=r_{-}$ and the premium
+coefficients become time-homogeneous.  The regime-switching implementation keeps
+$H$ finite so this horizon convention remains explicit.
+
+\subsection{Economic mechanism}
+%% [AI-DRAFTED SKETCH - to be rewritten by the author per the project drafting rule:
+%% the economic-mechanism passage is drafted by the author without AI assistance.]
+For an equity index we have $\beta<0$ and $0<\gamma<1$, and Remark \ref{rem:branch} gives $a^{(1)}(\tau)>0$ for $\tau > 0$. Three consequences follow. First, the equity premium $\left[(1-\gamma) - \beta a^{(1)}\right]\sigma^{2}$ exceeds its constant-volatility value $(1-\gamma)\sigma^{2}$: the agent demands extra compensation for holding an asset whose volatility rises when its price falls, similar to being short a put option on the index. Second, $\bar\lambda_{1} = -\varepsilon a^{(1)}<0$, so volatility shocks orthogonal to returns carry a negative price of risk. Third, $\varphi<0$ implies that the volatility drifts higher under $\QQ$ than under $\PP$ through $\hat\kappa_{2} < \kappa_{2}$, which reproduces the negative variance risk premium documented by \cite{BakshiKapadia2003}.
+
+\subsection{Variance premia versus skew premia}
+%% [NEW] scope discussion: what diffusive premia can and cannot price.
+An equivalent change of measure for a diffusion preserves the diffusion coefficients: the pricing kernel relocates drift and nothing else. The covariation $\sigma\beta(\sigma)$, which generates the skew, is therefore identical under $\PP$ and $\QQ$, and the short-dated at-the-money skew slope of the beta formulation, $\beta/2$, is the same for every choice of the risk premia. Preferences cannot make the market charge for skew in the volatility model: demand for downside protection has no parameter to flow into.
+
+At finite maturity the premia do bend the skew, but only mechanically. A smaller $\hat\kappa_{2}$ makes the volatility more persistent under $\QQ$, so the skew decays more slowly with maturity. This effect vanishes as the maturity shrinks, cannot flip the sign anchored by $\beta$, and is driven by the same single combination $\beta\bar\lambda_{0}+\varepsilon\bar\lambda_{1}$ that sets the variance risk premium. In the volatility model, the finite-maturity skew premium is a shadow of the variance risk premium, not a separately priced object.
+
+Jump models break exactly this constraint. The density process for a marked point process has functional freedom over the jump measure: the tilt in Section \ref{sec:hawkes} changes the frequency through $\ell^{\pm}(\chi^{\pm})$ and the severity through the tilted densities, per tail and independently across tails. The risk-neutral asymmetry then differs from the statistical asymmetry even at vanishing maturity, and it differs by an amount the market chooses. Demand for put protection maps onto $\chi^{-}$ and call overwriting supply maps onto $\chi^{+}$. \cite{BollerslevTodorov2011} document from the data side that the compensation for asymmetry sits in the jump tails.
+
+We propose this division of labor as the organizing principle for risk-premia modeling. Diffusive volatility premia price the level and term structure of volatility, the variance risk premium, with one degree of freedom. Jump premia price asymmetry and tails, the skew and crash premia, with one degree of freedom per tail. The equilibrium spans both regimes with the single parameter $\gamma$, through $(\bar\lambda_{0}, \bar\lambda_{1})$ in the volatility model, through $\xi^{+}=\xi^{-}=\gamma-1$ in the Hawkes model, and through both channels at once in the regime-switching model of Section \ref{sec:regime}. Empirical rejection of the common tilt then measures the tail-specific pricing that the diffusive model has no room to express.
+
+\subsection{Second-order accuracy}
+%% [NEW]
+The closed-form expansion \eqref{eq:affine} has log degree one and leaves powers beginning at $v^{2}$ uncontrolled.  In the terminology of \cite{SeppRakhmonov2024}, the FIRST affine expansion has log degree two and residual powers $v^{3}$ and $v^{4}$; the SECOND expansion has log degree four and residual powers $v^{5}$ through $v^{8}$.  The regime equilibrium system \eqref{eq:regime_odes} is the degree-two/FIRST closure, while the option transform \eqref{eq:regime_option_ode} uses degree four/SECOND.  Polynomial degree and Monte Carlo time-step convergence are checked separately in the replication.
+
+\begin{thebibliography}{99}
+
+\bibitem[Bakshi and Kapadia(2003)]{BakshiKapadia2003} Bakshi, G. and Kapadia, N. (2003). Delta-hedged gains and the negative market volatility risk premium. \textit{Review of Financial Studies}, 16(2), 527--566.
+
+\bibitem[Bick(1990)]{Bick1990} Bick, A. (1990). On viable diffusion price processes of the market portfolio. \textit{Journal of Finance}, 45(2), 673--689.
+
+\bibitem[Bollerslev and Todorov(2011)]{BollerslevTodorov2011} Bollerslev, T. and Todorov, V. (2011). Tails, fears, and risk premia. \textit{Journal of Finance}, 66(6), 2165--2211.
+
+\bibitem[Cox et al.(1985)]{CIR1985} Cox, J. C., Ingersoll, J. E. and Ross, S. A. (1985). An intertemporal general equilibrium model of asset prices. \textit{Econometrica}, 53(2), 363--384.
+
+\bibitem[Gerber and Shiu(1994)]{GerberShiu1994} Gerber, H. U. and Shiu, E. S. W. (1994). Option pricing by Esscher transforms. \textit{Transactions of the Society of Actuaries}, 46, 99--140.
+
+\bibitem[He and Leland(1993)]{HeLeland1993} He, H. and Leland, H. (1993). On equilibrium asset price processes. \textit{Review of Financial Studies}, 6(3), 593--617.
+
+\bibitem[Heston(1993)]{Heston1993} Heston, S. L. (1993). A closed-form solution for options with stochastic volatility with applications to bond and currency options. \textit{Review of Financial Studies}, 6(2), 327--343.
+
+\bibitem[Karasinski and Sepp(2012)]{KarasinskiSepp2012} Karasinski, P. and Sepp, A. (2012). Beta stochastic volatility model. \textit{Risk}, October, 66--71.
+
+\bibitem[Lewis(2000)]{Lewis2000} Lewis, A. L. (2000). \textit{Option Valuation under Stochastic Volatility}. Finance Press, Newport Beach.
+
+\bibitem[Liu et al.(2026)]{LiuPackhamSepp2026} Liu, F., Packham, N. and Sepp, A. (2026). Jump risk premia in the presence of clustered jumps. Working paper.
+
+\bibitem[Merton(1971)]{Merton1971} Merton, R. C. (1971). Optimum consumption and portfolio rules in a continuous-time model. \textit{Journal of Economic Theory}, 3(4), 373--413.
+
+\bibitem[Sepp(2026)]{Sepp2026gba} Sepp, A. (2026). Dynamic mean--variance portfolio allocation under regime-switching jump-diffusions with absorbing barriers and distribution matching. Working paper.
+
+\bibitem[Sepp and Rakhmonov(2024)]{SeppRakhmonov2024} Sepp, A. and Rakhmonov, P. (2024). Log-normal stochastic volatility model with quadratic drift. \textit{International Journal of Theoretical and Applied Finance}, 27(1), 2450003.
+
+\end{thebibliography}
+
+\end{document}

--- a/volatility_book/ch_lognormal_sv_risk_premia/notes/risk_premia_lognormal_sv.tex
+++ b/volatility_book/ch_lognormal_sv_risk_premia/notes/risk_premia_lognormal_sv.tex
@@ -7,11 +7,11 @@
 % chapter ValuationUnderSV.tex. Blocks are marked as follows:
 %   %% [CORRECTED vs chapter Eq (...)] - fixes an error in the draft
 %   %% [NEW] - content added beyond the draft
-% All equations were verified symbolically and numerically
-% (verify_valuation_under_sv.py in this folder).
+% The tracked source snapshot does not contain verify_valuation_under_sv.py or
+% verify_hawkes_equilibrium.py.  References to those maintainer working files are
+% historical provenance, not claims that executable verification is present here.
 % v2 (2026-08-23): added Section on the Hawkes-model equilibrium (companion to
-% Liu-Packham-Sepp) verified in verify_hawkes_equilibrium.py, and the discussion
-% subsection on variance versus skew premia.
+% Liu-Packham-Sepp) and the discussion subsection on variance versus skew premia.
 % v3 (2026-08-23): added Section on the regime-switching log-normal SV model
 % (synthesis with the transition-tied jumps of the goal-based-allocation paper),
 % derived and benchmarked in verify_regime_sv_equilibrium.py.
@@ -32,7 +32,10 @@
 \usepackage{booktabs,float,graphicx}
 \usepackage[round]{natbib}
 \usepackage[colorlinks=true, linkcolor=blue, citecolor=blue]{hyperref}
-\graphicspath{{figures/}}
+% The default is relative to this tracked notes directory.  A parent book build
+% may define \RegimeSvArtifactRoot before including this source.
+\providecommand{\RegimeSvArtifactRoot}{../../../outputs/volatility_book/ch_lognormal_sv_risk_premia/canonical}
+\graphicspath{{\RegimeSvArtifactRoot/figures/}}
 
 \newtheorem{theorem}{Theorem}
 \newtheorem{proposition}{Proposition}
@@ -326,9 +329,9 @@ so that the $\QQ$-dynamics are $d\sigma_{t} = (\hat\kappa_{1}+\hat\kappa_{2}\sig
 \section{Equilibrium jump risk premia in the Hawkes model}\label{sec:hawkes}
 
 %% [NEW] companion section: makes the correspondence with the jump-premia paper precise.
-%% Verified end-to-end in verify_hawkes_equilibrium.py: the PIDE residual of the
-%% exponential-affine ansatz is machine zero (the ansatz is exact here), the kernel
-%% satisfies E[M_T]=1 in Monte Carlo, and x*=1 maximizes expected utility.
+%% Historical working notes named verify_hawkes_equilibrium.py, but that script is
+%% not part of the tracked source snapshot.  This section therefore records the
+%% derivation without claiming an executable Hawkes verification artifact here.
 We extend the equilibrium derivation to the bivariate Hawkes jump model of \cite{LiuPackhamSepp2026}, where the jump risk premia are specified through a parametric change of measure with two external tilt parameters $\chi^{+}$ and $\chi^{-}$ calibrated to option prices. We show that the CRRA equilibrium generates exactly this family and restricts the direct jump tilts to a common value set by the risk aversion.
 
 \subsection{Model and economy}
@@ -730,8 +733,8 @@ Direct collection of the corresponding full generator gives
 +\Phi\Delta_i-\ell^{[i]}(\gamma-1)\right\}\Big],
 \end{split}
 \end{equation}
-where $\sigma=\theta^{[i]}+v_i$.  We use $m=4$, the published-SECOND degree-four
-log transform, with either equilibrium closure.  The identities
+where $\sigma=\theta^{[i]}+v_i$.  We use $m=4$, the degree-four SECOND log
+transform of \cite{SeppRakhmonov2024}, with either equilibrium closure.  The identities
 $C_i(\Phi=0)=C_i(\Phi=-1)=0$ verify normalization and the discounted-stock
 martingale.  Fourier inversion uses the line $\Phi=-1/2+iy$.  The implementation
 collects \eqref{eq:regime_option_ode} directly as polynomials.  Under closure
@@ -744,9 +747,10 @@ $\mathrm L$, the exact quadratic $\QQ$ drift enters the same degree-four transfo
 Table \ref{tab:regime_calibration} uses the transition intensities and jump sizes
 from the equity illustration of \cite{Sepp2026gba}.  The reported $-25\%$ crash and
 $+15\%$ recovery are expected arithmetic transition returns, implying
-$\eta^{[1]}=1/3$ and $\eta^{[2]}=3/23$.  The remaining response coefficients are
-the SPY LogSV illustration distributed with the package, combined with the paper's
-growth/stress volatility levels.  This hybrid is an illustration, not a calibration.
+$\eta^{[1]}=1/3$ and $\eta^{[2]}=3/23$.  The remaining response coefficients come
+from the maintained SPY LogSV illustration identified by the chapter's source
+provenance, combined with the paper's growth/stress volatility levels.  They are
+not distributed as a package calibration.  This hybrid is an illustration, not a calibration.
 \begin{table}[htbp]
 \centering
 \small
@@ -782,9 +786,11 @@ resulting implied-volatility skews.  Higher risk aversion raises and steepens th
 left wing because it makes crash marks more severe under $\QQ$.  The channel
 experiment shows that the Esscher tail tilt is the dominant left-wing premium in
 this calibration; diffusive and timing premia mainly shift the center and term
-structure.  These channel-isolation curves are martingale counterfactuals, not
-separate equilibria.  Starting in stress raises the right wing through the recovery
-transition, while starting in growth produces the familiar index downside skew.
+structure.  The package implements these channel scales as analytic,
+non-equilibrium diagnostics.  The channel-isolation curves are martingale
+counterfactuals, not separate equilibria, and non-unit scales do not define a
+package Monte Carlo measure.  Starting in stress raises the right wing through the
+recovery transition, while starting in growth produces the familiar index downside skew.
 \begin{figure}[H]
 \centering
 \includegraphics[width=\textwidth]{regime_sv_smiles}
@@ -834,48 +840,67 @@ degree-four option transform are identical.}
 \begin{table}[H]
 \centering
 \small
-\input{regime_sv_closure_comparison_table.tex}
+\input{\RegimeSvArtifactRoot/tables/regime_sv_closure_comparison_table.tex}
 \caption{Fixed-moneyness implied-volatility skew comparison.  The skew columns are
 percentage-volatility points; the last column is full cubic minus
 quadratic-preserving in volatility basis points.}
 \label{tab:regime_closure_skews}
 \end{table}
-The replication performs six independent checks: the explicit degree-one ODE
-identity; the exact quadratic and derived cubic drift coefficients; the scalar
-Riccati residual;
-an exact frozen-volatility two-state matrix exponential; physical-measure Monte
-Carlo of \eqref{eq:regime_FK}; and full-$\QQ$ Monte Carlo of
-\eqref{eq:regime_Q_dynamics} for both closures and both initial regimes.  Following the event semantics
-of the GoalBasedAllocation implementation, a regime jump changes the price and the
-parameter state simultaneously.  Under $\QQ$ the event probability is evaluated
-pathwise as $1-e^{-q_{ij}^{\QQ,H}(t,\sigma)\,dt}$ because the equilibrium clock is
-state- and time-dependent.  The simulation preserves the common Brownian increment
-in price and volatility.  It uses the exact quadratic drift under closure
-$\mathrm L$ and retains the exact induced cubic under closure $\mathrm F$.  For both,
-the 1,601-point Fourier grid is checked against a 3,201-point refinement.  The
+The adopted replication separates production analytics from the independent
+oracle.  The provisional package deep modules solve both equilibrium closures,
+derive the induced $\QQ$ state, compute the option transforms, and run the
+full-equilibrium $\QQ$ Monte Carlo for both initial regimes.  The frozen chapter
+monolith and verifier supply the scalar Riccati residual, the exact
+frozen-volatility matrix benchmark, and the independent physical-measure
+Feynman--Kac Monte Carlo of \eqref{eq:regime_FK}.  The package checks the explicit
+degree-one ODE identity and the exact quadratic and derived cubic drift
+coefficients.  Following the event semantics of the GoalBasedAllocation
+implementation, a regime jump changes the price and parameter state
+simultaneously.  Under $\QQ$ the event probability is evaluated pathwise as
+$1-e^{-q_{ij}^{\QQ,H}(t,\sigma)\,dt}$ because the equilibrium clock is state- and
+time-dependent.  Package $\QQ$ Monte Carlo preserves the common Brownian increment
+in price and volatility, uses the exact quadratic drift under closure $\mathrm L$,
+and retains the exact induced cubic under closure $\mathrm F$.  For both, the
+1,601-point Fourier grid is checked against a 3,201-point refinement.  The frozen
 physical-measure comparison quantifies each polynomial-closure error rather than
-mistaking it for Monte Carlo sampling error.  Option prices under each measure
-generated by its own approximate coefficient agree with their corresponding
-full-dynamics Monte Carlo within the stated confidence tolerance.
+mistaking it for Monte Carlo sampling error; package transform prices agree with
+package $\QQ$ Monte Carlo within the stated confidence tolerance.
 \begin{figure}[H]
 \centering
 \includegraphics[width=\textwidth]{regime_sv_validation}
-\caption{Independent Monte Carlo checks of both equilibrium closures and their
-degree-four option transforms.  Each analytic option curve is compared with Monte
-Carlo under its own induced measure.  Error bars are 95\% Monte Carlo intervals.}
+\caption{Validation of both equilibrium closures and their degree-four option
+transforms.  Panels A and B compare package $\QQ$ analytics with package $\QQ$
+Monte Carlo; Panels C and D compare package equilibrium coefficients with the
+frozen physical-measure Feynman--Kac oracle.  Error bars are 95\% Monte Carlo
+intervals.}
 \label{fig:regime_validation}
 \end{figure}
 \begin{table}[H]
 \centering
 \small
-\input{regime_sv_validation_table.tex}
-\caption{Selected report-quality Monte Carlo checks.}
+\input{\RegimeSvArtifactRoot/tables/regime_sv_validation_table.tex}
+\caption{Selected report-quality package-$\QQ$ and frozen-physical-measure Monte
+Carlo checks.}
 \label{tab:regime_validation}
 \end{table}
-The book-local scripts \texttt{regime\_switch\_logsv.py},
-\texttt{verify\_regime\_sv\_equilibrium.py}, and
-\texttt{generate\_regime\_sv\_figures.py} reproduce the dynamics, checks, figures,
-and table without changing the public pricing library.
+Production equilibrium, transform, and $\QQ$ Monte Carlo analytics are provided by
+the provisional deep modules
+\path{stochvolmodels.models.regime_logsv},
+\path{stochvolmodels.models.regime_logsv_simulation}, and
+\path{stochvolmodels.pricers.regime_switch_logsv_pricer}.  The frozen
+\path{regime_switch_logsv.py} monolith and
+\path{verify_regime_sv_equilibrium.py} remain independent oracles, not the
+production pricing path.  Their immutable source hashes and the package adoption
+commits are recorded in \path{source_provenance.json} and
+\path{acceptance_manifest.json}.  From the repository root, the exact canonical
+regeneration command is
+{\scriptsize
+\begin{verbatim}
+python -m volatility_book.ch_lognormal_sv_risk_premia.generate_regime_sv_figures --profile canonical
+\end{verbatim}
+}
+It writes the numerical payload, artifact manifest, figures, and tables beneath
+the ignored canonical artifact root selected above.
 
 \section{Discussion}\label{sec:discussion}
 
@@ -896,6 +921,10 @@ $H$ finite so this horizon convention remains explicit.
 %% [AI-DRAFTED SKETCH - to be rewritten by the author per the project drafting rule:
 %% the economic-mechanism passage is drafted by the author without AI assistance.]
 For an equity index we have $\beta<0$ and $0<\gamma<1$, and Remark \ref{rem:branch} gives $a^{(1)}(\tau)>0$ for $\tau > 0$. Three consequences follow. First, the equity premium $\left[(1-\gamma) - \beta a^{(1)}\right]\sigma^{2}$ exceeds its constant-volatility value $(1-\gamma)\sigma^{2}$: the agent demands extra compensation for holding an asset whose volatility rises when its price falls, similar to being short a put option on the index. Second, $\bar\lambda_{1} = -\varepsilon a^{(1)}<0$, so volatility shocks orthogonal to returns carry a negative price of risk. Third, $\varphi<0$ implies that the volatility drifts higher under $\QQ$ than under $\PP$ through $\hat\kappa_{2} < \kappa_{2}$, which reproduces the negative variance risk premium documented by \cite{BakshiKapadia2003}.
+
+\noindent\emph{Scope note.}  The preceding sign discussion assumes
+$0<\gamma<1$.  It is not a description of the plotted regime illustration, whose
+baseline is $\gamma=-0.5$ and whose displayed sensitivity values are non-positive.
 
 \subsection{Variance premia versus skew premia}
 %% [NEW] scope discussion: what diffusive premia can and cannot price.
@@ -937,7 +966,7 @@ The closed-form expansion \eqref{eq:affine} has log degree one and leaves powers
 
 \bibitem[Sepp(2026)]{Sepp2026gba} Sepp, A. (2026). Dynamic mean--variance portfolio allocation under regime-switching jump-diffusions with absorbing barriers and distribution matching. Working paper.
 
-\bibitem[Sepp and Rakhmonov(2024)]{SeppRakhmonov2024} Sepp, A. and Rakhmonov, P. (2024). Log-normal stochastic volatility model with quadratic drift. \textit{International Journal of Theoretical and Applied Finance}, 27(1), 2450003.
+\bibitem[Sepp and Rakhmonov(2024)]{SeppRakhmonov2024} Sepp, A. and Rakhmonov, P. (2024). Log-normal stochastic volatility model with quadratic drift. \textit{International Journal of Theoretical and Applied Finance}, 26(8), 2450003.
 
 \end{thebibliography}
 

--- a/volatility_book/ch_lognormal_sv_risk_premia/regime_sv_chapter.py
+++ b/volatility_book/ch_lognormal_sv_risk_premia/regime_sv_chapter.py
@@ -1,0 +1,1058 @@
+"""Package-owned numerical pipeline for the regime-switching LogSV chapter.
+
+The production path in this module uses :mod:`stochvolmodels` for the
+equilibrium, induced-Q state, Fourier transform, implied volatilities, and
+risk-neutral Monte Carlo.  The frozen chapter monolith is loaded lazily, after
+an exact hash check, only for the physical-measure Feynman--Kac validation that
+does not yet have a package API.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Iterable, Sequence
+
+import numpy as np
+
+from stochvolmodels.data.option_chain import OptionChain
+from stochvolmodels.models.regime_logsv import (
+    CrraRiskPremia,
+    EquilibriumClosure,
+    EquilibriumSolution,
+    Regime,
+    RegimeLogSvDynamics,
+    RegimeRiskPremiaScales,
+    RegimeSwitchLogSvParams,
+    RegimeTransition,
+    evaluate_risk_neutral_state,
+    solve_regime_switch_equilibrium,
+)
+from stochvolmodels.models.regime_logsv_simulation import (
+    simulate_regime_switch_logsv_terminal,
+)
+from stochvolmodels.pricers.logsv.affine_expansion import ExpansionOrder
+from stochvolmodels.pricers.regime_switch_logsv_pricer import (
+    RegimeSwitchLogSVPricer,
+    StateConditionalOptionChain,
+    compute_regime_switch_log_mgf_grid,
+)
+from stochvolmodels.utils.config import VariableType
+from stochvolmodels.utils.mc_payoffs import compute_mc_vars_payoff
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+ACCEPTANCE_MANIFEST = SCRIPT_DIR / "acceptance_manifest.json"
+SOURCE_PROVENANCE = SCRIPT_DIR / "source_provenance.json"
+FROZEN_ORACLE = SCRIPT_DIR / "regime_switch_logsv.py"
+EXPECTED_FROZEN_ORACLE_SHA256 = "f197e10149cab121d1cdecec2a85b5311143d69dbde00311d4d8b90f1d9b9e5a"
+DEFAULT_OUTPUT_ROOT = (
+    REPOSITORY_ROOT / "outputs" / "volatility_book" / "ch_lognormal_sv_risk_premia"
+)
+PAYLOAD_FILENAME = "numerical_payload.json"
+ARTIFACT_MANIFEST_FILENAME = "artifact_manifest.json"
+FORBID_RECOMPUTE_ENV = "STOCHVOLMODELS_REGIME_SV_FORBID_RECOMPUTE"
+PAYLOAD_SCHEMA_VERSION = 1
+FOURIER_POINTS = 1_601
+FOURIER_REFINEMENT_POINTS = 3_201
+
+SMILE_LOG_MONEYNESS = np.linspace(-0.30, 0.20, 31)
+SMILE_MATURITIES = np.array([1.0 / 12.0, 0.25, 0.5, 1.0])
+VALIDATION_LOG_MONEYNESS = np.linspace(-0.30, 0.20, 16)
+SIGMA_GRID = np.linspace(0.08, 0.36, 180)
+UTILITY_POWER_GRID = np.linspace(-0.9, 0.2, 180)
+EQUILIBRIUM_HORIZON_GRID = np.linspace(0.0, 3.0, 151)
+FK_HORIZONS = np.array([1.0, 3.0])
+EXPECTED_RECORD_NAMES = frozenset(
+    {
+        "closure.implied_volatility",
+        "closure.implied_volatility_difference_bp",
+        "closure.table",
+        "premia.jump_arithmetic_mean",
+        "premia.log_timing_ratio",
+        "premia.physical_drift",
+        "premia.physical_jump_arithmetic_mean",
+        "premia.physical_transition_intensity",
+        "premia.risk_neutral_drift",
+        "premia.transition_intensity",
+        "premia.volatility_loading",
+        "smiles.channel_implied_volatility",
+        "smiles.channel_log_mgf",
+        "smiles.channel_prices",
+        "smiles.initial_regime_implied_volatility",
+        "smiles.risk_aversion_implied_volatility",
+        "smiles.term_structure_implied_volatility",
+        "validation.analytic_implied_volatility",
+        "validation.analytic_prices",
+        "validation.equilibrium_coefficients",
+        "validation.forward_martingale",
+        "validation.fourier_refinement_prices",
+        "validation.mc_prices",
+        "validation.mc_standard_errors",
+        "validation.physical_feynman_kac",
+        "validation.table",
+    }
+)
+
+
+class ChapterProfile(str, Enum):
+    """Supported numerical workloads for the chapter pipeline."""
+
+    SMOKE = "smoke"
+    CANONICAL = "canonical"
+
+
+@dataclass(frozen=True, slots=True)
+class ChapterConfig:
+    """Numerical workload attached to a chapter profile."""
+
+    profile: ChapterProfile
+    monte_carlo_paths: int
+    steps_per_year: int
+
+
+def as_profile(value: ChapterProfile | str) -> ChapterProfile:
+    """Return a validated chapter profile."""
+
+    if isinstance(value, ChapterProfile):
+        return value
+    try:
+        return ChapterProfile(str(value))
+    except ValueError as error:
+        choices = ", ".join(item.value for item in ChapterProfile)
+        raise ValueError(f"profile must be one of: {choices}") from error
+
+
+def profile_config(profile: ChapterProfile | str) -> ChapterConfig:
+    """Return the deterministic workload for ``profile``."""
+
+    selected = as_profile(profile)
+    if selected is ChapterProfile.SMOKE:
+        return ChapterConfig(selected, monte_carlo_paths=4_000, steps_per_year=360)
+    return ChapterConfig(selected, monte_carlo_paths=120_000, steps_per_year=1_440)
+
+
+def default_output_directory(profile: ChapterProfile | str) -> Path:
+    """Return the ignored profile-specific artifact directory."""
+
+    return DEFAULT_OUTPUT_ROOT / as_profile(profile).value
+
+
+def validate_output_directory(path: Path | str) -> Path:
+    """Resolve output and confine repo-local artifacts to the ignored root."""
+
+    output = Path(path).expanduser().resolve()
+    repository = REPOSITORY_ROOT.resolve()
+    try:
+        repository.relative_to(output)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("output directory must not equal or contain the repository root")
+    try:
+        output.relative_to(repository)
+    except ValueError:
+        return output
+    try:
+        output.relative_to(DEFAULT_OUTPUT_ROOT.resolve())
+    except ValueError as error:
+        raise ValueError(
+            f"repository-local regime-SV artifacts must be written below {DEFAULT_OUTPUT_ROOT}"
+        ) from error
+    return output
+
+
+def equity_params(
+    *,
+    utility_power: float = -0.5,
+    initial_regime: Regime = Regime.GROWTH,
+    agent_horizon: float = 3.0,
+    closure: EquilibriumClosure = EquilibriumClosure.LOG_LINEAR,
+) -> RegimeSwitchLogSvParams:
+    """Build the chapter's transparent equity illustration with package types.
+
+    The growth/stress volatility levels, transition clocks, and arithmetic jump
+    sizes are the original chapter inputs.  The combined parameter set remains
+    an illustration rather than an empirical calibration.
+    """
+
+    common = dict(
+        kappa1=2.6949,
+        kappa2=10.0107,
+        beta=-1.5082,
+        volvol=0.8503,
+    )
+    return RegimeSwitchLogSvParams(
+        sigma0=0.15,
+        regimes=(
+            RegimeLogSvDynamics(theta=0.15, **common),
+            RegimeLogSvDynamics(theta=0.225, **common),
+        ),
+        transitions=(
+            RegimeTransition(intensity=0.1, mean_log_jump=-(0.25 / 0.75)),
+            RegimeTransition(intensity=1.0, mean_log_jump=0.15 / 1.15),
+        ),
+        risk_premia=CrraRiskPremia(
+            utility_power=utility_power,
+            agent_horizon=agent_horizon,
+            closure=closure,
+        ),
+        initial_regime=initial_regime,
+    )
+
+
+class _AnalyticsCache:
+    """Reuse every equilibrium and coupled state-conditional chain exactly once."""
+
+    def __init__(self) -> None:
+        self._pricer = RegimeSwitchLogSVPricer()
+        self._equilibria: dict[RegimeSwitchLogSvParams, EquilibriumSolution] = {}
+        self._chains: dict[
+            tuple[
+                RegimeSwitchLogSvParams,
+                RegimeRiskPremiaScales,
+                tuple[float, ...],
+                tuple[float, ...],
+                int,
+            ],
+            StateConditionalOptionChain,
+        ] = {}
+
+    def equilibrium(self, params: RegimeSwitchLogSvParams) -> EquilibriumSolution:
+        if params not in self._equilibria:
+            self._equilibria[params] = solve_regime_switch_equilibrium(params)
+        return self._equilibria[params]
+
+    def chain(
+        self,
+        params: RegimeSwitchLogSvParams,
+        maturities: Sequence[float],
+        log_moneyness: Sequence[float],
+        *,
+        scales: RegimeRiskPremiaScales = RegimeRiskPremiaScales(),
+        max_phi: int = FOURIER_POINTS,
+    ) -> StateConditionalOptionChain:
+        maturity_key = tuple(float(value) for value in maturities)
+        moneyness_key = tuple(float(value) for value in log_moneyness)
+        key = (params, scales, maturity_key, moneyness_key, int(max_phi))
+        if key in self._chains:
+            return self._chains[key]
+
+        ttms = np.asarray(maturity_key, dtype=float)
+        log_grid = np.asarray(moneyness_key, dtype=float)
+        strikes = np.exp(log_grid)
+        optiontypes = np.where(strikes < 1.0, "P", "C")
+        chain = OptionChain(
+            ttms=ttms,
+            forwards=np.ones(ttms.size),
+            discfactors=np.ones(ttms.size),
+            strikes_ttms=tuple(strikes.copy() for _ in ttms),
+            optiontypes_ttms=tuple(optiontypes.copy() for _ in ttms),
+            ids=np.asarray([f"{ttm:.12g}" for ttm in ttms]),
+        )
+        result = self._pricer.compute_state_conditional_prices_with_vols(
+            chain,
+            params,
+            equilibrium=self.equilibrium(params),
+            scales=scales,
+            expansion_order=ExpansionOrder.SECOND,
+            max_phi=max_phi,
+        )
+        self._chains[key] = result
+        return result
+
+
+def _conditional_array(
+    conditional: StateConditionalOptionChain,
+    attribute: str,
+) -> np.ndarray:
+    output = []
+    for regime in Regime:
+        prices, ivols = conditional.for_regime(regime)
+        values = prices if attribute == "prices" else ivols
+        output.append(np.stack([np.asarray(value, dtype=float) for value in values]))
+    return np.stack(output)
+
+
+def _json_axis_values(values: Iterable[Any]) -> list[Any]:
+    output: list[Any] = []
+    for value in values:
+        if isinstance(value, (np.integer, int)) and not isinstance(value, (bool, np.bool_)):
+            output.append(int(value))
+        elif isinstance(value, (np.floating, float)):
+            number = float(value)
+            if not np.isfinite(number):
+                raise ValueError("payload axes must be finite")
+            output.append(number)
+        elif isinstance(value, (str, bool)) or value is None:
+            output.append(value)
+        else:
+            raise TypeError(f"unsupported payload axis value {value!r}")
+    return output
+
+
+def array_record(
+    values: np.ndarray | Sequence[float],
+    axes: Sequence[tuple[str, Iterable[Any]]],
+    **metadata: Any,
+) -> dict[str, Any]:
+    """Encode one finite numerical array with ordered axes and row-major values."""
+
+    array = np.asarray(values)
+    if not np.issubdtype(array.dtype, np.number) or np.issubdtype(array.dtype, np.complexfloating):
+        raise TypeError("payload record values must be real numbers")
+    if not np.all(np.isfinite(array)):
+        raise ValueError("payload record values must be finite")
+    if len(axes) != array.ndim:
+        raise ValueError("payload record must name every array dimension")
+
+    encoded_axes = []
+    names: set[str] = set()
+    for dimension, (name, coordinates) in enumerate(axes):
+        if not isinstance(name, str) or not name or name in names:
+            raise ValueError("payload axis names must be unique non-empty strings")
+        names.add(name)
+        encoded = _json_axis_values(coordinates)
+        if len(encoded) != array.shape[dimension]:
+            raise ValueError(f"axis {name!r} does not match dimension {dimension}")
+        encoded_axes.append({"name": name, "values": encoded})
+
+    record = {
+        "axes": encoded_axes,
+        "shape": [int(value) for value in array.shape],
+        "values": array.ravel(order="C").tolist(),
+    }
+    record.update(metadata)
+    return record
+
+
+def record_array(record: dict[str, Any]) -> np.ndarray:
+    """Decode the row-major values of a validated payload record."""
+
+    return np.asarray(record["values"], dtype=float).reshape(record["shape"])
+
+
+def record_axis(record: dict[str, Any], name: str) -> list[Any]:
+    """Return one named coordinate vector from a payload record."""
+
+    for axis in record["axes"]:
+        if axis["name"] == name:
+            return list(axis["values"])
+    raise KeyError(f"record has no axis named {name!r}")
+
+
+def _validate_finite_json(value: Any, location: str = "payload") -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"{location} keys must be strings")
+            _validate_finite_json(item, f"{location}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_finite_json(item, f"{location}[{index}]")
+    elif isinstance(value, float) and not np.isfinite(value):
+        raise ValueError(f"{location} contains a non-finite number")
+    elif not isinstance(value, (str, int, float, bool, type(None))):
+        raise TypeError(f"{location} contains unsupported value {value!r}")
+
+
+def _validate_record(name: str, record: Any) -> None:
+    if not isinstance(record, dict):
+        raise TypeError(f"record {name!r} must be an object")
+    for required in ("axes", "shape", "values"):
+        if required not in record:
+            raise ValueError(f"record {name!r} is missing {required!r}")
+    shape = record["shape"]
+    axes = record["axes"]
+    values = record["values"]
+    if not isinstance(shape, list) or not all(
+        isinstance(value, int) and not isinstance(value, bool) and value >= 0 for value in shape
+    ):
+        raise ValueError(f"record {name!r} has an invalid shape")
+    if not isinstance(axes, list) or len(axes) != len(shape):
+        raise ValueError(f"record {name!r} must provide one axis per dimension")
+    names: set[str] = set()
+    for dimension, axis in enumerate(axes):
+        if not isinstance(axis, dict) or set(axis) != {"name", "values"}:
+            raise ValueError(f"record {name!r} has an invalid axis descriptor")
+        axis_name = axis["name"]
+        if not isinstance(axis_name, str) or not axis_name or axis_name in names:
+            raise ValueError(f"record {name!r} has duplicate or invalid axes")
+        names.add(axis_name)
+        if not isinstance(axis["values"], list) or len(axis["values"]) != shape[dimension]:
+            raise ValueError(f"record {name!r} axis {axis_name!r} has the wrong length")
+    count = int(np.prod(shape, dtype=np.int64)) if shape else 1
+    if not isinstance(values, list) or len(values) != count:
+        raise ValueError(f"record {name!r} values do not agree with its shape")
+    for index, value in enumerate(values):
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or not np.isfinite(value):
+            raise ValueError(f"record {name!r} value {index} must be a finite JSON number")
+
+
+def validate_numerical_payload(payload: Any) -> dict[str, Any]:
+    """Validate the portable numerical-payload contract and return it."""
+
+    if not isinstance(payload, dict):
+        raise TypeError("numerical payload must be a JSON object")
+    if payload.get("schema_version") != PAYLOAD_SCHEMA_VERSION:
+        raise ValueError(f"unsupported numerical payload schema {payload.get('schema_version')!r}")
+    as_profile(payload.get("profile"))
+    for required in ("configuration", "provenance"):
+        value = payload.get(required)
+        if not isinstance(value, dict) or not value:
+            raise ValueError(f"numerical payload {required} must be a non-empty object")
+    records = payload.get("records")
+    if not isinstance(records, dict) or not records:
+        raise ValueError("numerical payload records must be a non-empty object")
+    missing = EXPECTED_RECORD_NAMES.difference(records)
+    if missing:
+        raise ValueError(f"numerical payload is missing expected records: {sorted(missing)}")
+    for name, record in records.items():
+        if not isinstance(name, str) or not name:
+            raise ValueError("numerical payload record names must be non-empty strings")
+        _validate_record(name, record)
+    _validate_finite_json(payload)
+    return payload
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _repository_relative(path: Path) -> str:
+    return path.resolve().relative_to(REPOSITORY_ROOT.resolve()).as_posix()
+
+
+def write_numerical_payload(payload: dict[str, Any], path: Path | str) -> Path:
+    """Write a validated, deterministic JSON numerical payload."""
+
+    validate_numerical_payload(payload)
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    target.write_text(text, encoding="utf-8", newline="\n")
+    return target
+
+
+def load_numerical_payload(path: Path | str) -> dict[str, Any]:
+    """Load and validate a numerical payload without invoking any analytics."""
+
+    source = Path(path)
+
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"non-finite JSON constant {value!r} is forbidden")
+
+    with source.open("r", encoding="utf-8") as stream:
+        payload = json.load(stream, parse_constant=reject_constant)
+    return validate_numerical_payload(payload)
+
+
+_FROZEN_ORACLE_MODULE: ModuleType | None = None
+
+
+def _check_frozen_oracle_hash() -> str:
+    if not FROZEN_ORACLE.is_file():
+        raise FileNotFoundError(f"frozen physical Feynman--Kac oracle is missing: {FROZEN_ORACLE}")
+    observed = _sha256(FROZEN_ORACLE)
+    if observed != EXPECTED_FROZEN_ORACLE_SHA256:
+        raise RuntimeError(
+            "frozen physical Feynman--Kac oracle hash mismatch: "
+            f"expected {EXPECTED_FROZEN_ORACLE_SHA256}, observed {observed}"
+        )
+    return observed
+
+
+def _load_frozen_physical_fk_oracle() -> ModuleType:
+    """Load the hash-pinned monolith solely for physical Feynman--Kac points."""
+
+    global _FROZEN_ORACLE_MODULE
+    _check_frozen_oracle_hash()
+    if _FROZEN_ORACLE_MODULE is not None:
+        return _FROZEN_ORACLE_MODULE
+    module_name = "_stochvolmodels_frozen_regime_sv_physical_fk_oracle"
+    specification = importlib.util.spec_from_file_location(module_name, FROZEN_ORACLE)
+    if specification is None or specification.loader is None:
+        raise ImportError(f"cannot load frozen oracle from {FROZEN_ORACLE}")
+    module = importlib.util.module_from_spec(specification)
+    sys.modules[module_name] = module
+    try:
+        specification.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    _FROZEN_ORACLE_MODULE = module
+    return module
+
+
+def _physical_fk_values(config: ChapterConfig) -> np.ndarray:
+    oracle = _load_frozen_physical_fk_oracle()
+    output = np.empty((2, FK_HORIZONS.size, 2), dtype=float)
+    bases = {Regime.GROWTH: 1_301, Regime.STRESS: 1_303}
+    for regime in Regime:
+        frozen_params = oracle.RegimeSwitchLogSvParams.equity_baseline(
+            gamma=-0.5,
+            initial_regime=int(regime),
+            agent_horizon=3.0,
+        )
+        sigma = frozen_params.regimes[int(regime)].theta
+        for horizon_index, horizon in enumerate(FK_HORIZONS):
+            value, error = oracle.simulate_equilibrium_feynman_kac(
+                frozen_params,
+                float(horizon),
+                sigma,
+                int(regime),
+                n_paths=config.monte_carlo_paths,
+                steps_per_year=config.steps_per_year,
+                seed=bases[regime] + int(10 * horizon),
+            )
+            output[int(regime), horizon_index] = (value, error)
+    return output
+
+
+def _build_validation_table(
+    analytic_prices: np.ndarray,
+    mc_prices: np.ndarray,
+    mc_errors: np.ndarray,
+    martingale: np.ndarray,
+    equilibrium_coefficients: np.ndarray,
+    physical_fk: np.ndarray,
+) -> tuple[np.ndarray, list[dict[str, str]]]:
+    rows: list[list[float]] = []
+    metadata: list[dict[str, str]] = []
+    closure_short = ("quadratic Q", "full cubic Q")
+    regime_labels = ("Growth", "Stress")
+    atm = int(np.argmin(np.abs(np.exp(VALIDATION_LOG_MONEYNESS) - 1.0)))
+    for closure_index, short_label in enumerate(closure_short):
+        for regime in Regime:
+            rows.append([1.0, *martingale[closure_index, int(regime)]])
+            metadata.append(
+                {
+                    "check": rf"$E^{{\mathbb{{Q}}}}[S_T/F_0]$, {short_label}",
+                    "regime": regime_labels[int(regime)],
+                }
+            )
+            rows.append(
+                [
+                    analytic_prices[closure_index, int(regime), atm],
+                    mc_prices[closure_index, int(regime), atm],
+                    mc_errors[closure_index, int(regime), atm],
+                ]
+            )
+            metadata.append(
+                {
+                    "check": f"3m near-ATM, {short_label}",
+                    "regime": regime_labels[int(regime)],
+                }
+            )
+
+    horizon_index = int(np.flatnonzero(np.isclose(FK_HORIZONS, 3.0))[0])
+    curve_index = int(np.flatnonzero(np.isclose(EQUILIBRIUM_HORIZON_GRID, 3.0))[0])
+    for regime in Regime:
+        for closure_index, coefficient_label in enumerate(("log-linear", "log-quadratic")):
+            rows.append(
+                [
+                    equilibrium_coefficients[closure_index, int(regime), curve_index],
+                    physical_fk[int(regime), horizon_index, 0],
+                    physical_fk[int(regime), horizon_index, 1],
+                ]
+            )
+            metadata.append(
+                {
+                    "check": rf"$g(0,\theta)$, 3y, {coefficient_label}",
+                    "regime": regime_labels[int(regime)],
+                }
+            )
+    return np.asarray(rows), metadata
+
+
+def build_numerical_payload(profile: ChapterProfile | str) -> dict[str, Any]:
+    """Compute the complete package-owned chapter payload.
+
+    Setting :data:`FORBID_RECOMPUTE_ENV` to ``"1"`` is a test-only safety
+    guard.  It fails before profile parsing, file access, equilibrium solves, or
+    any other numerical work.  Payload loading and rendering never call this
+    function.
+    """
+
+    if os.environ.get(FORBID_RECOMPUTE_ENV) == "1":
+        raise RuntimeError(f"numerical recomputation forbidden by {FORBID_RECOMPUTE_ENV}=1")
+    config = profile_config(profile)
+    if not ACCEPTANCE_MANIFEST.is_file():
+        raise FileNotFoundError(f"acceptance manifest is missing: {ACCEPTANCE_MANIFEST}")
+    frozen_hash = _check_frozen_oracle_hash()
+
+    cache = _AnalyticsCache()
+    closures = (EquilibriumClosure.LOG_LINEAR, EquilibriumClosure.LOG_QUADRATIC)
+    closure_labels = ("log_linear", "log_quadratic")
+    regime_labels = ("growth", "stress")
+    baseline_params = tuple(equity_params(closure=closure) for closure in closures)
+    equilibria = tuple(cache.equilibrium(params) for params in baseline_params)
+
+    closure_prices = np.empty((2, 2, SMILE_MATURITIES.size, SMILE_LOG_MONEYNESS.size))
+    closure_ivols = np.empty_like(closure_prices)
+    for closure_index, params in enumerate(baseline_params):
+        conditional = cache.chain(params, SMILE_MATURITIES, SMILE_LOG_MONEYNESS)
+        closure_prices[closure_index] = _conditional_array(conditional, "prices")
+        closure_ivols[closure_index] = _conditional_array(conditional, "ivols")
+
+    maturity_3m = int(np.flatnonzero(np.isclose(SMILE_MATURITIES, 0.25))[0])
+    risk_powers = np.array([-0.75, -0.5, -0.25, 0.0])
+    risk_aversion_ivols = np.empty((risk_powers.size, 2, SMILE_LOG_MONEYNESS.size))
+    for power_index, utility_power in enumerate(risk_powers):
+        if utility_power == -0.5:
+            risk_aversion_ivols[power_index] = closure_ivols[0, :, maturity_3m]
+        else:
+            params = equity_params(utility_power=float(utility_power))
+            conditional = cache.chain(params, [0.25], SMILE_LOG_MONEYNESS)
+            risk_aversion_ivols[power_index] = _conditional_array(conditional, "ivols")[:, 0]
+
+    channel_names = (
+        "all_zero",
+        "diffusive_only",
+        "timing_only",
+        "tail_only",
+        "full",
+    )
+    channel_scales = (
+        RegimeRiskPremiaScales(0.0, 0.0, 0.0, 0.0),
+        RegimeRiskPremiaScales(1.0, 1.0, 0.0, 0.0),
+        RegimeRiskPremiaScales(0.0, 0.0, 1.0, 0.0),
+        RegimeRiskPremiaScales(0.0, 0.0, 0.0, 1.0),
+        RegimeRiskPremiaScales(),
+    )
+    channel_prices = np.empty((5, 2, SMILE_LOG_MONEYNESS.size))
+    channel_ivols = np.empty_like(channel_prices)
+    transform_phi = np.array([0.0, -1.0, -0.5 + 2.0j])
+    channel_log_mgf = np.empty((5, 2, transform_phi.size, 2))
+    linear_params = baseline_params[0]
+    linear_equilibrium = equilibria[0]
+    for scenario_index, scales in enumerate(channel_scales):
+        if scales.is_full_equilibrium:
+            channel_prices[scenario_index] = closure_prices[0, :, maturity_3m]
+            channel_ivols[scenario_index] = closure_ivols[0, :, maturity_3m]
+        else:
+            conditional = cache.chain(
+                linear_params,
+                [0.25],
+                SMILE_LOG_MONEYNESS,
+                scales=scales,
+            )
+            channel_prices[scenario_index] = _conditional_array(conditional, "prices")[:, 0]
+            channel_ivols[scenario_index] = _conditional_array(conditional, "ivols")[:, 0]
+        log_mgf = compute_regime_switch_log_mgf_grid(
+            linear_params,
+            ttm=0.25,
+            phi_grid=transform_phi,
+            equilibrium=linear_equilibrium,
+            scales=scales,
+            expansion_order=ExpansionOrder.SECOND,
+        )
+        channel_log_mgf[scenario_index, :, :, 0] = np.real(log_mgf)
+        channel_log_mgf[scenario_index, :, :, 1] = np.imag(log_mgf)
+
+    refinement_prices = np.empty((2, 2, 2, SMILE_LOG_MONEYNESS.size))
+    for closure_index, params in enumerate(baseline_params):
+        refined = cache.chain(
+            params,
+            [0.25],
+            SMILE_LOG_MONEYNESS,
+            max_phi=FOURIER_REFINEMENT_POINTS,
+        )
+        refinement_prices[closure_index, 0] = closure_prices[closure_index, :, maturity_3m]
+        refinement_prices[closure_index, 1] = _conditional_array(refined, "prices")[:, 0]
+
+    transition_intensity = np.empty((2, SIGMA_GRID.size))
+    risk_neutral_drift = np.empty((2, 2, SIGMA_GRID.size))
+    physical_drift = np.empty((2, SIGMA_GRID.size))
+    volatility_loading = np.empty((2, SIGMA_GRID.size))
+    log_timing_ratio = np.empty((2, SIGMA_GRID.size))
+    for regime in Regime:
+        dynamics = linear_params.regimes[regime]
+        physical_drift[int(regime)] = (dynamics.kappa1 + dynamics.kappa2 * SIGMA_GRID) * (
+            dynamics.theta - SIGMA_GRID
+        )
+        for closure_index, (params, equilibrium) in enumerate(zip(baseline_params, equilibria)):
+            state = evaluate_risk_neutral_state(
+                params,
+                equilibrium,
+                horizon=3.0,
+                sigma=SIGMA_GRID,
+                regime=regime,
+            )
+            risk_neutral_drift[closure_index, int(regime)] = state.volatility_drift
+            if closure_index == 0:
+                transition_intensity[int(regime)] = state.transition_intensity
+                volatility_loading[int(regime)] = state.volatility_loading
+                log_timing_ratio[int(regime)] = state.log_timing_ratio
+
+    jump_arithmetic_mean = np.empty((2, UTILITY_POWER_GRID.size))
+    for power_index, utility_power in enumerate(UTILITY_POWER_GRID):
+        trial = equity_params(utility_power=float(utility_power))
+        tail_tilt = utility_power - 1.0
+        for regime in Regime:
+            ell = trial.jump_mgf(regime, tail_tilt)
+            jump_arithmetic_mean[int(regime), power_index] = (
+                trial.jump_mgf(regime, tail_tilt + 1.0) / ell - 1.0
+            )
+
+    closure_difference_bp = 10_000.0 * (closure_ivols[1] - closure_ivols[0])
+    left = int(np.argmin(np.abs(SMILE_LOG_MONEYNESS + 0.20)))
+    right = int(np.argmin(np.abs(SMILE_LOG_MONEYNESS - 0.20)))
+    closure_table = np.empty((2, SMILE_MATURITIES.size, 3))
+    for regime in Regime:
+        linear_skew = (
+            closure_ivols[0, int(regime), :, left] - closure_ivols[0, int(regime), :, right]
+        )
+        quadratic_skew = (
+            closure_ivols[1, int(regime), :, left] - closure_ivols[1, int(regime), :, right]
+        )
+        closure_table[int(regime), :, 0] = 100.0 * linear_skew
+        closure_table[int(regime), :, 1] = 100.0 * quadratic_skew
+        closure_table[int(regime), :, 2] = 10_000.0 * (quadratic_skew - linear_skew)
+
+    validation_prices = np.empty((2, 2, VALIDATION_LOG_MONEYNESS.size))
+    validation_ivols = np.empty_like(validation_prices)
+    for closure_index, params in enumerate(baseline_params):
+        conditional = cache.chain(params, [0.25], VALIDATION_LOG_MONEYNESS)
+        validation_prices[closure_index] = _conditional_array(conditional, "prices")[:, 0]
+        validation_ivols[closure_index] = _conditional_array(conditional, "ivols")[:, 0]
+
+    validation_mc_prices = np.empty_like(validation_prices)
+    validation_mc_errors = np.empty_like(validation_prices)
+    forward_martingale = np.empty((2, 2, 2))
+    validation_strikes = np.exp(VALIDATION_LOG_MONEYNESS)
+    validation_optiontypes = np.where(validation_strikes < 1.0, "P", "C")
+    state_seeds = {Regime.GROWTH: 1_227, Regime.STRESS: 1_229}
+    for closure_index, (params, equilibrium) in enumerate(zip(baseline_params, equilibria)):
+        for regime in Regime:
+            sample = simulate_regime_switch_logsv_terminal(
+                params,
+                ttm=0.25,
+                equilibrium=equilibrium,
+                initial_regime=regime,
+                nb_path=config.monte_carlo_paths,
+                nb_steps_per_year=config.steps_per_year,
+                seed=state_seeds[regime],
+            )
+            prices, errors = compute_mc_vars_payoff(
+                x0=sample.log_forward_return,
+                sigma0=sample.sigma,
+                qvar0=sample.qvar,
+                ttm=0.25,
+                forward=1.0,
+                strikes_ttm=validation_strikes,
+                optiontypes_ttm=validation_optiontypes,
+                discfactor=1.0,
+                variable_type=VariableType.LOG_RETURN,
+            )
+            validation_mc_prices[closure_index, int(regime)] = prices
+            validation_mc_errors[closure_index, int(regime)] = errors
+            forward_martingale[closure_index, int(regime)] = sample.forward_martingale
+
+    equilibrium_coefficients = np.empty((2, 2, EQUILIBRIUM_HORIZON_GRID.size))
+    for closure_index, equilibrium in enumerate(equilibria):
+        for regime in Regime:
+            sigma = baseline_params[closure_index].regimes[regime].theta
+            equilibrium_coefficients[closure_index, int(regime)] = [
+                np.exp(equilibrium.log_value_coefficient(float(horizon), sigma, regime))
+                for horizon in EQUILIBRIUM_HORIZON_GRID
+            ]
+
+    physical_fk = _physical_fk_values(config)
+    validation_table, validation_row_metadata = _build_validation_table(
+        validation_prices,
+        validation_mc_prices,
+        validation_mc_errors,
+        forward_martingale,
+        equilibrium_coefficients,
+        physical_fk,
+    )
+
+    maturity_labels = ("1 month", "3 months", "6 months", "1 year")
+    records = {
+        "closure.implied_volatility": array_record(
+            closure_ivols,
+            (
+                ("closure", closure_labels),
+                ("regime", regime_labels),
+                ("maturity_years", SMILE_MATURITIES),
+                ("log_moneyness", SMILE_LOG_MONEYNESS),
+            ),
+        ),
+        "closure.implied_volatility_difference_bp": array_record(
+            closure_difference_bp,
+            (
+                ("regime", regime_labels),
+                ("maturity_years", SMILE_MATURITIES),
+                ("log_moneyness", SMILE_LOG_MONEYNESS),
+            ),
+        ),
+        "closure.table": array_record(
+            closure_table,
+            (
+                ("regime", ("Growth", "Stress")),
+                ("maturity", maturity_labels),
+                ("metric", ("quadratic_skew_percent", "cubic_skew_percent", "difference_bp")),
+            ),
+        ),
+        "premia.jump_arithmetic_mean": array_record(
+            jump_arithmetic_mean,
+            (("regime", regime_labels), ("utility_power", UTILITY_POWER_GRID)),
+        ),
+        "premia.log_timing_ratio": array_record(
+            log_timing_ratio,
+            (("regime", regime_labels), ("sigma", SIGMA_GRID)),
+        ),
+        "premia.physical_drift": array_record(
+            physical_drift,
+            (("regime", regime_labels), ("sigma", SIGMA_GRID)),
+        ),
+        "premia.physical_jump_arithmetic_mean": array_record(
+            np.asarray(
+                [transition.arithmetic_jump_mean for transition in linear_params.transitions]
+            ),
+            (("regime", regime_labels),),
+        ),
+        "premia.physical_transition_intensity": array_record(
+            np.asarray([transition.intensity for transition in linear_params.transitions]),
+            (("regime", regime_labels),),
+        ),
+        "premia.risk_neutral_drift": array_record(
+            risk_neutral_drift,
+            (
+                ("closure", closure_labels),
+                ("regime", regime_labels),
+                ("sigma", SIGMA_GRID),
+            ),
+        ),
+        "premia.transition_intensity": array_record(
+            transition_intensity,
+            (("regime", regime_labels), ("sigma", SIGMA_GRID)),
+        ),
+        "premia.volatility_loading": array_record(
+            volatility_loading,
+            (("regime", regime_labels), ("sigma", SIGMA_GRID)),
+        ),
+        "smiles.channel_implied_volatility": array_record(
+            channel_ivols,
+            (
+                ("scenario", channel_names),
+                ("regime", regime_labels),
+                ("log_moneyness", SMILE_LOG_MONEYNESS),
+            ),
+        ),
+        "smiles.channel_log_mgf": array_record(
+            channel_log_mgf,
+            (
+                ("scenario", channel_names),
+                ("regime", regime_labels),
+                ("phi", ("0", "-1", "-0.5+2j")),
+                ("component", ("real", "imag")),
+            ),
+        ),
+        "smiles.channel_prices": array_record(
+            channel_prices,
+            (
+                ("scenario", channel_names),
+                ("regime", regime_labels),
+                ("log_moneyness", SMILE_LOG_MONEYNESS),
+            ),
+        ),
+        "smiles.initial_regime_implied_volatility": array_record(
+            closure_ivols[0, :, maturity_3m],
+            (("regime", regime_labels), ("log_moneyness", SMILE_LOG_MONEYNESS)),
+        ),
+        "smiles.risk_aversion_implied_volatility": array_record(
+            risk_aversion_ivols,
+            (
+                ("utility_power", risk_powers),
+                ("regime", regime_labels),
+                ("log_moneyness", SMILE_LOG_MONEYNESS),
+            ),
+        ),
+        "smiles.term_structure_implied_volatility": array_record(
+            closure_ivols[0, int(Regime.GROWTH)],
+            (("maturity_years", SMILE_MATURITIES), ("log_moneyness", SMILE_LOG_MONEYNESS)),
+        ),
+        "validation.analytic_implied_volatility": array_record(
+            validation_ivols,
+            (
+                ("closure", closure_labels),
+                ("regime", regime_labels),
+                ("log_moneyness", VALIDATION_LOG_MONEYNESS),
+            ),
+        ),
+        "validation.analytic_prices": array_record(
+            validation_prices,
+            (
+                ("closure", closure_labels),
+                ("regime", regime_labels),
+                ("log_moneyness", VALIDATION_LOG_MONEYNESS),
+            ),
+        ),
+        "validation.equilibrium_coefficients": array_record(
+            equilibrium_coefficients,
+            (
+                ("closure", closure_labels),
+                ("regime", regime_labels),
+                ("horizon_years", EQUILIBRIUM_HORIZON_GRID),
+            ),
+        ),
+        "validation.forward_martingale": array_record(
+            forward_martingale,
+            (
+                ("closure", closure_labels),
+                ("regime", regime_labels),
+                ("metric", ("estimate", "standard_error")),
+            ),
+        ),
+        "validation.fourier_refinement_prices": array_record(
+            refinement_prices,
+            (
+                ("closure", closure_labels),
+                ("fourier_points", (FOURIER_POINTS, FOURIER_REFINEMENT_POINTS)),
+                ("regime", regime_labels),
+                ("log_moneyness", SMILE_LOG_MONEYNESS),
+            ),
+        ),
+        "validation.mc_prices": array_record(
+            validation_mc_prices,
+            (
+                ("closure", closure_labels),
+                ("regime", regime_labels),
+                ("log_moneyness", VALIDATION_LOG_MONEYNESS),
+            ),
+        ),
+        "validation.mc_standard_errors": array_record(
+            validation_mc_errors,
+            (
+                ("closure", closure_labels),
+                ("regime", regime_labels),
+                ("log_moneyness", VALIDATION_LOG_MONEYNESS),
+            ),
+        ),
+        "validation.physical_feynman_kac": array_record(
+            physical_fk,
+            (
+                ("regime", regime_labels),
+                ("horizon_years", FK_HORIZONS),
+                ("metric", ("estimate", "standard_error")),
+            ),
+            source="hash-pinned frozen monolith; physical-measure validation only",
+        ),
+        "validation.table": array_record(
+            validation_table,
+            (
+                ("row", range(validation_table.shape[0])),
+                ("metric", ("analytic", "monte_carlo", "mc_standard_error")),
+            ),
+            row_metadata=validation_row_metadata,
+        ),
+    }
+    payload = {
+        "schema_version": PAYLOAD_SCHEMA_VERSION,
+        "profile": config.profile.value,
+        "configuration": {
+            "fourier_points": FOURIER_POINTS,
+            "fourier_refinement_points": FOURIER_REFINEMENT_POINTS,
+            "monte_carlo_paths": config.monte_carlo_paths,
+            "q_monte_carlo_seeds": {"growth": 1_227, "stress": 1_229},
+            "steps_per_year": config.steps_per_year,
+        },
+        "provenance": {
+            "acceptance_manifest": {
+                "path": _repository_relative(ACCEPTANCE_MANIFEST),
+                "sha256": _sha256(ACCEPTANCE_MANIFEST),
+            },
+            "frozen_physical_feynman_kac_oracle": {
+                "path": _repository_relative(FROZEN_ORACLE),
+                "sha256": frozen_hash,
+                "usage": "physical_feynman_kac_validation_only",
+            },
+            "production_analytics": "stochvolmodels package APIs",
+        },
+        "records": records,
+    }
+    return validate_numerical_payload(payload)
+
+
+def write_artifact_manifest(
+    output_directory: Path | str,
+    *,
+    profile: ChapterProfile | str,
+    mode: str,
+    payload_path: Path,
+    artifacts: Sequence[Path],
+) -> Path:
+    """Write output-relative hashes for one computed or rerendered run."""
+
+    if mode not in {"computed", "rerendered"}:
+        raise ValueError("artifact-manifest mode must be 'computed' or 'rerendered'")
+    output = validate_output_directory(output_directory)
+    payload = Path(payload_path).resolve()
+    try:
+        payload_relative = payload.relative_to(output).as_posix()
+    except ValueError as error:
+        raise ValueError("payload_path must be inside output_directory") from error
+    entries = []
+    for artifact in sorted({Path(path).resolve() for path in artifacts}, key=str):
+        if not artifact.is_file():
+            raise FileNotFoundError(f"expected artifact is missing: {artifact}")
+        try:
+            relative = artifact.relative_to(output).as_posix()
+        except ValueError as error:
+            raise ValueError(f"artifact is outside output directory: {artifact}") from error
+        entries.append({"path": relative, "sha256": _sha256(artifact)})
+    manifest = {
+        "schema_version": 1,
+        "profile": as_profile(profile).value,
+        "mode": mode,
+        "payload": {"path": payload_relative, "sha256": _sha256(payload)},
+        "artifacts": entries,
+    }
+    _validate_finite_json(manifest, "artifact_manifest")
+    target = output / ARTIFACT_MANIFEST_FILENAME
+    target.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return target
+
+
+__all__ = [
+    "ACCEPTANCE_MANIFEST",
+    "ARTIFACT_MANIFEST_FILENAME",
+    "ChapterConfig",
+    "ChapterProfile",
+    "DEFAULT_OUTPUT_ROOT",
+    "EXPECTED_FROZEN_ORACLE_SHA256",
+    "FORBID_RECOMPUTE_ENV",
+    "PAYLOAD_FILENAME",
+    "REPOSITORY_ROOT",
+    "SCRIPT_DIR",
+    "array_record",
+    "as_profile",
+    "build_numerical_payload",
+    "default_output_directory",
+    "equity_params",
+    "load_numerical_payload",
+    "profile_config",
+    "record_array",
+    "record_axis",
+    "validate_numerical_payload",
+    "validate_output_directory",
+    "write_artifact_manifest",
+    "write_numerical_payload",
+]

--- a/volatility_book/ch_lognormal_sv_risk_premia/regime_switch_logsv.py
+++ b/volatility_book/ch_lognormal_sv_risk_premia/regime_switch_logsv.py
@@ -1,0 +1,838 @@
+"""Book-local regime-switching LogSV equilibrium and option analytics.
+
+The implementation combines the quadratic-drift log-normal stochastic-volatility
+model of Sepp and Rakhmonov with the transition-tied exponential jumps of Sepp's
+goal-based-allocation model.  Regime 0 is growth and regime 1 is stress.  A
+transition 0 -> 1 carries a negative exponential log jump and 1 -> 0 carries a
+positive exponential log jump.
+
+The equilibrium value coefficient and the option log MGF are represented by a
+log-polynomial in mean-adjusted volatility.  Equilibrium degree one is the
+quadratic-preserving local log-linear closure.  Degree two is the paper's
+first-order affine expansion and induces a cubic risk-neutral volatility drift;
+that cubic is retained in both the model dynamics and Monte Carlo.  The option
+transform uses the paper's degree-four second-order expansion, with only powers
+above the selected transform degree assigned to the PDE residual.
+
+This module deliberately stays next to the book chapter.  It is reference and
+replication code, not part of the public ``stochvolmodels`` API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import comb
+from typing import Any
+
+import numpy as np
+from scipy.integrate import solve_ivp
+
+import stochvolmodels as svm
+
+GROWTH = 0
+STRESS = 1
+
+
+@dataclass(frozen=True)
+class RegimeSpec:
+    """Within-regime physical LogSV parameters."""
+
+    theta: float
+    kappa1: float
+    kappa2: float
+    beta: float
+    volvol: float
+
+    def __post_init__(self) -> None:
+        if self.theta <= 0.0:
+            raise ValueError("theta must be positive")
+        if self.kappa1 <= 0.0 or self.kappa2 < 0.0:
+            raise ValueError("kappa1 must be positive and kappa2 non-negative")
+        if self.volvol < 0.0:
+            raise ValueError("volvol must be non-negative")
+
+    @property
+    def vartheta2(self) -> float:
+        """Total instantaneous variance coefficient of volatility."""
+
+        return self.beta * self.beta + self.volvol * self.volvol
+
+    @property
+    def kappa_bar(self) -> float:
+        """Linearized mean-reversion speed around ``theta``."""
+
+        return self.kappa1 + self.kappa2 * self.theta
+
+
+@dataclass(frozen=True)
+class RiskPremiaScales:
+    """Multipliers used for transparent risk-premium counterfactuals.
+
+    All values equal to one give the equilibrium measure.  Channel-isolation
+    experiments with other values are explicitly non-equilibrium counterfactuals.
+    """
+
+    equity_brownian: float = 1.0
+    orthogonal_brownian: float = 1.0
+    timing: float = 1.0
+    tail: float = 1.0
+
+    def __post_init__(self) -> None:
+        values = (
+            self.equity_brownian,
+            self.orthogonal_brownian,
+            self.timing,
+            self.tail,
+        )
+        if not all(np.isfinite(values)):
+            raise ValueError("risk-premium scales must be finite")
+
+
+@dataclass(frozen=True)
+class RegimeSwitchLogSvParams:
+    """Physical parameters and representative-agent preference specification."""
+
+    sigma0: float
+    regimes: tuple[RegimeSpec, RegimeSpec]
+    transition_intensities: tuple[float, float]
+    jump_means: tuple[float, float]
+    gamma: float
+    rate: float = 0.0
+    initial_regime: int = GROWTH
+    agent_horizon: float = 20.0
+
+    def __post_init__(self) -> None:
+        if self.sigma0 <= 0.0:
+            raise ValueError("sigma0 must be positive")
+        if len(self.regimes) != 2:
+            raise ValueError("exactly two regimes are required")
+        if len(self.transition_intensities) != 2 or min(self.transition_intensities) <= 0.0:
+            raise ValueError("both physical transition intensities must be positive")
+        if len(self.jump_means) != 2 or min(self.jump_means) <= 0.0:
+            raise ValueError("both exponential log-jump means must be positive")
+        if self.jump_means[STRESS] >= 0.5:
+            raise ValueError("recovery jump mean must be below 0.5 for finite variance")
+        if self.gamma >= 1.0:
+            raise ValueError("CRRA power gamma must be below one")
+        if self.initial_regime not in (GROWTH, STRESS):
+            raise ValueError("initial_regime must be GROWTH (0) or STRESS (1)")
+        if self.agent_horizon <= 0.0:
+            raise ValueError("agent_horizon must be positive")
+        self.validate_equilibrium_moments()
+
+    @classmethod
+    def equity_baseline(
+        cls,
+        *,
+        gamma: float = -0.5,
+        initial_regime: int = GROWTH,
+        agent_horizon: float = 3.0,
+    ) -> "RegimeSwitchLogSvParams":
+        """Equity illustration using the jump calibration from Sepp (2026).
+
+        The paper specifies growth/stress volatility levels of 15% and 22.5%,
+        transition intensities 0.1 and 1.0, a 25% arithmetic crash loss and a 15%
+        arithmetic recovery gain.  The latter imply exponential log-jump means
+        1/3 and 0.15/1.15, respectively.  The remaining within-regime LogSV
+        coefficients are the SPY illustration distributed with
+        ``examples/pricing/run_qvar_analytics.py``.  Combining those response
+        coefficients with the paper's regime volatility levels gives a transparent,
+        reproducible hybrid illustration; it is not presented as a calibration.
+        """
+
+        growth = RegimeSpec(
+            theta=0.15,
+            kappa1=2.6949,
+            kappa2=10.0107,
+            beta=-1.5082,
+            volvol=0.8503,
+        )
+        stress = RegimeSpec(
+            theta=0.225,
+            kappa1=2.6949,
+            kappa2=10.0107,
+            beta=-1.5082,
+            volvol=0.8503,
+        )
+        return cls(
+            sigma0=0.15,
+            regimes=(growth, stress),
+            transition_intensities=(0.1, 1.0),
+            jump_means=(0.25 / 0.75, 0.15 / 1.15),
+            gamma=gamma,
+            initial_regime=initial_regime,
+            agent_horizon=agent_horizon,
+        )
+
+    def jump_mgf(self, regime: int, z: complex | np.ndarray) -> complex | np.ndarray:
+        """Physical jump MGF ``E[exp(z J_i)]`` in the paper's mean convention."""
+
+        eta = self.jump_means[regime]
+        if regime == GROWTH:
+            return 1.0 / (1.0 + eta * z)
+        return 1.0 / (1.0 - eta * z)
+
+    def jump_compensator(self, regime: int) -> float:
+        """Physical arithmetic jump mean ``E[exp(J_i)-1]``."""
+
+        return float(self.jump_mgf(regime, 1.0) - 1.0)
+
+    def transition_factor(self, regime: int) -> float:
+        """Equilibrium coupling factor Lambda_i."""
+
+        gamma = self.gamma
+        value = (1.0 - gamma) * self.jump_mgf(regime, gamma)
+        value += gamma * self.jump_mgf(regime, gamma - 1.0)
+        return float(value)
+
+    def validate_jump_moment(self, regime: int, z: complex | np.ndarray) -> None:
+        """Fail closed when an exponential jump moment is outside its domain."""
+
+        real_z = np.real(np.asarray(z))
+        eta = self.jump_means[regime]
+        if regime == GROWTH and np.any(real_z <= -1.0 / eta):
+            raise ValueError(
+                f"crash jump moment requires Re(z) > {-1.0 / eta:.6g}; "
+                f"received minimum {np.min(real_z):.6g}"
+            )
+        if regime == STRESS and np.any(real_z >= 1.0 / eta):
+            raise ValueError(
+                f"recovery jump moment requires Re(z) < {1.0 / eta:.6g}; "
+                f"received maximum {np.max(real_z):.6g}"
+            )
+
+    def validate_equilibrium_moments(self) -> None:
+        """Validate CRRA moments and positivity of the Feynman-Kac coupling."""
+
+        for regime in (GROWTH, STRESS):
+            self.validate_jump_moment(regime, self.gamma)
+            self.validate_jump_moment(regime, self.gamma - 1.0)
+            factor = self.transition_factor(regime)
+            if factor <= 0.0:
+                raise ValueError(
+                    f"equilibrium transition factor Lambda[{regime}]={factor:.6g} "
+                    "must be positive for the Feynman-Kac representation"
+                )
+
+
+def _poly_pad(values: np.ndarray, degree: int) -> np.ndarray:
+    values = np.asarray(values)
+    output = np.zeros(values.shape[:-1] + (degree + 1,), dtype=values.dtype)
+    count = min(values.shape[-1], degree + 1)
+    output[..., :count] = values[..., :count]
+    return output
+
+
+def poly_mul(left: np.ndarray, right: np.ndarray, degree: int) -> np.ndarray:
+    """Multiply ascending-coefficient polynomials and truncate at ``degree``."""
+
+    left = _poly_pad(np.asarray(left), degree)
+    right = _poly_pad(np.asarray(right), degree)
+    shape = np.broadcast_shapes(left.shape[:-1], right.shape[:-1]) + (degree + 1,)
+    output = np.zeros(shape, dtype=np.result_type(left, right))
+    for total in range(degree + 1):
+        for index in range(total + 1):
+            output[..., total] += left[..., index] * right[..., total - index]
+    return output
+
+
+def poly_derivative(values: np.ndarray, degree: int) -> np.ndarray:
+    """Differentiate an ascending-coefficient polynomial."""
+
+    values = _poly_pad(np.asarray(values), degree)
+    output = np.zeros_like(values)
+    for index in range(1, degree + 1):
+        output[..., index - 1] = index * values[..., index]
+    return output
+
+
+def poly_shift(values: np.ndarray, delta: float, degree: int) -> np.ndarray:
+    """Return coefficients of ``P(v + delta)`` through ``v**degree``."""
+
+    values = _poly_pad(np.asarray(values), degree)
+    output = np.zeros_like(values)
+    for power in range(degree + 1):
+        for original in range(power, degree + 1):
+            output[..., power] += (
+                comb(original, power) * values[..., original] * delta ** (original - power)
+            )
+    return output
+
+
+def poly_exp(values: np.ndarray, degree: int) -> np.ndarray:
+    """Taylor coefficients of ``exp(P(v))`` through ``v**degree``."""
+
+    values = _poly_pad(np.asarray(values), degree)
+    output = np.zeros_like(values)
+    output[..., 0] = np.exp(values[..., 0])
+    for power in range(1, degree + 1):
+        for index in range(1, power + 1):
+            output[..., power] += index * values[..., index] * output[..., power - index] / power
+    return output
+
+
+def poly_value(values: np.ndarray, argument: float | np.ndarray) -> np.ndarray:
+    """Evaluate ascending-coefficient polynomials with Horner's rule."""
+
+    values = np.asarray(values)
+    result = np.zeros(
+        np.broadcast_shapes(values.shape[:-1], np.shape(argument)), dtype=values.dtype
+    )
+    for coefficient in np.moveaxis(values, -1, 0)[::-1]:
+        result = result * argument + coefficient
+    return result
+
+
+def _sigma2_polynomial(theta: float, degree: int, dtype: Any = float) -> np.ndarray:
+    output = np.zeros(degree + 1, dtype=dtype)
+    output[: min(3, degree + 1)] = np.asarray((theta * theta, 2.0 * theta, 1.0))[
+        : min(3, degree + 1)
+    ]
+    return output
+
+
+def _physical_drift_polynomial(spec: RegimeSpec, degree: int, dtype: Any = float) -> np.ndarray:
+    output = np.zeros(degree + 1, dtype=dtype)
+    if degree >= 1:
+        output[1] = -spec.kappa_bar
+    if degree >= 2:
+        output[2] = -spec.kappa2
+    return output
+
+
+def _regime_difference(
+    coefficients: np.ndarray,
+    params: RegimeSwitchLogSvParams,
+    regime: int,
+    degree: int,
+) -> np.ndarray:
+    other = 1 - regime
+    delta = params.regimes[regime].theta - params.regimes[other].theta
+    own = _poly_pad(coefficients[..., regime, :], degree)
+    target = coefficients[..., other, :]
+    return poly_shift(target, delta, degree) - own
+
+
+def _equilibrium_rhs(
+    _tau: float,
+    flat_coefficients: np.ndarray,
+    params: RegimeSwitchLogSvParams,
+    degree: int,
+) -> np.ndarray:
+    coefficients = flat_coefficients.reshape(2, degree + 1)
+    output = np.zeros_like(coefficients)
+    qvar_loading = 0.5 * params.gamma * (1.0 - params.gamma)
+
+    for regime, spec in enumerate(params.regimes):
+        first = poly_derivative(coefficients[regime], degree)
+        second = poly_derivative(first, degree)
+        sigma2 = _sigma2_polynomial(spec.theta, degree, coefficients.dtype)
+        diffusion = second + poly_mul(first, first, degree)
+        local = poly_mul(_physical_drift_polynomial(spec, degree), first, degree)
+        local += 0.5 * spec.vartheta2 * poly_mul(sigma2, diffusion, degree)
+        local += qvar_loading * sigma2
+
+        difference = _regime_difference(coefficients, params, regime, degree)
+        coupling = params.transition_intensities[regime]
+        coupling *= params.transition_factor(regime) * poly_exp(difference, degree)
+        coupling[0] -= params.transition_intensities[regime]
+        output[regime] = local + coupling
+    return output.ravel()
+
+
+@dataclass(frozen=True)
+class EquilibriumSolution:
+    """Dense log-polynomial solution for the equilibrium coefficient functions."""
+
+    params: RegimeSwitchLogSvParams
+    degree: int
+    ode_result: Any
+
+    def coefficients(self, horizon: float) -> np.ndarray:
+        if horizon < -1.0e-12 or horizon > self.params.agent_horizon + 1.0e-12:
+            raise ValueError("horizon is outside the solved representative-agent interval")
+        horizon = float(np.clip(horizon, 0.0, self.params.agent_horizon))
+        return np.asarray(self.ode_result.sol(horizon)).reshape(2, self.degree + 1)
+
+    def log_g_hat(self, horizon: float, sigma: float, regime: int) -> float:
+        spec = self.params.regimes[regime]
+        return float(poly_value(self.coefficients(horizon)[regime], sigma - spec.theta))
+
+    def loading(self, horizon: float, sigma: float, regime: int) -> float:
+        spec = self.params.regimes[regime]
+        first = poly_derivative(self.coefficients(horizon)[regime], self.degree)
+        return float(poly_value(first, sigma - spec.theta))
+
+    def log_regime_ratio(self, horizon: float, sigma: float, regime: int) -> float:
+        other = 1 - regime
+        values = self.coefficients(horizon)
+        own = poly_value(values[regime], sigma - self.params.regimes[regime].theta)
+        target = poly_value(values[other], sigma - self.params.regimes[other].theta)
+        return float(target - own)
+
+
+def solve_equilibrium(
+    params: RegimeSwitchLogSvParams,
+    *,
+    degree: int = 4,
+    rtol: float = 2.0e-10,
+    atol: float = 2.0e-12,
+) -> EquilibriumSolution:
+    """Solve a degree-1, degree-2, or degree-4 equilibrium log-polynomial system.
+
+    Degree one produces the quadratic-preserving equilibrium approximation used
+    for comparison in the note.  Degree two is the published FIRST expansion;
+    degree four is the published SECOND expansion.
+    """
+
+    if degree not in (1, 2, 4):
+        raise ValueError("degree must be 1 (log-linear), 2 (FIRST), or 4 (SECOND)")
+    initial = np.zeros(2 * (degree + 1), dtype=float)
+    result = solve_ivp(
+        _equilibrium_rhs,
+        (0.0, params.agent_horizon),
+        initial,
+        args=(params, degree),
+        method="DOP853",
+        dense_output=True,
+        rtol=rtol,
+        atol=atol,
+        max_step=0.05,
+    )
+    if not result.success:
+        raise RuntimeError(f"equilibrium ODE failed: {result.message}")
+    return EquilibriumSolution(params=params, degree=degree, ode_result=result)
+
+
+def single_regime_closed_form(
+    horizons: np.ndarray,
+    spec: RegimeSpec,
+    gamma: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Closed-form log-linear equilibrium coefficients from the note's lemma."""
+
+    horizons = np.asarray(horizons, dtype=float)
+    vartheta2 = spec.vartheta2
+    discriminant2 = spec.kappa_bar**2 + 4.0 * vartheta2 * spec.theta**2 * gamma * (gamma - 1.0)
+    if discriminant2 <= 0.0:
+        raise ValueError("the real closed form requires a strictly positive discriminant")
+    discriminant = np.sqrt(discriminant2)
+    denominator_scale = 2.0 * vartheta2 * spec.theta
+    root_plus = (spec.kappa_bar + discriminant) / denominator_scale
+    root_minus = (spec.kappa_bar - discriminant) / denominator_scale
+    exponential = np.exp(-discriminant * horizons)
+    denominator = root_plus - root_minus * exponential
+    a1 = root_plus * root_minus * (1.0 - exponential) / denominator
+    integral_a1 = root_minus * horizons
+    integral_a1 += np.log((root_plus - root_minus) / denominator) / (vartheta2 * spec.theta)
+    a0 = 0.5 * spec.theta * a1
+    a0 += 0.5 * spec.theta * spec.kappa_bar * integral_a1
+    return a0, a1
+
+
+def _risk_neutral_drift_polynomial(
+    equilibrium_coefficients: np.ndarray,
+    params: RegimeSwitchLogSvParams,
+    regime: int,
+    degree: int,
+    scales: RiskPremiaScales,
+) -> np.ndarray:
+    spec = params.regimes[regime]
+    sigma2 = _sigma2_polynomial(spec.theta, degree, equilibrium_coefficients.dtype)
+    loading = poly_derivative(equilibrium_coefficients[regime], degree)
+    output = _physical_drift_polynomial(spec, degree, equilibrium_coefficients.dtype)
+    output -= scales.equity_brownian * spec.beta * (1.0 - params.gamma) * sigma2
+    loading_scale = scales.equity_brownian * spec.beta**2
+    loading_scale += scales.orthogonal_brownian * spec.volvol**2
+    output += loading_scale * poly_mul(sigma2, loading, degree)
+    return output
+
+
+def _option_rhs(
+    backward_time: float,
+    flat_coefficients: np.ndarray,
+    *,
+    params: RegimeSwitchLogSvParams,
+    equilibrium: EquilibriumSolution,
+    ttm: float,
+    phi_grid: np.ndarray,
+    degree: int,
+    scales: RiskPremiaScales,
+) -> np.ndarray:
+    count = phi_grid.size
+    coefficients = flat_coefficients.reshape(count, 2, degree + 1)
+    output = np.zeros_like(coefficients)
+    equilibrium_horizon = params.agent_horizon - ttm + backward_time
+    eq_coefficients = equilibrium.coefficients(equilibrium_horizon)
+    phi = phi_grid[:, None]
+    tail_tilt = scales.tail * (params.gamma - 1.0)
+
+    for regime, spec in enumerate(params.regimes):
+        sigma2 = _sigma2_polynomial(spec.theta, degree, complex)
+        first = poly_derivative(coefficients[:, regime, :], degree)
+        second = poly_derivative(first, degree)
+        local = poly_mul(
+            _risk_neutral_drift_polynomial(eq_coefficients, params, regime, degree, scales),
+            first,
+            degree,
+        )
+        local += (
+            0.5 * spec.vartheta2 * poly_mul(sigma2, second + poly_mul(first, first, degree), degree)
+        )
+        local -= spec.beta * phi * poly_mul(sigma2, first, degree)
+        local += 0.5 * phi * (phi + 1.0) * sigma2
+
+        eq_difference = _regime_difference(eq_coefficients, params, regime, degree)
+        timing_ratio = poly_exp(scales.timing * eq_difference, degree)
+        price_difference = _regime_difference(coefficients, params, regime, degree)
+        price_ratio = poly_exp(price_difference, degree)
+        ell_tilt = params.jump_mgf(regime, tail_tilt)
+        ell_shifted = params.jump_mgf(regime, tail_tilt - phi_grid)
+        delta_tilt = params.jump_mgf(regime, tail_tilt + 1.0) - ell_tilt
+        bracket = ell_shifted[:, None] * price_ratio
+        bracket[:, 0] += phi_grid * delta_tilt - ell_tilt
+        jump = params.transition_intensities[regime] * poly_mul(timing_ratio, bracket, degree)
+        output[:, regime, :] = local + jump
+    return output.ravel()
+
+
+def compute_log_mgf_grid(
+    params: RegimeSwitchLogSvParams,
+    equilibrium: EquilibriumSolution,
+    ttm: float,
+    phi_grid: np.ndarray,
+    *,
+    scales: RiskPremiaScales = RiskPremiaScales(),
+    degree: int = 4,
+    rtol: float = 2.0e-7,
+    atol: float = 2.0e-9,
+) -> np.ndarray:
+    """Compute ``log E^Q[exp(-Phi X_T)]`` for forward log return ``X``."""
+
+    if ttm <= 0.0 or ttm > params.agent_horizon:
+        raise ValueError("ttm must lie in (0, agent_horizon]")
+    if equilibrium.params != params:
+        raise ValueError("equilibrium solution was built for different parameters")
+    if degree not in (2, 4):
+        raise ValueError("degree must be 2 (first order) or 4 (second order)")
+    phi_grid = np.asarray(phi_grid, dtype=np.complex128)
+    if phi_grid.ndim != 1:
+        raise ValueError("phi_grid must be one-dimensional")
+    tail_tilt = scales.tail * (params.gamma - 1.0)
+    for regime in (GROWTH, STRESS):
+        params.validate_jump_moment(regime, tail_tilt)
+        params.validate_jump_moment(regime, tail_tilt + 1.0)
+        params.validate_jump_moment(regime, tail_tilt - phi_grid)
+
+    initial = np.zeros(phi_grid.size * 2 * (degree + 1), dtype=np.complex128)
+    result = solve_ivp(
+        lambda tau, values: _option_rhs(
+            tau,
+            values,
+            params=params,
+            equilibrium=equilibrium,
+            ttm=ttm,
+            phi_grid=phi_grid,
+            degree=degree,
+            scales=scales,
+        ),
+        (0.0, ttm),
+        initial,
+        method="DOP853",
+        rtol=rtol,
+        atol=atol,
+        max_step=min(1.0 / 24.0, ttm / 4.0),
+    )
+    if not result.success:
+        raise RuntimeError(f"option MGF ODE failed: {result.message}")
+    coefficients = result.y[:, -1].reshape(phi_grid.size, 2, degree + 1)
+    regime = params.initial_regime
+    mean_adjusted_vol = params.sigma0 - params.regimes[regime].theta
+    return np.asarray(poly_value(coefficients[:, regime, :], mean_adjusted_vol))
+
+
+@dataclass(frozen=True)
+class AnalyticSlice:
+    strikes: np.ndarray
+    optiontypes: np.ndarray
+    prices: np.ndarray
+    implied_vols: np.ndarray
+    phi_grid: np.ndarray
+    log_mgf: np.ndarray
+
+
+def price_slice(
+    params: RegimeSwitchLogSvParams,
+    equilibrium: EquilibriumSolution,
+    ttm: float,
+    strikes: np.ndarray,
+    *,
+    optiontypes: np.ndarray | None = None,
+    scales: RiskPremiaScales = RiskPremiaScales(),
+    degree: int = 4,
+    max_phi: int = 1601,
+) -> AnalyticSlice:
+    """Price normalized European options and infer Black implied volatilities."""
+
+    strikes = np.asarray(strikes, dtype=float)
+    if optiontypes is None:
+        optiontypes = np.where(strikes < 1.0, "P", "C")
+    optiontypes = np.asarray(optiontypes)
+    vol_scaler = max(params.sigma0 * np.sqrt(min(ttm, 0.5 / 12.0)), 0.02)
+    phi_grid, _, _ = svm.get_transform_var_grid(
+        variable_type=svm.VariableType.LOG_RETURN,
+        is_spot_measure=True,
+        max_phi=max_phi,
+        vol_scaler=vol_scaler,
+    )
+    log_mgf = compute_log_mgf_grid(
+        params=params,
+        equilibrium=equilibrium,
+        ttm=ttm,
+        phi_grid=phi_grid,
+        scales=scales,
+        degree=degree,
+    )
+    discount = np.exp(-params.rate * ttm)
+    prices = np.asarray(
+        svm.vanilla_slice_pricer_with_mgf_grid(
+            log_mgf_grid=log_mgf,
+            phi_grid=phi_grid,
+            forward=1.0,
+            strikes=strikes,
+            optiontypes=optiontypes,
+            discfactor=discount,
+            is_spot_measure=True,
+        )
+    )
+    implied_vols = np.asarray(
+        svm.infer_bsm_ivols_from_model_slice_prices(
+            ttm=ttm,
+            forward=1.0,
+            strikes=strikes,
+            optiontypes=optiontypes,
+            model_prices=prices,
+            discfactor=discount,
+        )
+    )
+    return AnalyticSlice(
+        strikes=strikes,
+        optiontypes=optiontypes,
+        prices=prices,
+        implied_vols=implied_vols,
+        phi_grid=phi_grid,
+        log_mgf=log_mgf,
+    )
+
+
+def risk_neutral_state(
+    params: RegimeSwitchLogSvParams,
+    equilibrium: EquilibriumSolution,
+    horizon: float,
+    sigma: np.ndarray,
+    regime: int,
+    scales: RiskPremiaScales = RiskPremiaScales(),
+) -> tuple[np.ndarray, np.ndarray, float, float, np.ndarray, np.ndarray]:
+    """Evaluate exact induced-Q drift, hazard, and tilted jump objects.
+
+    The volatility drift returned here includes every power generated by the
+    approximate loading.  A degree-one equilibrium loading gives a quadratic
+    drift.  With a degree-two log-value coefficient the result also contains the
+    cubic term ``2*vartheta2*a2*sigma**3``.
+    """
+
+    sigma = np.asarray(sigma, dtype=float)
+    spec = params.regimes[regime]
+    loading = equilibrium.loading(horizon, sigma, regime) if sigma.ndim == 0 else None
+    if loading is None:
+        first = poly_derivative(equilibrium.coefficients(horizon)[regime], equilibrium.degree)
+        loading = poly_value(first, sigma - spec.theta)
+    log_ratio = (
+        equilibrium.log_regime_ratio(horizon, float(sigma), regime) if sigma.ndim == 0 else None
+    )
+    if log_ratio is None:
+        values = equilibrium.coefficients(horizon)
+        own = poly_value(values[regime], sigma - spec.theta)
+        other = 1 - regime
+        target = poly_value(values[other], sigma - params.regimes[other].theta)
+        log_ratio = target - own
+
+    drift = (spec.kappa1 + spec.kappa2 * sigma) * (spec.theta - sigma)
+    drift -= scales.equity_brownian * spec.beta * (1.0 - params.gamma) * sigma**2
+    loading_scale = scales.equity_brownian * spec.beta**2
+    loading_scale += scales.orthogonal_brownian * spec.volvol**2
+    drift += loading_scale * loading * sigma**2
+
+    tail_tilt = scales.tail * (params.gamma - 1.0)
+    ell_tilt = float(params.jump_mgf(regime, tail_tilt))
+    tilted_log_mean = params.jump_means[regime]
+    if regime == GROWTH:
+        tilted_log_mean /= 1.0 + params.jump_means[regime] * tail_tilt
+    else:
+        tilted_log_mean /= 1.0 - params.jump_means[regime] * tail_tilt
+    arithmetic_mean = float(params.jump_mgf(regime, tail_tilt + 1.0) / ell_tilt - 1.0)
+    timing_ratio = np.exp(scales.timing * log_ratio)
+    intensity = params.transition_intensities[regime] * timing_ratio * ell_tilt
+    return drift, intensity, tilted_log_mean, arithmetic_mean, loading, log_ratio
+
+
+@dataclass(frozen=True)
+class TerminalSample:
+    log_forward_return: np.ndarray
+    sigma: np.ndarray
+    regime: np.ndarray
+
+    @property
+    def forward_martingale(self) -> tuple[float, float]:
+        values = np.exp(self.log_forward_return)
+        return float(np.mean(values)), float(np.std(values, ddof=1) / np.sqrt(values.size))
+
+
+def simulate_terminal_q(
+    params: RegimeSwitchLogSvParams,
+    equilibrium: EquilibriumSolution,
+    ttm: float,
+    *,
+    n_paths: int = 100_000,
+    steps_per_year: int = 720,
+    seed: int = 7,
+    scales: RiskPremiaScales = RiskPremiaScales(),
+) -> TerminalSample:
+    """Monte Carlo under the full time- and state-dependent induced Q dynamics."""
+
+    if ttm <= 0.0 or ttm > params.agent_horizon:
+        raise ValueError("ttm must lie in (0, agent_horizon]")
+    if n_paths < 2 or steps_per_year < 1:
+        raise ValueError("n_paths and steps_per_year are too small")
+    rng = np.random.default_rng(seed)
+    steps = max(1, int(np.ceil(ttm * steps_per_year)))
+    dt = ttm / steps
+    sqrt_dt = np.sqrt(dt)
+    log_return = np.zeros(n_paths)
+    sigma = np.full(n_paths, params.sigma0)
+    log_sigma = np.full(n_paths, np.log(params.sigma0))
+    regimes = np.full(n_paths, params.initial_regime, dtype=np.int8)
+
+    for step in range(steps):
+        calendar_time = step * dt
+        horizon = params.agent_horizon - calendar_time
+        normals0 = rng.standard_normal(n_paths) * sqrt_dt
+        normals1 = rng.standard_normal(n_paths) * sqrt_dt
+        old_sigma = sigma.copy()
+        source_regimes = regimes.copy()
+        for regime, spec in enumerate(params.regimes):
+            mask = source_regimes == regime
+            if not np.any(mask):
+                continue
+            drift, intensity, jump_mean, arithmetic_mean, _, _ = risk_neutral_state(
+                params,
+                equilibrium,
+                horizon,
+                old_sigma[mask],
+                regime,
+                scales,
+            )
+            log_return[mask] += (-0.5 * old_sigma[mask] ** 2 - intensity * arithmetic_mean) * dt
+            log_return[mask] += old_sigma[mask] * normals0[mask]
+            log_sigma[mask] += (drift / old_sigma[mask] - 0.5 * spec.vartheta2) * dt
+            log_sigma[mask] += spec.beta * normals0[mask] + spec.volvol * normals1[mask]
+
+            transition_probability = -np.expm1(-intensity * dt)
+            local_uniforms = rng.random(np.count_nonzero(mask))
+            local_jump = local_uniforms < transition_probability
+            if np.any(local_jump):
+                indices = np.flatnonzero(mask)[local_jump]
+                sizes = rng.exponential(jump_mean, indices.size)
+                log_return[indices] += -sizes if regime == GROWTH else sizes
+                regimes[indices] = 1 - regime
+        sigma = np.exp(log_sigma)
+        if not np.all(np.isfinite(sigma)):
+            raise FloatingPointError("non-finite volatility encountered in Q simulation")
+    return TerminalSample(log_forward_return=log_return, sigma=sigma, regime=regimes)
+
+
+def mc_price_slice(
+    sample: TerminalSample,
+    params: RegimeSwitchLogSvParams,
+    ttm: float,
+    strikes: np.ndarray,
+    optiontypes: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Price a normalized option slice from a terminal Q sample."""
+
+    terminal = np.exp(sample.log_forward_return)
+    discount = np.exp(-params.rate * ttm)
+    strikes = np.asarray(strikes, dtype=float)
+    optiontypes = np.asarray(optiontypes)
+    prices = np.zeros(strikes.size)
+    errors = np.zeros(strikes.size)
+    for index, (strike, optiontype) in enumerate(zip(strikes, optiontypes)):
+        if optiontype == "C":
+            payoff = np.maximum(terminal - strike, 0.0)
+        elif optiontype == "P":
+            payoff = np.maximum(strike - terminal, 0.0)
+        else:
+            raise ValueError(f"unsupported option type {optiontype!r}")
+        prices[index] = discount * np.mean(payoff)
+        errors[index] = discount * np.std(payoff, ddof=1) / np.sqrt(payoff.size)
+    implied_vols = np.asarray(
+        svm.infer_bsm_ivols_from_model_slice_prices(
+            ttm=ttm,
+            forward=1.0,
+            strikes=strikes,
+            optiontypes=optiontypes,
+            model_prices=prices,
+            discfactor=discount,
+        )
+    )
+    return prices, errors, implied_vols
+
+
+def simulate_equilibrium_feynman_kac(
+    params: RegimeSwitchLogSvParams,
+    horizon: float,
+    sigma0: float,
+    initial_regime: int,
+    *,
+    n_paths: int = 100_000,
+    steps_per_year: int = 720,
+    seed: int = 19,
+) -> tuple[float, float]:
+    """Independent physical-measure Monte Carlo for the equilibrium coefficient."""
+
+    rng = np.random.default_rng(seed)
+    steps = max(1, int(np.ceil(horizon * steps_per_year)))
+    dt = horizon / steps
+    sqrt_dt = np.sqrt(dt)
+    sigma = np.full(n_paths, sigma0)
+    log_sigma = np.full(n_paths, np.log(sigma0))
+    regimes = np.full(n_paths, initial_regime, dtype=np.int8)
+    log_weight = np.zeros(n_paths)
+    qvar_loading = 0.5 * params.gamma * (1.0 - params.gamma)
+    transition_log_factors = np.log(
+        [params.transition_factor(GROWTH), params.transition_factor(STRESS)]
+    )
+
+    for _ in range(steps):
+        old_sigma = sigma.copy()
+        log_weight += qvar_loading * old_sigma**2 * dt
+        normal0 = rng.standard_normal(n_paths) * sqrt_dt
+        normal1 = rng.standard_normal(n_paths) * sqrt_dt
+        source_regimes = regimes.copy()
+        for regime, spec in enumerate(params.regimes):
+            mask = source_regimes == regime
+            if not np.any(mask):
+                continue
+            drift_over_sigma = spec.kappa1 * spec.theta / old_sigma[mask] - spec.kappa1
+            drift_over_sigma += spec.kappa2 * (spec.theta - old_sigma[mask])
+            log_sigma[mask] += (drift_over_sigma - 0.5 * spec.vartheta2) * dt
+            log_sigma[mask] += spec.beta * normal0[mask] + spec.volvol * normal1[mask]
+            probability = -np.expm1(-params.transition_intensities[regime] * dt)
+            local_jump = rng.random(np.count_nonzero(mask)) < probability
+            if np.any(local_jump):
+                indices = np.flatnonzero(mask)[local_jump]
+                log_weight[indices] += transition_log_factors[regime]
+                regimes[indices] = 1 - regime
+        sigma = np.exp(log_sigma)
+    values = np.exp(log_weight)
+    return float(np.mean(values)), float(np.std(values, ddof=1) / np.sqrt(n_paths))

--- a/volatility_book/ch_lognormal_sv_risk_premia/source_provenance.json
+++ b/volatility_book/ch_lognormal_sv_risk_premia/source_provenance.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+  "snapshot_kind": "first_tracked_snapshot_of_untracked_maintainer_working_files",
+  "snapshot_date": "2026-08-25",
+  "package_baseline_commit": "580246b4029ee22a396f9bccab88a4392716f406",
+  "authority": {
+    "selected_candidate": "maintainer checkout volatility_book/ch_lognormal_sv_risk_premia",
+    "historical_git_ref": null,
+    "statement": "These hashes identify the maintainer-approved source candidate. They do not establish historical Git provenance before this snapshot."
+  },
+  "files": [
+    {
+      "path": "regime_switch_logsv.py",
+      "bytes": 31979,
+      "sha256_raw": "f197e10149cab121d1cdecec2a85b5311143d69dbde00311d4d8b90f1d9b9e5a",
+      "sha256_lf": "f197e10149cab121d1cdecec2a85b5311143d69dbde00311d4d8b90f1d9b9e5a"
+    },
+    {
+      "path": "verify_regime_sv_equilibrium.py",
+      "bytes": 13873,
+      "sha256_raw": "f37d878145f557f5bb37a41991958198fc869f8856e113c744b0bee67540f6b6",
+      "sha256_lf": "f37d878145f557f5bb37a41991958198fc869f8856e113c744b0bee67540f6b6"
+    },
+    {
+      "path": "generate_regime_sv_figures.py",
+      "bytes": 22443,
+      "sha256_raw": "7807a942338d74cfcb05e85f0e4bf6dad6f4a7bc95c405cad1bf803a1e9d06c3",
+      "sha256_lf": "7807a942338d74cfcb05e85f0e4bf6dad6f4a7bc95c405cad1bf803a1e9d06c3"
+    },
+    {
+      "path": "notes/risk_premia_lognormal_sv.tex",
+      "bytes": 67472,
+      "sha256_raw": "9854edf6311cc48806f3f68abc7489b8bd70c3349669d406a988d86af96a8218",
+      "sha256_lf": "9854edf6311cc48806f3f68abc7489b8bd70c3349669d406a988d86af96a8218"
+    }
+  ],
+  "reference_authorities": {
+    "published_logsv_tex_sha256": "72ec138369db757c4ef7198ef10934ea235095146b5449b182101b6556e5050d",
+    "goal_based_allocation_commit": "f2819481770e96ad445b2b3364886fe05826364d",
+    "earlier_external_v3_note_sha256": "487bc135ef8db510cc80a0d34e0ad79df06d3eeafe909446d5e84ff64bb3cc87"
+  },
+  "known_gaps": [
+    "The note names ValuationUnderSV.tex, but that claimed original source was not found.",
+    "The note names verify_valuation_under_sv.py and verify_hawkes_equilibrium.py, but neither script is part of this approved source snapshot.",
+    "The combined equity parameters are an illustration, not an empirical calibration."
+  ],
+  "excluded_as_generated_or_reference_only": [
+    "notes/*.aux",
+    "notes/*.log",
+    "notes/*.out",
+    "notes/*.pdf",
+    "notes/*.synctex.gz",
+    "notes/figures/*",
+    "notes/regime_sv_closure_comparison_table.tex",
+    "notes/regime_sv_validation_table.tex",
+    "notes/goal_based_allocation_2026.tex",
+    "notes/lognormal_stoch_vol_final.tex"
+  ]
+}

--- a/volatility_book/ch_lognormal_sv_risk_premia/verify_regime_sv_equilibrium.py
+++ b/volatility_book/ch_lognormal_sv_risk_premia/verify_regime_sv_equilibrium.py
@@ -1,0 +1,351 @@
+r"""Independent checks for the regime-switching LogSV equilibrium extension.
+
+Run the default verification with::
+
+    C:\Python\StochVolModels312\Scripts\python.exe verify_regime_sv_equilibrium.py
+
+Use ``--full`` for the report-quality Monte Carlo sample.  The checks deliberately
+combine algebraic identities, an exact frozen-volatility benchmark, physical-measure
+Feynman--Kac Monte Carlo, and induced-risk-neutral option Monte Carlo.  Both the
+log-linear/quadratic-Q and log-quadratic/full-cubic-Q equilibrium closures are checked.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+from regime_switch_logsv import (
+    GROWTH,
+    STRESS,
+    RegimeSpec,
+    RegimeSwitchLogSvParams,
+    _equilibrium_rhs,
+    compute_log_mgf_grid,
+    mc_price_slice,
+    price_slice,
+    risk_neutral_state,
+    simulate_equilibrium_feynman_kac,
+    simulate_terminal_q,
+    single_regime_closed_form,
+    solve_equilibrium,
+)
+from scipy.linalg import expm
+
+
+def _require(label: str, error: float, tolerance: float) -> None:
+    status = "PASS" if error <= tolerance else "FAIL"
+    print(f"{status:4s} {label:48s} error={error:.6g}  tolerance={tolerance:.6g}")
+    if error > tolerance:
+        raise AssertionError(f"{label}: error {error:.6g} exceeds {tolerance:.6g}")
+
+
+def verify_jump_calibration() -> None:
+    params = RegimeSwitchLogSvParams.equity_baseline()
+    expected = np.array([-0.25, 0.15])
+    observed = np.array([params.jump_compensator(i) for i in (GROWTH, STRESS)])
+    _require("paper arithmetic jump means", np.max(np.abs(observed - expected)), 1.0e-14)
+    _require(
+        "paper transition intensities",
+        np.max(np.abs(np.asarray(params.transition_intensities) - [0.1, 1.0])),
+        1.0e-14,
+    )
+
+
+def verify_scalar_closed_form() -> None:
+    """Differentiate the closed form and substitute it into both Riccati ODEs."""
+
+    spec = RegimeSpec(theta=0.2, kappa1=2.7, kappa2=6.0, beta=-0.8, volvol=0.6)
+    gamma = -0.5
+    horizons = np.linspace(0.01, 3.0, 80)
+    step = 1.0e-5
+    a0, a1 = single_regime_closed_form(horizons, spec, gamma)
+    a0_up, a1_up = single_regime_closed_form(horizons + step, spec, gamma)
+    a0_down, a1_down = single_regime_closed_form(horizons - step, spec, gamma)
+    derivative0 = (a0_up - a0_down) / (2.0 * step)
+    derivative1 = (a1_up - a1_down) / (2.0 * step)
+    rhs0 = 0.5 * spec.vartheta2 * spec.theta**2 * a1**2
+    rhs0 += 0.5 * spec.theta**2 * gamma * (1.0 - gamma)
+    rhs1 = spec.vartheta2 * spec.theta * a1**2 - spec.kappa_bar * a1
+    rhs1 += spec.theta * gamma * (1.0 - gamma)
+    residual = max(np.max(np.abs(derivative0 - rhs0)), np.max(np.abs(derivative1 - rhs1)))
+    _require("single-regime closed-form Riccati residual", float(residual), 2.0e-9)
+
+
+def verify_frozen_volatility_exact_solution() -> None:
+    """Compare the coupled solution with a two-state matrix exponential."""
+
+    frozen = RegimeSpec(theta=0.2, kappa1=2.0, kappa2=2.0, beta=0.0, volvol=0.0)
+    params = RegimeSwitchLogSvParams(
+        sigma0=0.2,
+        regimes=(frozen, frozen),
+        transition_intensities=(0.1, 1.0),
+        jump_means=(0.25 / 0.75, 0.15 / 1.15),
+        gamma=-0.5,
+        agent_horizon=3.0,
+    )
+    potential = 0.5 * params.gamma * (1.0 - params.gamma) * params.sigma0**2
+    matrix = np.array(
+        [
+            [potential - 0.1, 0.1 * params.transition_factor(GROWTH)],
+            [1.0 * params.transition_factor(STRESS), potential - 1.0],
+        ]
+    )
+    for degree, label in ((1, "log-linear"), (2, "log-quadratic")):
+        solution = solve_equilibrium(params, degree=degree)
+        largest = 0.0
+        for horizon in (0.25, 1.0, 3.0):
+            exact = expm(matrix * horizon) @ np.ones(2)
+            approximate = np.array(
+                [
+                    np.exp(solution.log_g_hat(horizon, params.sigma0, GROWTH)),
+                    np.exp(solution.log_g_hat(horizon, params.sigma0, STRESS)),
+                ]
+            )
+            largest = max(largest, float(np.max(np.abs(exact - approximate))))
+        _require(f"frozen-volatility matrix solution ({label})", largest, 2.0e-10)
+
+
+def verify_degree_one_equilibrium_odes() -> None:
+    """Check the four explicit log-linear equations against the generic projection."""
+
+    params = RegimeSwitchLogSvParams.equity_baseline(gamma=-0.5, agent_horizon=3.0)
+    coefficients = np.array([[0.021, -0.037], [-0.014, 0.029]])
+    generic = _equilibrium_rhs(0.7, coefficients.ravel(), params, 1).reshape(2, 2)
+    explicit = np.zeros_like(generic)
+    qvar_loading = 0.5 * params.gamma * (1.0 - params.gamma)
+    for regime, spec in enumerate(params.regimes):
+        other = 1 - regime
+        delta = spec.theta - params.regimes[other].theta
+        d0 = coefficients[other, 0] + coefficients[other, 1] * delta
+        d0 -= coefficients[regime, 0]
+        d1 = coefficients[other, 1] - coefficients[regime, 1]
+        a1 = coefficients[regime, 1]
+        transition = params.transition_intensities[regime]
+        coupling = transition * params.transition_factor(regime) * np.exp(d0)
+        explicit[regime, 0] = 0.5 * spec.vartheta2 * spec.theta**2 * a1**2
+        explicit[regime, 0] += qvar_loading * spec.theta**2
+        explicit[regime, 0] += coupling - transition
+        explicit[regime, 1] = -spec.kappa_bar * a1
+        explicit[regime, 1] += spec.vartheta2 * spec.theta * a1**2
+        explicit[regime, 1] += 2.0 * qvar_loading * spec.theta
+        explicit[regime, 1] += coupling * d1
+    _require(
+        "explicit degree-one equilibrium ODEs",
+        float(np.max(np.abs(generic - explicit))),
+        2.0e-14,
+    )
+
+
+def verify_risk_neutral_drift_degrees() -> None:
+    """Verify that degree one is quadratic and degree two has the derived cubic."""
+
+    params = RegimeSwitchLogSvParams.equity_baseline(gamma=-0.5, agent_horizon=3.0)
+    linear = solve_equilibrium(params, degree=1)
+    quadratic = solve_equilibrium(params, degree=2)
+    sigma_grid = np.linspace(0.08, 0.36, 31)
+    for regime, spec in enumerate(params.regimes):
+        drift_linear, *_ = risk_neutral_state(
+            params, linear, params.agent_horizon, sigma_grid, regime
+        )
+        a1 = linear.coefficients(params.agent_horizon)[regime, 1]
+        expected_linear = (spec.kappa1 + spec.kappa2 * sigma_grid) * (
+            spec.theta - sigma_grid
+        )
+        expected_linear += (
+            -spec.beta * (1.0 - params.gamma) + spec.vartheta2 * a1
+        ) * sigma_grid**2
+        _require(
+            f"quadratic Q drift identity: regime={regime + 1}",
+            float(np.max(np.abs(drift_linear - expected_linear))),
+            2.0e-14,
+        )
+
+        drift_quadratic, *_ = risk_neutral_state(
+            params, quadratic, params.agent_horizon, sigma_grid, regime
+        )
+        v_grid = sigma_grid - spec.theta
+        fitted = np.polynomial.polynomial.polyfit(v_grid, drift_quadratic, 3)
+        a2 = quadratic.coefficients(params.agent_horizon)[regime, 2]
+        expected_cubic = 2.0 * spec.vartheta2 * a2
+        _require(
+            f"full cubic Q-drift coefficient: regime={regime + 1}",
+            float(abs(fitted[3] - expected_cubic)),
+            2.0e-10,
+        )
+
+
+def verify_equilibrium_monte_carlo(full: bool) -> None:
+    params = RegimeSwitchLogSvParams.equity_baseline(agent_horizon=3.0)
+    solutions = {
+        "log-linear": solve_equilibrium(params, degree=1),
+        "log-quadratic": solve_equilibrium(params, degree=2),
+    }
+    n_paths = 120_000 if full else 40_000
+    steps_per_year = 1_440 if full else 720
+    for horizon in (1.0, 3.0):
+        for regime in (GROWTH, STRESS):
+            sigma = params.regimes[regime].theta
+            monte_carlo, standard_error = simulate_equilibrium_feynman_kac(
+                params,
+                horizon,
+                sigma,
+                regime,
+                n_paths=n_paths,
+                steps_per_year=steps_per_year,
+                seed=181 + 17 * regime + int(10 * horizon),
+            )
+            for label, solution in solutions.items():
+                analytic = np.exp(solution.log_g_hat(horizon, sigma, regime))
+                error = abs(analytic - monte_carlo)
+                relative_closure_allowance = 5.0e-3 if label == "log-linear" else 1.5e-3
+                tolerance = 5.0 * standard_error + relative_closure_allowance * monte_carlo
+                _require(
+                    f"P-FK MC ({label}): h={horizon:g}, regime={regime + 1}",
+                    error,
+                    tolerance,
+                )
+
+
+def _empirical_mgf(log_return: np.ndarray, phi: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    means = np.empty(phi.size, dtype=complex)
+    errors = np.empty(phi.size)
+    for index, transform in enumerate(phi):
+        values = np.exp(-transform * log_return)
+        means[index] = np.mean(values)
+        errors[index] = np.sqrt(np.mean(np.abs(values - means[index]) ** 2) / values.size)
+    return means, errors
+
+
+def verify_option_monte_carlo(full: bool) -> None:
+    ttm = 0.25
+    strikes = np.array([0.8, 0.9, 1.0, 1.1, 1.2])
+    optiontypes = np.where(strikes < 1.0, "P", "C")
+    n_paths = 160_000 if full else 50_000
+    steps_per_year = 1_440 if full else 720
+    phi = np.array([-0.5 + 1j * value for value in (0.0, 1.0, 2.0, 5.0, 10.0)])
+
+    for equilibrium_degree, closure_label in ((1, "quadratic Q"), (2, "full cubic Q")):
+        for regime in (GROWTH, STRESS):
+            params = RegimeSwitchLogSvParams.equity_baseline(
+                gamma=-0.5,
+                initial_regime=regime,
+                agent_horizon=3.0,
+            )
+            equilibrium = solve_equilibrium(params, degree=equilibrium_degree)
+            invariant = compute_log_mgf_grid(
+                params, equilibrium, ttm, np.array([0.0, -1.0]), degree=4
+            )
+            _require(
+                f"MGF identities ({closure_label}): regime={regime + 1}",
+                float(np.max(np.abs(invariant))),
+                2.0e-11,
+            )
+            analytic = price_slice(
+                params,
+                equilibrium,
+                ttm,
+                strikes,
+                optiontypes=optiontypes,
+                degree=4,
+                max_phi=1_601,
+            )
+            refined = price_slice(
+                params,
+                equilibrium,
+                ttm,
+                strikes,
+                optiontypes=optiontypes,
+                degree=4,
+                max_phi=3_201,
+            )
+            _require(
+                f"Fourier refinement ({closure_label}): regime={regime + 1}",
+                float(np.max(np.abs(analytic.prices - refined.prices))),
+                5.0e-6,
+            )
+
+            seed = 911 + regime + 100 * equilibrium_degree
+            sample = simulate_terminal_q(
+                params,
+                equilibrium,
+                ttm,
+                n_paths=n_paths,
+                steps_per_year=steps_per_year,
+                seed=seed,
+            )
+            monte_carlo, standard_errors, _ = mc_price_slice(
+                sample, params, ttm, strikes, optiontypes
+            )
+            price_errors = np.abs(analytic.prices - monte_carlo)
+            price_tolerances = 5.0 * standard_errors + 1.5e-4
+            _require(
+                f"Q option MC ({closure_label}): regime={regime + 1}",
+                float(np.max(price_errors / price_tolerances)),
+                1.0,
+            )
+
+            martingale, martingale_error = sample.forward_martingale
+            _require(
+                f"forward martingale ({closure_label}): regime={regime + 1}",
+                abs(martingale - 1.0),
+                5.0 * martingale_error + 5.0e-4,
+            )
+
+            analytic_mgf = np.exp(
+                compute_log_mgf_grid(params, equilibrium, ttm, phi, degree=4)
+            )
+            monte_carlo_mgf, mgf_errors = _empirical_mgf(sample.log_forward_return, phi)
+            normalized = np.abs(analytic_mgf - monte_carlo_mgf) / (
+                5.0 * mgf_errors + 1.0e-3
+            )
+            _require(
+                f"complex MGF MC ({closure_label}): regime={regime + 1}",
+                float(np.max(normalized)),
+                1.0,
+            )
+
+            if regime == GROWTH:
+                coarse_sample = simulate_terminal_q(
+                    params,
+                    equilibrium,
+                    ttm,
+                    n_paths=n_paths,
+                    steps_per_year=max(1, steps_per_year // 2),
+                    seed=seed + 1_000,
+                )
+                coarse_prices, coarse_errors, _ = mc_price_slice(
+                    coarse_sample, params, ttm, strikes, optiontypes
+                )
+                atm = int(np.argmin(np.abs(strikes - 1.0)))
+                refinement_error = abs(coarse_prices[atm] - monte_carlo[atm])
+                refinement_tolerance = (
+                    5.0 * np.hypot(coarse_errors[atm], standard_errors[atm]) + 2.0e-4
+                )
+                _require(
+                    f"Q MC time-step ({closure_label}): growth near-ATM",
+                    float(refinement_error),
+                    float(refinement_tolerance),
+                )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="use report-quality path counts and a finer time grid",
+    )
+    args = parser.parse_args()
+    verify_jump_calibration()
+    verify_scalar_closed_form()
+    verify_frozen_volatility_exact_solution()
+    verify_degree_one_equilibrium_odes()
+    verify_risk_neutral_drift_degrees()
+    verify_equilibrium_monte_carlo(args.full)
+    verify_option_monte_carlo(args.full)
+    print("All regime-switching LogSV verification checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/volatility_book/ch_lognormal_sv_risk_premia/verify_regime_sv_package_adoption.py
+++ b/volatility_book/ch_lognormal_sv_risk_premia/verify_regime_sv_package_adoption.py
@@ -1,0 +1,1243 @@
+"""Verify the package-owned regime-SV chapter pipeline and frozen oracle.
+
+This is the executable adoption gate for the chapter. It deliberately keeps
+the frozen monolith as an oracle while requiring every generated artifact to be
+written below an explicit ignored or temporary output directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import importlib.util
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterable, Mapping
+from pathlib import Path, PurePosixPath
+from types import ModuleType
+from typing import Any
+
+import numpy as np
+
+try:
+    from . import regime_sv_chapter as chapter
+except ImportError:  # pragma: no cover - direct script execution
+    import regime_sv_chapter as chapter
+
+
+GENERATOR_MODULE = "volatility_book.ch_lognormal_sv_risk_premia.generate_regime_sv_figures"
+CHAPTER_RELATIVE = PurePosixPath("volatility_book/ch_lognormal_sv_risk_premia")
+EXPECTED_DEFAULT_OUTPUT = PurePosixPath("outputs") / CHAPTER_RELATIVE
+FROZEN_MONOLITH_SHA256 = "f197e10149cab121d1cdecec2a85b5311143d69dbde00311d4d8b90f1d9b9e5a"
+FROZEN_VERIFIER_SHA256 = "f37d878145f557f5bb37a41991958198fc869f8856e113c744b0bee67540f6b6"
+SOURCE_LEDGER_SHA256 = "13a93e1a7c0d90b1a98d0ff9b4d137e09f13fdcc8a0e7cf123d3a4872b1b2d1e"
+
+FIGURE_STEMS = (
+    "regime_sv_smiles",
+    "regime_sv_premia",
+    "regime_sv_closure_comparison",
+    "regime_sv_validation",
+)
+TABLE_NAMES = (
+    "regime_sv_closure_comparison_table.tex",
+    "regime_sv_validation_table.tex",
+)
+EXPECTED_ARTIFACTS = {
+    "numerical_payload.json",
+    *(f"figures/{stem}.{suffix}" for stem in FIGURE_STEMS for suffix in ("pdf", "png")),
+    *(f"tables/{name}" for name in TABLE_NAMES),
+}
+EXPECTED_RENDERED_ARTIFACTS = EXPECTED_ARTIFACTS - {"numerical_payload.json"}
+EXPECTED_OUTPUT_FILES = EXPECTED_ARTIFACTS | {"artifact_manifest.json"}
+REQUIRED_PAYLOAD_SECTIONS = {
+    "smiles",
+    "premia",
+    "closure",
+    "validation",
+}
+_SHA256_PATTERN = re.compile(r"[0-9a-f]{64}\Z")
+_WINDOWS_ABSOLUTE_PATTERN = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _sha256(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _sha256_lf(path: Path) -> str:
+    content = path.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    return _sha256_bytes(content)
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(
+        path.read_text(encoding="utf-8"),
+        parse_constant=_reject_json_constant,
+    )
+    _require(isinstance(payload, dict), f"{path.name} must contain a JSON object")
+    return payload
+
+
+def _portable_relative_path(value: object, label: str) -> PurePosixPath:
+    _require(isinstance(value, str) and bool(value), f"{label} must be a non-empty string")
+    _require("\\" not in value, f"{label} must use portable '/' separators: {value!r}")
+    _require(
+        not value.startswith(("/", "~")) and not _WINDOWS_ABSOLUTE_PATTERN.match(value),
+        f"{label} must be repository/output relative: {value!r}",
+    )
+    path = PurePosixPath(value)
+    _require(not path.is_absolute(), f"{label} must be relative: {value!r}")
+    _require(
+        all(part not in ("", ".", "..") for part in path.parts),
+        f"{label} cannot traverse directories: {value!r}",
+    )
+    return path
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _assert_portable_json_tree(value: object, *, key: str = "root") -> None:
+    """Reject non-finite numbers and machine-specific paths recursively."""
+
+    if isinstance(value, Mapping):
+        for child_key, child in value.items():
+            _require(isinstance(child_key, str), f"{key} contains a non-string JSON key")
+            _assert_portable_json_tree(child, key=f"{key}.{child_key}")
+        return
+    if isinstance(value, list):
+        for index, child in enumerate(value):
+            _assert_portable_json_tree(child, key=f"{key}[{index}]")
+        return
+    if isinstance(value, bool) or value is None:
+        return
+    if isinstance(value, (int, float)):
+        _require(math.isfinite(float(value)), f"{key} contains a non-finite number")
+        return
+    if isinstance(value, str):
+        is_gitignore_rule = key.rsplit(".", 1)[-1] == "gitignore_rule"
+        _require(
+            (not value.startswith("/") or is_gitignore_rule)
+            and not value.startswith(("file://", "\\\\"))
+            and not _WINDOWS_ABSOLUTE_PATTERN.match(value),
+            f"{key} contains a machine-specific absolute path: {value!r}",
+        )
+        path_key = any(
+            token in key.rsplit(".", 1)[-1].lower()
+            for token in ("path", "file", "directory", "root")
+        )
+        if path_key and ("/" in value or "\\" in value):
+            _portable_relative_path(value, key)
+        return
+    raise AssertionError(f"{key} contains a non-JSON value of type {type(value).__name__}")
+
+
+def _repo_path(relative: object, label: str) -> Path:
+    portable = _portable_relative_path(relative, label)
+    repository = Path(chapter.REPOSITORY_ROOT).resolve()
+    resolved = repository.joinpath(*portable.parts).resolve()
+    _require(_is_relative_to(resolved, repository), f"{label} escapes the repository")
+    return resolved
+
+
+def _manifest_file_records(manifest: Mapping[str, Any]) -> list[dict[str, Any]]:
+    provenance = manifest.get("provenance")
+    _require(isinstance(provenance, dict), "acceptance manifest needs provenance")
+    records = provenance.get("files")
+    _require(isinstance(records, list) and bool(records), "provenance.files must be non-empty")
+    for record in records:
+        _require(isinstance(record, dict), "every provenance.files entry must be an object")
+        _require(
+            {"role", "path", "sha256", "hash_scope"} <= set(record),
+            "every provenance file needs role/path/sha256/hash_scope",
+        )
+    return records
+
+
+def _verify_manifest_file_hashes(manifest: Mapping[str, Any]) -> dict[str, str]:
+    observed: dict[str, str] = {}
+    for index, record in enumerate(_manifest_file_records(manifest)):
+        label = f"provenance.files[{index}]"
+        portable = _portable_relative_path(record["path"], f"{label}.path")
+        path_text = portable.as_posix()
+        _require(path_text not in observed, f"duplicate provenance path: {path_text}")
+        expected = record["sha256"]
+        _require(
+            isinstance(expected, str) and _SHA256_PATTERN.fullmatch(expected),
+            f"{label}.sha256 must be lowercase SHA-256",
+        )
+        source = _repo_path(path_text, f"{label}.path")
+        _require(source.is_file(), f"tracked provenance source is missing: {path_text}")
+        scope = str(record["hash_scope"]).lower()
+        if "expected to differ" in scope or str(record["role"]).startswith("pre_adoption"):
+            observed[path_text] = expected
+            continue
+        actual = _sha256_lf(source) if "lf" in scope else _sha256(source)
+        _require(actual == expected, f"provenance hash mismatch for {path_text}")
+        observed[path_text] = actual
+    return observed
+
+
+def _verify_source_ledger(manifest_hashes: Mapping[str, str]) -> None:
+    script_dir = Path(chapter.ACCEPTANCE_MANIFEST).resolve().parent
+    ledger = script_dir / "source_provenance.json"
+    monolith = script_dir / "regime_switch_logsv.py"
+    verifier = script_dir / "verify_regime_sv_equilibrium.py"
+    expected = {
+        (CHAPTER_RELATIVE / "regime_switch_logsv.py").as_posix(): FROZEN_MONOLITH_SHA256,
+        (CHAPTER_RELATIVE / "verify_regime_sv_equilibrium.py").as_posix(): FROZEN_VERIFIER_SHA256,
+        (CHAPTER_RELATIVE / "source_provenance.json").as_posix(): SOURCE_LEDGER_SHA256,
+    }
+    _require(_sha256(monolith) == FROZEN_MONOLITH_SHA256, "frozen monolith hash changed")
+    _require(_sha256(verifier) == FROZEN_VERIFIER_SHA256, "frozen verifier hash changed")
+    _require(_sha256(ledger) == SOURCE_LEDGER_SHA256, "source ledger hash changed")
+    for relative, digest in expected.items():
+        _require(
+            manifest_hashes.get(relative) == digest,
+            f"acceptance manifest does not pin {relative} to its frozen hash",
+        )
+
+    ledger_payload = _load_json(ledger)
+    _require(ledger_payload.get("schema_version") == 1, "source ledger schema must be v1")
+    records = ledger_payload.get("files")
+    _require(isinstance(records, list), "source ledger files must be a list")
+    by_path = {
+        record.get("path"): record
+        for record in records
+        if isinstance(record, dict) and isinstance(record.get("path"), str)
+    }
+    for relative_name, record in by_path.items():
+        manifest_path = (CHAPTER_RELATIVE / relative_name).as_posix()
+        if manifest_path in manifest_hashes:
+            _require(
+                manifest_hashes[manifest_path] == record.get("sha256_raw"),
+                f"manifest and source ledger disagree for {relative_name}",
+            )
+    for name, digest, source in (
+        ("regime_switch_logsv.py", FROZEN_MONOLITH_SHA256, monolith),
+        ("verify_regime_sv_equilibrium.py", FROZEN_VERIFIER_SHA256, verifier),
+    ):
+        record = by_path.get(name)
+        _require(record is not None, f"source ledger omits {name}")
+        _require(record.get("sha256_raw") == digest, f"source ledger raw hash changed: {name}")
+        _require(record.get("sha256_lf") == digest, f"source ledger LF hash changed: {name}")
+        _require(
+            record.get("bytes") == source.stat().st_size,
+            f"source ledger size changed: {name}",
+        )
+
+
+def _iter_strings(value: object) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, Mapping):
+        for child in value.values():
+            yield from _iter_strings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _iter_strings(child)
+
+
+def _verify_manifest_contract(manifest: Mapping[str, Any]) -> None:
+    required = {
+        "schema_version",
+        "manifest_id",
+        "acceptance_status",
+        "chapter",
+        "provenance",
+        "execution",
+        "output_contract",
+        "numerical_payload_schema",
+        "grids",
+        "seeds",
+        "tolerances",
+        "oracle_contract",
+        "stable_hash_policy",
+        "scope",
+    }
+    _require(required <= set(manifest), "acceptance manifest is missing required sections")
+    _require(manifest["schema_version"] == 1, "acceptance manifest schema must be v1")
+    _require(
+        manifest["chapter"] == CHAPTER_RELATIVE.as_posix(),
+        "acceptance manifest chapter path is wrong",
+    )
+    _assert_portable_json_tree(manifest, key="acceptance_manifest")
+
+    execution = manifest["execution"]
+    _require(isinstance(execution, dict), "execution must be an object")
+    _require(execution.get("module") == GENERATOR_MODULE, "generator module contract changed")
+    execution_strings = set(_iter_strings(execution))
+    for token in ("smoke", "canonical", "--profile", "--output-dir"):
+        _require(token in execution_strings, f"execution contract omits {token!r}")
+
+    output = manifest["output_contract"]
+    _require(isinstance(output, dict), "output_contract must be an object")
+    _require(
+        output.get("default_root") == EXPECTED_DEFAULT_OUTPUT.as_posix(),
+        "manifest default output root is wrong",
+    )
+    _require(output.get("gitignore_rule") == "/outputs/", "manifest must cite /outputs/")
+    _require(
+        output.get("generated_artifacts_are_tracked") is False,
+        "generated chapter artifacts must remain untracked",
+    )
+    profile_directories = output.get("profile_directories")
+    _require(isinstance(profile_directories, dict), "profile_directories must be an object")
+    for profile in ("smoke", "canonical"):
+        expected = (EXPECTED_DEFAULT_OUTPUT / profile).as_posix()
+        _require(
+            profile_directories.get(profile) == expected,
+            f"default {profile} output directory is wrong",
+        )
+    declared_artifacts = set(
+        _iter_strings(output.get("artifacts_relative_to_profile_directory", []))
+    )
+    _require(
+        EXPECTED_OUTPUT_FILES <= declared_artifacts,
+        "manifest output contract omits required figure/table/payload artifacts",
+    )
+
+
+def verify_acceptance_manifest() -> dict[str, Any]:
+    manifest_path = Path(chapter.ACCEPTANCE_MANIFEST).resolve()
+    script_dir = manifest_path.parent
+    repository = Path(chapter.REPOSITORY_ROOT).resolve()
+    _require(manifest_path.name == "acceptance_manifest.json", "acceptance manifest name changed")
+    _require(
+        script_dir == Path(__file__).resolve().parent,
+        "acceptance manifest is not chapter-local",
+    )
+    _require(
+        _is_relative_to(manifest_path, repository),
+        "acceptance manifest is outside repository",
+    )
+    _require(manifest_path.is_file(), "tracked acceptance manifest is missing")
+    manifest = _load_json(manifest_path)
+    _verify_manifest_contract(manifest)
+    hashes = _verify_manifest_file_hashes(manifest)
+    _verify_source_ledger(hashes)
+    return manifest
+
+
+def _load_frozen_module() -> ModuleType:
+    default = Path(chapter.ACCEPTANCE_MANIFEST).resolve().parent / "regime_switch_logsv.py"
+    source = Path(getattr(chapter, "FROZEN_ORACLE", default)).resolve()
+    _require(_sha256(source) == FROZEN_MONOLITH_SHA256, "refusing modified frozen oracle")
+    module_name = "_stochvolmodels_frozen_regime_switch_logsv"
+    spec = importlib.util.spec_from_file_location(module_name, source)
+    _require(spec is not None and spec.loader is not None, "cannot load frozen oracle")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _package_params(frozen_params: Any, closure: Any) -> Any:
+    from stochvolmodels.models.regime_logsv import (
+        CrraRiskPremia,
+        Regime,
+        RegimeLogSvDynamics,
+        RegimeSwitchLogSvParams,
+        RegimeTransition,
+    )
+
+    dynamics = tuple(
+        RegimeLogSvDynamics(
+            theta=spec.theta,
+            kappa1=spec.kappa1,
+            kappa2=spec.kappa2,
+            beta=spec.beta,
+            volvol=spec.volvol,
+        )
+        for spec in frozen_params.regimes
+    )
+    transitions = (
+        RegimeTransition(
+            intensity=frozen_params.transition_intensities[0],
+            mean_log_jump=-frozen_params.jump_means[0],
+        ),
+        RegimeTransition(
+            intensity=frozen_params.transition_intensities[1],
+            mean_log_jump=frozen_params.jump_means[1],
+        ),
+    )
+    return RegimeSwitchLogSvParams(
+        sigma0=frozen_params.sigma0,
+        regimes=dynamics,
+        transitions=transitions,
+        risk_premia=CrraRiskPremia(
+            utility_power=frozen_params.gamma,
+            agent_horizon=frozen_params.agent_horizon,
+            closure=closure,
+        ),
+        initial_regime=Regime.GROWTH,
+    )
+
+
+def _assert_close(label: str, actual: object, expected: object, tolerance: float) -> None:
+    actual_array = np.asarray(actual)
+    expected_array = np.asarray(expected)
+    _require(actual_array.shape == expected_array.shape, f"{label}: shape mismatch")
+    error = float(np.max(np.abs(actual_array - expected_array))) if actual_array.size else 0.0
+    _require(error <= tolerance, f"{label}: max error {error:.6g} exceeds {tolerance:.6g}")
+
+
+def verify_package_frozen_oracle() -> None:
+    """Cross-check both closures and source states through independent APIs."""
+
+    frozen = _load_frozen_module()
+    from stochvolmodels.models.regime_logsv import (
+        EquilibriumClosure,
+        Regime,
+        solve_regime_switch_equilibrium,
+    )
+    from stochvolmodels.models.regime_logsv_simulation import (
+        simulate_regime_switch_logsv_terminal,
+    )
+    from stochvolmodels.pricers.logsv.affine_expansion import ExpansionOrder
+    from stochvolmodels.pricers.regime_switch_logsv_pricer import (
+        compute_regime_switch_log_mgf_grid,
+        regime_switch_logsv_chain_pricer,
+    )
+
+    ttm = 0.25
+    horizons = (0.0, 0.25, 1.0, 3.0)
+    phi_grid = np.array([0.0, -1.0, -0.5 + 0.75j, -0.5 + 2.0j])
+    strikes = np.array([0.90, 1.00, 1.10])
+    optiontypes = np.array(["P", "C", "C"])
+    path_count = 512
+    steps_per_year = 96
+
+    closure_specs = (
+        ("log-linear", EquilibriumClosure.LOG_LINEAR, 1),
+        ("log-quadratic", EquilibriumClosure.LOG_QUADRATIC, 2),
+    )
+    for closure_label, package_closure, frozen_degree in closure_specs:
+        frozen_growth = frozen.RegimeSwitchLogSvParams.equity_baseline(
+            gamma=-0.5,
+            initial_regime=frozen.GROWTH,
+            agent_horizon=3.0,
+        )
+        package_params = _package_params(frozen_growth, package_closure)
+        package_equilibrium = solve_regime_switch_equilibrium(package_params)
+        package_mgf = compute_regime_switch_log_mgf_grid(
+            package_params,
+            ttm,
+            phi_grid,
+            equilibrium=package_equilibrium,
+            expansion_order=ExpansionOrder.SECOND,
+            rtol=2.0e-9,
+            atol=2.0e-11,
+        )
+        package_prices = regime_switch_logsv_chain_pricer(
+            package_params,
+            ttms=np.array([ttm]),
+            forwards=np.array([1.0]),
+            discfactors=np.array([1.0]),
+            strikes_ttms=(strikes,),
+            optiontypes_ttms=(optiontypes,),
+            equilibrium=package_equilibrium,
+            expansion_order=ExpansionOrder.SECOND,
+            max_phi=401,
+        )
+
+        for state in (Regime.GROWTH, Regime.STRESS):
+            frozen_params = frozen.RegimeSwitchLogSvParams.equity_baseline(
+                gamma=-0.5,
+                initial_regime=int(state),
+                agent_horizon=3.0,
+            )
+            frozen_equilibrium = frozen.solve_equilibrium(
+                frozen_params,
+                degree=frozen_degree,
+            )
+            for horizon in horizons:
+                _assert_close(
+                    f"{closure_label}/state={int(state)} coefficients at H={horizon:g}",
+                    package_equilibrium.coefficients(horizon),
+                    frozen_equilibrium.coefficients(horizon),
+                    3.0e-12,
+                )
+
+            frozen_mgf = frozen.compute_log_mgf_grid(
+                frozen_params,
+                frozen_equilibrium,
+                ttm,
+                phi_grid,
+                degree=4,
+                rtol=2.0e-9,
+                atol=2.0e-11,
+            )
+            _assert_close(
+                f"{closure_label}/state={int(state)} MGF",
+                package_mgf[state],
+                frozen_mgf,
+                8.0e-11,
+            )
+
+            frozen_prices = frozen.price_slice(
+                frozen_params,
+                frozen_equilibrium,
+                ttm,
+                strikes,
+                optiontypes=optiontypes,
+                degree=4,
+                max_phi=401,
+            ).prices
+            _assert_close(
+                f"{closure_label}/state={int(state)} prices",
+                package_prices[state][0],
+                frozen_prices,
+                2.0e-10,
+            )
+
+            seed = 1_901 + 100 * frozen_degree + int(state)
+            package_sample = simulate_regime_switch_logsv_terminal(
+                package_params,
+                ttm,
+                equilibrium=package_equilibrium,
+                initial_regime=state,
+                nb_path=path_count,
+                nb_steps_per_year=steps_per_year,
+                seed=seed,
+            )
+            frozen_sample = frozen.simulate_terminal_q(
+                frozen_params,
+                frozen_equilibrium,
+                ttm,
+                n_paths=path_count,
+                steps_per_year=steps_per_year,
+                seed=seed,
+            )
+            np.testing.assert_allclose(
+                package_sample.log_forward_return,
+                frozen_sample.log_forward_return,
+                rtol=0.0,
+                atol=5.0e-15,
+                err_msg=f"{closure_label}/state={int(state)} terminal return replay",
+            )
+            np.testing.assert_allclose(
+                package_sample.sigma,
+                frozen_sample.sigma,
+                rtol=0.0,
+                atol=5.0e-15,
+                err_msg=f"{closure_label}/state={int(state)} terminal sigma replay",
+            )
+            np.testing.assert_array_equal(
+                package_sample.regime,
+                frozen_sample.regime,
+                err_msg=f"{closure_label}/state={int(state)} terminal regime replay",
+            )
+
+
+def verify_frozen_oracle_boundary() -> None:
+    """Prove the adopted generator cannot use the monolith for production analytics."""
+
+    script_dir = Path(chapter.ACCEPTANCE_MANIFEST).resolve().parent
+    generator_text = (script_dir / "generate_regime_sv_figures.py").read_text(encoding="utf-8")
+    _require(
+        "regime_switch_logsv" not in generator_text and "FROZEN_ORACLE" not in generator_text,
+        "adopted generator must not import or name the frozen monolith",
+    )
+
+    chapter_tree = ast.parse(
+        (script_dir / "regime_sv_chapter.py").read_text(encoding="utf-8"),
+        filename="regime_sv_chapter.py",
+    )
+    callers: list[str] = []
+
+    class FrozenLoaderVisitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.function_stack: list[str] = []
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+            self.function_stack.append(node.name)
+            self.generic_visit(node)
+            self.function_stack.pop()
+
+        def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+            if (
+                isinstance(node.func, ast.Name)
+                and node.func.id == "_load_frozen_physical_fk_oracle"
+            ):
+                callers.append(self.function_stack[-1] if self.function_stack else "<module>")
+            self.generic_visit(node)
+
+    FrozenLoaderVisitor().visit(chapter_tree)
+    _require(
+        callers == ["_physical_fk_values"],
+        f"frozen oracle loader escaped the physical-FK boundary: {callers}",
+    )
+
+
+def verify_frozen_channel_hash_anchors(acceptance_manifest: Mapping[str, Any]) -> None:
+    """Recompute the manifest's exact channel hashes with the frozen oracle only."""
+
+    frozen = _load_frozen_module()
+    oracle = acceptance_manifest["oracle_contract"]["panel_c"]
+    scenarios = oracle["scenarios"]
+    log_moneyness = np.linspace(-0.30, 0.20, oracle["vector_count"])
+    strikes = np.exp(log_moneyness)
+    optiontypes = np.where(strikes < 1.0, "P", "C")
+    selected = np.asarray(oracle["selected_indices"], dtype=int)
+    phi_grid = np.array([0.0, -1.0, -0.5 + 2.0j])
+    states: dict[int, tuple[Any, Any]] = {}
+    for state in (frozen.GROWTH, frozen.STRESS):
+        params = frozen.RegimeSwitchLogSvParams.equity_baseline(
+            gamma=-0.5,
+            initial_regime=state,
+            agent_horizon=3.0,
+        )
+        states[state] = (params, frozen.solve_equilibrium(params, degree=1))
+
+    ivol_tolerance = acceptance_manifest["tolerances"]["channel_selected_ivol_percent"]
+    mgf_tolerance = acceptance_manifest["tolerances"]["channel_complex_log_mgf"]
+    for scenario_name, expected in scenarios.items():
+        scales = frozen.RiskPremiaScales(*expected["scales"])
+        growth_params, growth_equilibrium = states[frozen.GROWTH]
+        analytic = frozen.price_slice(
+            growth_params,
+            growth_equilibrium,
+            0.25,
+            strikes,
+            optiontypes=optiontypes,
+            scales=scales,
+            degree=4,
+            max_phi=1_601,
+        )
+        np.testing.assert_allclose(
+            100.0 * analytic.implied_vols[selected],
+            expected["selected_ivols_percent"],
+            rtol=ivol_tolerance["relative"],
+            atol=ivol_tolerance["absolute"],
+        )
+        _require(
+            _decimal15_hash(analytic.implied_vols) == expected["ivols_decimal15_json_sha256"],
+            f"frozen channel IV decimal15 hash changed: {scenario_name}",
+        )
+        _require(
+            _decimal15_hash(analytic.prices) == expected["prices_decimal15_json_sha256"],
+            f"frozen channel price decimal15 hash changed: {scenario_name}",
+        )
+        for hash_name in ("ivols_raw_le_f8_sha256", "prices_raw_le_f8_sha256"):
+            _require(
+                isinstance(expected.get(hash_name), str)
+                and _SHA256_PATTERN.fullmatch(expected[hash_name]),
+                f"frozen raw-hash provenance is malformed: {scenario_name}.{hash_name}",
+            )
+
+        observed_mgf = np.empty((2, 3), dtype=complex)
+        for state, (params, equilibrium) in states.items():
+            observed_mgf[state] = frozen.compute_log_mgf_grid(
+                params,
+                equilibrium,
+                0.25,
+                phi_grid,
+                scales=scales,
+                degree=4,
+            )
+        np.testing.assert_allclose(
+            observed_mgf[:, :2],
+            0.0,
+            rtol=0.0,
+            atol=oracle["transform_roots"]["absolute_tolerance"],
+        )
+        observed_probe = np.stack((observed_mgf[:, 2].real, observed_mgf[:, 2].imag), axis=1)
+        np.testing.assert_allclose(
+            observed_probe,
+            expected["complex_log_mgf"],
+            rtol=mgf_tolerance["relative"],
+            atol=mgf_tolerance["absolute"],
+        )
+
+
+def _numerical_block_count(value: object, *, location: str) -> int:
+    if isinstance(value, Mapping):
+        if "values" in value:
+            _require(
+                {"axes", "shape", "values"} <= set(value),
+                f"numerical block {location} needs axes/shape/values",
+            )
+            shape = value["shape"]
+            _require(
+                isinstance(shape, list)
+                and all(
+                    isinstance(item, int) and not isinstance(item, bool) and item >= 0
+                    for item in shape
+                ),
+                f"numerical block {location} has an invalid shape",
+            )
+            try:
+                values = np.asarray(value["values"], dtype=float)
+            except (TypeError, ValueError) as error:
+                raise AssertionError(
+                    f"numerical block {location} values are not numeric"
+                ) from error
+            count = int(np.prod(shape, dtype=np.int64)) if shape else 1
+            _require(
+                values.ndim == 1 and values.size == count,
+                f"numerical block {location} shape is wrong",
+            )
+            _require(np.all(np.isfinite(values)), f"numerical block {location} is non-finite")
+            axes = value["axes"]
+            _require(
+                isinstance(axes, list) and len(axes) == len(shape),
+                f"numerical block {location} axes are wrong",
+            )
+            for dimension, axis in enumerate(axes):
+                _require(
+                    isinstance(axis, dict) and set(axis) == {"name", "values"},
+                    f"numerical block {location} has an invalid axis",
+                )
+                _require(
+                    isinstance(axis["values"], list) and len(axis["values"]) == shape[dimension],
+                    f"numerical block {location} axis length is wrong",
+                )
+            return 1
+        return sum(
+            _numerical_block_count(child, location=f"{location}.{key}")
+            for key, child in value.items()
+        )
+    if isinstance(value, list):
+        return sum(
+            _numerical_block_count(child, location=f"{location}[{index}]")
+            for index, child in enumerate(value)
+        )
+    return 0
+
+
+def _record_array(record: Mapping[str, Any]) -> np.ndarray:
+    return np.asarray(record["values"], dtype=float).reshape(record["shape"])
+
+
+def _record_axis(record: Mapping[str, Any], name: str) -> list[Any]:
+    for axis in record["axes"]:
+        if axis["name"] == name:
+            return list(axis["values"])
+    raise AssertionError(f"payload record omits axis {name!r}")
+
+
+def _decimal15_hash(values: np.ndarray) -> str:
+    encoded = json.dumps(
+        [format(float(value), ".15e") for value in np.ravel(values)],
+        separators=(",", ":"),
+    ).encode("ascii")
+    return _sha256_bytes(encoded)
+
+
+def _verify_channel_payload(
+    payload: Mapping[str, Any],
+    acceptance_manifest: Mapping[str, Any],
+) -> None:
+    records = payload["records"]
+    ivol_record = records.get("smiles.channel_implied_volatility")
+    price_record = records.get("smiles.channel_prices")
+    mgf_record = records.get("smiles.channel_log_mgf")
+    _require(
+        all(isinstance(record, dict) for record in (ivol_record, price_record, mgf_record)),
+        "payload omits channel IV, price, or MGF records",
+    )
+    ivols = _record_array(ivol_record)
+    prices = _record_array(price_record)
+    log_mgf = _record_array(mgf_record)
+    scenario_names = _record_axis(ivol_record, "scenario")
+    _require(
+        scenario_names
+        == _record_axis(price_record, "scenario")
+        == _record_axis(mgf_record, "scenario"),
+        "channel scenario axes disagree",
+    )
+    _require(
+        _record_axis(ivol_record, "regime") == ["growth", "stress"],
+        "channel regime axis changed",
+    )
+    oracle = acceptance_manifest["oracle_contract"]["panel_c"]
+    scenarios = oracle["scenarios"]
+    _require(scenario_names == list(scenarios), "payload channel order differs from oracle")
+    selected = np.asarray(oracle["selected_indices"], dtype=int)
+    log_moneyness = np.asarray(_record_axis(ivol_record, "log_moneyness"), dtype=float)
+    np.testing.assert_allclose(
+        log_moneyness[selected],
+        oracle["selected_log_moneyness"],
+        rtol=0.0,
+        atol=2.0e-15,
+    )
+    _require(ivols.shape == prices.shape, "channel IV and price shapes differ")
+    _require(ivols.shape == (len(scenario_names), 2, oracle["vector_count"]), "bad channel shape")
+
+    ivol_tolerance = acceptance_manifest["tolerances"]["channel_selected_ivol_percent"]
+    mgf_tolerance = acceptance_manifest["tolerances"]["channel_complex_log_mgf"]
+    for scenario_index, scenario_name in enumerate(scenario_names):
+        expected = scenarios[scenario_name]
+        growth_ivols = ivols[scenario_index, 0]
+        np.testing.assert_allclose(
+            100.0 * growth_ivols[selected],
+            expected["selected_ivols_percent"],
+            rtol=ivol_tolerance["relative"],
+            atol=ivol_tolerance["absolute"],
+        )
+        for hash_name in (
+            "ivols_decimal15_json_sha256",
+            "prices_decimal15_json_sha256",
+            "ivols_raw_le_f8_sha256",
+            "prices_raw_le_f8_sha256",
+        ):
+            _require(
+                isinstance(expected.get(hash_name), str)
+                and _SHA256_PATTERN.fullmatch(expected[hash_name]),
+                f"frozen channel hash is malformed: {scenario_name}.{hash_name}",
+            )
+
+        observed_probe = log_mgf[scenario_index, :, 2, :]
+        np.testing.assert_allclose(
+            observed_probe,
+            expected["complex_log_mgf"],
+            rtol=mgf_tolerance["relative"],
+            atol=mgf_tolerance["absolute"],
+        )
+
+    roots = log_mgf[:, :, :2, 0] + 1j * log_mgf[:, :, :2, 1]
+    root_contract = oracle["transform_roots"]
+    np.testing.assert_allclose(
+        roots,
+        0.0,
+        rtol=0.0,
+        atol=root_contract["absolute_tolerance"],
+    )
+    _require(
+        _record_axis(mgf_record, "phi") == ["0", "-1", "-0.5+2j"],
+        "channel transform probe axis changed",
+    )
+
+    provenance = payload.get("provenance")
+    _require(isinstance(provenance, dict), "payload provenance is missing")
+    frozen_usage = provenance.get("frozen_physical_feynman_kac_oracle")
+    _require(
+        isinstance(frozen_usage, dict)
+        and frozen_usage.get("usage") == "physical_feynman_kac_validation_only"
+        and frozen_usage.get("sha256") == FROZEN_MONOLITH_SHA256,
+        "payload does not restrict the frozen oracle to physical FK",
+    )
+    acceptance = provenance.get("acceptance_manifest")
+    _require(
+        isinstance(acceptance, dict)
+        and acceptance.get("sha256") == _sha256(Path(chapter.ACCEPTANCE_MANIFEST)),
+        "payload acceptance-manifest hash is wrong",
+    )
+    _require(
+        provenance.get("production_analytics") == "stochvolmodels package APIs",
+        "payload production analytics are not package-owned",
+    )
+
+
+def _axis_position(record: Mapping[str, Any], name: str) -> int:
+    for index, axis in enumerate(record["axes"]):
+        if axis["name"] == name:
+            return index
+    raise AssertionError(f"payload record omits axis {name!r}")
+
+
+def _verify_numerical_acceptance(
+    payload: Mapping[str, Any],
+    acceptance_manifest: Mapping[str, Any],
+) -> None:
+    records = payload["records"]
+    refinement_record = records.get("validation.fourier_refinement_prices")
+    _require(isinstance(refinement_record, dict), "payload omits Fourier refinement prices")
+    refinement = _record_array(refinement_record)
+    closure_axis = _axis_position(refinement_record, "closure")
+    point_axis = _axis_position(refinement_record, "fourier_points")
+    _require(
+        len(_record_axis(refinement_record, "closure")) == 2,
+        "Fourier refinement must cover both closures",
+    )
+    coarse = np.take(refinement, 0, axis=point_axis)
+    refined = np.take(refinement, 1, axis=point_axis)
+    adjusted_closure_axis = closure_axis - int(point_axis < closure_axis)
+    _require(
+        coarse.shape[adjusted_closure_axis] == 2,
+        "Fourier refinement lost a closure after slicing",
+    )
+    refinement_tolerance = acceptance_manifest["tolerances"]["fourier_refinement_price_absolute"]
+    _require(
+        float(np.max(np.abs(coarse - refined))) <= refinement_tolerance,
+        "both-closure Fourier refinement exceeds the acceptance tolerance",
+    )
+
+    analytic = _record_array(records["validation.analytic_prices"])
+    monte_carlo = _record_array(records["validation.mc_prices"])
+    standard_error = _record_array(records["validation.mc_standard_errors"])
+    _require(
+        analytic.shape == monte_carlo.shape == standard_error.shape,
+        "Q analytic/Monte Carlo price records are not aligned",
+    )
+    _require(
+        np.all(np.abs(analytic - monte_carlo) <= 5.0 * standard_error + 1.5e-4),
+        "Q price-versus-Monte-Carlo confidence bound failed",
+    )
+
+    martingale_record = records["validation.forward_martingale"]
+    martingale = _record_array(martingale_record)
+    metric_axis = _axis_position(martingale_record, "metric")
+    metrics = _record_axis(martingale_record, "metric")
+    estimate_index = metrics.index("estimate")
+    error_index = metrics.index("standard_error")
+    estimates = np.take(martingale, estimate_index, axis=metric_axis)
+    errors = np.take(martingale, error_index, axis=metric_axis)
+    _require(
+        np.all(np.abs(estimates - 1.0) <= 5.0 * errors + 5.0e-4),
+        "Q forward martingale confidence bound failed",
+    )
+
+    coefficient_record = records["validation.equilibrium_coefficients"]
+    coefficients = _record_array(coefficient_record)
+    coefficient_horizons = np.asarray(
+        _record_axis(coefficient_record, "horizon_years"), dtype=float
+    )
+    fk_record = records["validation.physical_feynman_kac"]
+    physical_fk = _record_array(fk_record)
+    fk_horizons = np.asarray(_record_axis(fk_record, "horizon_years"), dtype=float)
+    fk_metrics = _record_axis(fk_record, "metric")
+    fk_metric_axis = _axis_position(fk_record, "metric")
+    fk_estimates = np.take(physical_fk, fk_metrics.index("estimate"), axis=fk_metric_axis)
+    fk_errors = np.take(physical_fk, fk_metrics.index("standard_error"), axis=fk_metric_axis)
+    closure_names = _record_axis(coefficient_record, "closure")
+    _require(closure_names == ["log_linear", "log_quadratic"], "FK closure axis changed")
+    relative_allowance = {"log_linear": 5.0e-3, "log_quadratic": 1.5e-3}
+    for horizon_index, horizon in enumerate(fk_horizons):
+        matches = np.flatnonzero(np.isclose(coefficient_horizons, horizon, rtol=0.0, atol=1.0e-15))
+        _require(matches.size == 1, f"equilibrium coefficients omit FK horizon {horizon:g}")
+        coefficient_values = coefficients[:, :, int(matches[0])]
+        for closure_index, closure_name in enumerate(closure_names):
+            tolerance = 5.0 * fk_errors + relative_allowance[closure_name] * np.abs(fk_estimates)
+            _require(
+                np.all(
+                    np.abs(coefficient_values[closure_index] - fk_estimates[:, horizon_index])
+                    <= tolerance[:, horizon_index]
+                ),
+                f"physical FK acceptance failed for {closure_name} at H={horizon:g}",
+            )
+
+
+def _validate_payload(
+    path: Path,
+    profile: str,
+    acceptance_manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    payload = _load_json(path)
+    chapter.validate_numerical_payload(payload)
+    _assert_portable_json_tree(payload, key="numerical_payload")
+    _require(payload.get("schema_version") == 1, "numerical payload schema must be v1")
+    _require(payload.get("profile") == profile, "numerical payload profile is wrong")
+    records = payload.get("records")
+    _require(isinstance(records, dict), "numerical payload records must be an object")
+    sections = {str(name).split(".", 1)[0] for name in records}
+    _require(
+        REQUIRED_PAYLOAD_SECTIONS <= sections,
+        "numerical payload omits a required chapter section",
+    )
+    for name, record in records.items():
+        count = _numerical_block_count(record, location=f"records.{name}")
+        _require(count > 0, f"payload record {name!r} has no numerical block")
+    _verify_channel_payload(payload, acceptance_manifest)
+    _verify_numerical_acceptance(payload, acceptance_manifest)
+    return payload
+
+
+def _validate_artifact_manifest(
+    output_dir: Path,
+    *,
+    profile: str,
+    expected_mode: str,
+) -> dict[str, Any]:
+    manifest_path = output_dir / "artifact_manifest.json"
+    manifest = _load_json(manifest_path)
+    _assert_portable_json_tree(manifest, key="artifact_manifest")
+    _require(manifest.get("schema_version") == 1, "artifact manifest schema must be v1")
+    _require(manifest.get("profile") == profile, "artifact manifest profile is wrong")
+    _require(manifest.get("mode") == expected_mode, "artifact manifest mode is wrong")
+    payload_digest = _sha256(output_dir / "numerical_payload.json")
+    payload_record = manifest.get("payload")
+    _require(
+        isinstance(payload_record, dict)
+        and payload_record.get("path") == "numerical_payload.json"
+        and payload_record.get("sha256") == payload_digest,
+        "artifact manifest payload hash is wrong",
+    )
+    records = manifest.get("artifacts")
+    _require(isinstance(records, list), "artifact manifest artifacts must be a list")
+    by_path: dict[str, str] = {}
+    for index, record in enumerate(records):
+        _require(isinstance(record, dict), f"artifacts[{index}] must be an object")
+        _require({"path", "sha256"} <= set(record), f"artifacts[{index}] lacks path/hash")
+        relative = _portable_relative_path(record["path"], f"artifacts[{index}].path").as_posix()
+        digest = record["sha256"]
+        _require(
+            isinstance(digest, str) and _SHA256_PATTERN.fullmatch(digest),
+            f"artifacts[{index}].sha256 is invalid",
+        )
+        _require(relative not in by_path, f"duplicate artifact record: {relative}")
+        artifact = (output_dir / Path(*PurePosixPath(relative).parts)).resolve()
+        _require(_is_relative_to(artifact, output_dir), f"artifact escapes output: {relative}")
+        _require(artifact.is_file(), f"declared artifact is missing: {relative}")
+        _require(not artifact.is_symlink(), f"artifact cannot be a symlink: {relative}")
+        _require(_sha256(artifact) == digest, f"artifact hash mismatch: {relative}")
+        by_path[relative] = digest
+    _require(
+        set(by_path) in (EXPECTED_RENDERED_ARTIFACTS, EXPECTED_ARTIFACTS),
+        "artifact manifest file set is incomplete",
+    )
+    return manifest
+
+
+def _validate_output_tree(
+    output_dir: Path,
+    *,
+    profile: str,
+    mode: str,
+    acceptance_manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    _require(output_dir.is_dir(), f"generator did not create {output_dir}")
+    actual_files: set[str] = set()
+    for artifact in output_dir.rglob("*"):
+        if artifact.is_dir():
+            continue
+        _require(not artifact.is_symlink(), f"output cannot contain symlink: {artifact}")
+        resolved = artifact.resolve()
+        _require(_is_relative_to(resolved, output_dir), f"output escaped directory: {artifact}")
+        actual_files.add(artifact.relative_to(output_dir).as_posix())
+    _require(actual_files == EXPECTED_OUTPUT_FILES, "generator output file set is wrong")
+
+    for stem in FIGURE_STEMS:
+        pdf = output_dir / "figures" / f"{stem}.pdf"
+        png = output_dir / "figures" / f"{stem}.png"
+        _require(
+            pdf.stat().st_size > 100 and pdf.read_bytes()[:4] == b"%PDF",
+            f"bad PDF: {pdf}",
+        )
+        _require(
+            png.stat().st_size > 100 and png.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n",
+            f"bad PNG: {png}",
+        )
+    for name in TABLE_NAMES:
+        table = output_dir / "tables" / name
+        text = table.read_text(encoding="utf-8")
+        _require(bool(text.strip()), f"empty TeX table: {name}")
+        _require(
+            not _WINDOWS_ABSOLUTE_PATTERN.search(text) and "file://" not in text,
+            f"non-portable path in TeX table: {name}",
+        )
+    _validate_payload(
+        output_dir / "numerical_payload.json",
+        profile,
+        acceptance_manifest,
+    )
+    return _validate_artifact_manifest(output_dir, profile=profile, expected_mode=mode)
+
+
+def _tree_fingerprint(root: Path) -> tuple[tuple[str, int, int, str], ...]:
+    if not root.exists():
+        return ()
+    return tuple(
+        sorted(
+            (
+                path.relative_to(root).as_posix(),
+                path.stat().st_size,
+                path.stat().st_mtime_ns,
+                _sha256(path),
+            )
+            for path in root.rglob("*")
+            if path.is_file()
+        )
+    )
+
+
+def _validate_output_root(output_root: Path) -> Path:
+    repository = Path(chapter.REPOSITORY_ROOT).resolve()
+    expected_default = repository.joinpath(*EXPECTED_DEFAULT_OUTPUT.parts).resolve()
+    notes = Path(chapter.ACCEPTANCE_MANIFEST).resolve().parent / "notes"
+    resolved = output_root.expanduser().resolve()
+    _require(resolved != repository, "output root cannot be the repository root")
+    _require(not _is_relative_to(repository, resolved), "output root cannot contain repository")
+    _require(not _is_relative_to(resolved, notes.resolve()), "output root cannot be under notes")
+    if _is_relative_to(resolved, repository):
+        _require(
+            _is_relative_to(resolved, expected_default),
+            "repository-local output must stay under the ignored chapter output root",
+        )
+    if resolved.exists():
+        _require(resolved.is_dir() and not resolved.is_symlink(), "output root must be a directory")
+        _require(not any(resolved.iterdir()), "output root must be empty to avoid overwriting data")
+    else:
+        resolved.mkdir(parents=True)
+    return resolved
+
+
+def _generator_environment(*, forbid_recompute: bool) -> dict[str, str]:
+    environment = os.environ.copy()
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    repository = Path(chapter.REPOSITORY_ROOT).resolve()
+    entries = [str(repository), str(repository / "src")]
+    existing = environment.get("PYTHONPATH")
+    if existing:
+        entries.append(existing)
+    environment["PYTHONPATH"] = os.pathsep.join(entries)
+    if forbid_recompute:
+        environment["STOCHVOLMODELS_REGIME_SV_FORBID_RECOMPUTE"] = "1"
+    else:
+        environment.pop("STOCHVOLMODELS_REGIME_SV_FORBID_RECOMPUTE", None)
+    return environment
+
+
+def _run_generator(arguments: list[str], *, forbid_recompute: bool) -> None:
+    command = [sys.executable, "-m", GENERATOR_MODULE, *arguments]
+    result = subprocess.run(
+        command,
+        cwd=Path(chapter.REPOSITORY_ROOT),
+        env=_generator_environment(forbid_recompute=forbid_recompute),
+        capture_output=True,
+        text=True,
+        timeout=600,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = "\n".join(part for part in (result.stdout, result.stderr) if part.strip())
+        raise AssertionError(f"generator command failed ({result.returncode}):\n{detail}")
+
+
+def verify_generator_roundtrip(
+    profile: str,
+    output_root: Path,
+    acceptance_manifest: Mapping[str, Any],
+) -> None:
+    """Compute once, then prove payload-only rendering cannot recompute."""
+
+    root = _validate_output_root(output_root)
+    computed = root / "computed"
+    rerendered = root / "rerendered"
+    notes = Path(chapter.ACCEPTANCE_MANIFEST).resolve().parent / "notes"
+    notes_before = _tree_fingerprint(notes)
+
+    _run_generator(
+        ["--profile", profile, "--output-dir", str(computed)],
+        forbid_recompute=False,
+    )
+    computed_manifest = _validate_output_tree(
+        computed,
+        profile=profile,
+        mode="computed",
+        acceptance_manifest=acceptance_manifest,
+    )
+
+    source_payload = computed / "numerical_payload.json"
+    _run_generator(
+        [
+            "--profile",
+            profile,
+            "--payload",
+            str(source_payload),
+            "--output-dir",
+            str(rerendered),
+        ],
+        forbid_recompute=True,
+    )
+    rerendered_manifest = _validate_output_tree(
+        rerendered,
+        profile=profile,
+        mode="rerendered",
+        acceptance_manifest=acceptance_manifest,
+    )
+
+    _require(
+        _sha256(source_payload) == _sha256(rerendered / "numerical_payload.json"),
+        "payload-only rerender changed the numerical payload hash",
+    )
+    _require(
+        computed_manifest["payload"]["sha256"] == rerendered_manifest["payload"]["sha256"],
+        "payload hash provenance differs after rerender",
+    )
+    for name in TABLE_NAMES:
+        _require(
+            _sha256(computed / "tables" / name) == _sha256(rerendered / "tables" / name),
+            f"payload-only rerender changed numerical table {name}",
+        )
+    _require(_tree_fingerprint(notes) == notes_before, "generator wrote under tracked notes/")
+
+
+def verify_output_policy(manifest: Mapping[str, Any]) -> None:
+    repository = Path(chapter.REPOSITORY_ROOT).resolve()
+    expected = repository.joinpath(*EXPECTED_DEFAULT_OUTPUT.parts).resolve()
+    _require(
+        Path(chapter.DEFAULT_OUTPUT_ROOT).resolve() == expected,
+        "chapter default output root must be outputs/volatility_book/<chapter>",
+    )
+    gitignore = (repository / ".gitignore").read_text(encoding="utf-8").splitlines()
+    _require("/outputs/" in (line.strip() for line in gitignore), "/outputs/ is not gitignored")
+    output = manifest["output_contract"]
+    _require(output["default_root"] == EXPECTED_DEFAULT_OUTPUT.as_posix(), "path policy drift")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile",
+        choices=("smoke",),
+        default="smoke",
+        help="bounded adoption profile (only smoke is accepted by this verifier)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help=(
+            "empty temporary directory or path below the ignored chapter output root; "
+            "default creates a unique ignored directory"
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _default_verifier_output() -> Path:
+    default_root = Path(chapter.DEFAULT_OUTPUT_ROOT).resolve()
+    default_root.mkdir(parents=True, exist_ok=True)
+    return Path(tempfile.mkdtemp(prefix="adoption-smoke-", dir=default_root))
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the complete portable package-adoption contract."""
+
+    args = _parse_args(argv)
+    manifest = verify_acceptance_manifest()
+    verify_output_policy(manifest)
+    verify_package_frozen_oracle()
+    verify_frozen_channel_hash_anchors(manifest)
+    verify_frozen_oracle_boundary()
+    output_dir = args.output_dir if args.output_dir is not None else _default_verifier_output()
+    verify_generator_roundtrip(args.profile, output_dir, manifest)
+    print("PASS regime-SV package adoption: manifest, oracle, outputs, and rerender")
+
+
+if __name__ == "__main__":
+    main()

--- a/volatility_book/ch_tdist_risk_premia/acceptance_manifest.json
+++ b/volatility_book/ch_tdist_risk_premia/acceptance_manifest.json
@@ -1,0 +1,166 @@
+{
+  "schema_version": 1,
+  "manifest_id": "stochvolmodels.tdist_risk_premia_chapter.acceptance",
+  "acceptance_status": "T3T_ADOPTION_CONTRACT",
+  "chapter": "volatility_book/ch_tdist_risk_premia",
+  "provenance": {
+    "hash_algorithm": "sha256",
+    "commits": {
+      "frozen_chapter_snapshot": "3d5d848340cd14a37a596269dd99e7014cc76fd7",
+      "package_terminal_law_baseline": "e616e3844d7532a992c69b219b5a59e678e140ce"
+    },
+    "files": [
+      {
+        "role": "verification_only_frozen_oracle",
+        "path": "volatility_book/ch_tdist_risk_premia/risk_premium_smile_examples.py",
+        "sha256": "4e6f4a6700c3d63ed4981be962ce3fa73a09475607ea7aaeb5457cbb2f3b6533",
+        "hash_scope": "raw bytes at frozen_chapter_snapshot"
+      },
+      {
+        "role": "source_provenance_ledger",
+        "path": "volatility_book/ch_tdist_risk_premia/source_provenance.json",
+        "sha256": "22bd1a21b3b3852f11577b5a8596ab3393cca4b2f3e11e22404a55ac606521a5",
+        "hash_scope": "raw tracked bytes at package_terminal_law_baseline"
+      },
+      {
+        "role": "pre_adoption_note",
+        "path": "volatility_book/ch_tdist_risk_premia/notes/tdist_risk_premia_note.tex",
+        "sha256": "49d2cd1182727675e79facbaca5e4bba8721e3af4a2177e264a72305079e169a",
+        "hash_scope": "raw bytes at frozen_chapter_snapshot; adopted note is expected to differ"
+      }
+    ]
+  },
+  "ownership": {
+    "production_terminal_law": "stochvolmodels.models.inverse_gamma_normal.InverseGammaNormalTerminalModel",
+    "symmetric_reference": "stochvolmodels.pricers.tdist_pricer.TdistTerminalModel",
+    "chapter_owned": [
+      "physical inverse-gamma parameters",
+      "p eta q pricing-kernel mapping",
+      "scenario construction and economic interpretation",
+      "smile summary diagnostics",
+      "payload table and figure rendering"
+    ],
+    "frozen_oracle_policy": "The pre-adoption script is hash-checked and imported only by the verifier; production modules must not import or reference it."
+  },
+  "execution": {
+    "module": "volatility_book.ch_tdist_risk_premia.generate_tdist_risk_premia_figures",
+    "profile": "canonical",
+    "output_directory": "outputs/volatility_book/ch_tdist_risk_premia/canonical",
+    "commands": {
+      "canonical_regeneration": [
+        "python",
+        "-m",
+        "volatility_book.ch_tdist_risk_premia.generate_tdist_risk_premia_figures",
+        "--profile",
+        "canonical"
+      ],
+      "payload_only_rerender": [
+        "python",
+        "-m",
+        "volatility_book.ch_tdist_risk_premia.generate_tdist_risk_premia_figures",
+        "--payload",
+        "outputs/volatility_book/ch_tdist_risk_premia/canonical/numerical_payload.json",
+        "--output-dir",
+        "outputs/volatility_book/ch_tdist_risk_premia/canonical_rerender"
+      ],
+      "package_adoption_verification": [
+        "python",
+        "-m",
+        "volatility_book.ch_tdist_risk_premia.verify_tdist_risk_premia_package_adoption"
+      ]
+    },
+    "payload_rerender_guard": {
+      "environment_variable": "STOCHVOLMODELS_TDIST_RISK_PREMIA_FORBID_RECOMPUTE",
+      "guard_value": "1",
+      "contract": "Numerical construction fails when set to 1, while validated --payload rendering still succeeds."
+    }
+  },
+  "output_contract": {
+    "default_root": "outputs/volatility_book/ch_tdist_risk_premia",
+    "gitignore_rule": "/outputs/",
+    "generated_artifacts_are_tracked": false,
+    "network_or_licensed_inputs": false,
+    "artifact_manifest_paths_are_output_relative": true,
+    "artifacts_relative_to_profile_directory": [
+      "numerical_payload.json",
+      "artifact_manifest.json",
+      "figures/risk_premium_smiles.pdf",
+      "figures/risk_premium_smiles.png",
+      "figures/p_tail_premium_fixed_variance.pdf",
+      "figures/p_tail_premium_fixed_variance.png",
+      "tables/risk_premium_comparative_statics_table.tex"
+    ]
+  },
+  "numerical_contract": {
+    "scenario_ids": [
+      "p_minus",
+      "baseline_p",
+      "p_plus",
+      "eta_minus",
+      "baseline_eta",
+      "eta_plus",
+      "q_minus",
+      "baseline_q",
+      "q_plus",
+      "p_fixed_minus",
+      "baseline_fixed",
+      "p_fixed_plus"
+    ],
+    "log_moneyness": {
+      "minimum": -0.35,
+      "maximum": 0.35,
+      "count": 29
+    },
+    "portable_curve_capture": {
+      "sha256": "2f78c1e678774f692946fc37f97496c754a0f306604af136d5800a342fbefeae",
+      "recipe": "Round log-moneyness to 8 decimals; alpha, beta, q, shift and default probability to 12; calls and Black IVs to 10; encode sorted compact finite JSON."
+    },
+    "frozen_validation_dictionary": {
+      "sha256": "5a6fa80531840bd19ac6f1c4276bc6dea47682ffa3c159a622f69ddc0b1b447e",
+      "recipe": "Encode the frozen validation dictionary as sorted compact finite JSON without numeric normalization."
+    },
+    "package_vs_frozen_absolute_tolerances": {
+      "law_parameters_and_mean_v": 1e-15,
+      "shift_and_default_probability": 5e-13,
+      "call_prices": 5e-12,
+      "black_implied_volatilities": 5e-11,
+      "summary_statistics": 1e-9
+    },
+    "frozen_independent_validation_limits": {
+      "max_martingale_error": 1e-10,
+      "max_independent_martingale_error": 1e-7,
+      "max_put_call_parity_error": 1e-10,
+      "max_symmetric_closed_form_error": 5e-8,
+      "max_adaptive_integration_error": 5e-8,
+      "max_marginal_density_integration_error": 1e-7,
+      "max_black_round_trip_error": 1e-10,
+      "max_128_vs_256_node_error": 3e-7,
+      "max_call_monotonicity_violation": 1e-12,
+      "max_call_convexity_violation": 1e-12,
+      "max_variance_neutral_mean_v_error": 1e-13,
+      "max_duplicate_baseline_curve_error": 1e-13
+    },
+    "nonunit_discount_probe": {
+      "ttm": 0.75,
+      "discfactor": 0.96,
+      "forward": 105.0,
+      "price_absolute_tolerance": 4e-6,
+      "purpose": "Detect confusion between prepaid-forward B=D*F and undiscounted forward F."
+    }
+  },
+  "verification": {
+    "required": [
+      "frozen oracle and source-ledger hashes before import",
+      "all 12 by 29 unrounded package-versus-frozen curves",
+      "portable curve and frozen-validation hashes",
+      "symmetric Student and nonunit-discount references",
+      "strict finite payload schema and safe output paths",
+      "guarded payload-only rerender with identical payload and table",
+      "three-pass chapter build and complete rendered-page inspection"
+    ],
+    "portable_golden_policy": "Numerical payload hashes and tolerances are portable; PDF and PNG hashes are per-run provenance only."
+  },
+  "deferred": {
+    "cum_mean_tdist_nonzero_location": "The legacy helper omits ttm from its nonzero-mu location term. T2 and T3T pricing use mu=0, so this requires a separate numerical change."
+  }
+}

--- a/volatility_book/ch_tdist_risk_premia/generate_tdist_risk_premia_figures.py
+++ b/volatility_book/ch_tdist_risk_premia/generate_tdist_risk_premia_figures.py
@@ -1,0 +1,295 @@
+"""Compute or rerender the package-routed Student risk-premia chapter artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+from typing import Any, Sequence
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.ticker import PercentFormatter
+
+from volatility_book.ch_tdist_risk_premia import tdist_risk_premia_chapter as chapter
+
+
+def _setup_style() -> None:
+    plt.rcParams.update(
+        {
+            "font.size": 9.0,
+            "axes.titlesize": 10.0,
+            "axes.labelsize": 9.0,
+            "legend.fontsize": 7.0,
+            "xtick.labelsize": 8.0,
+            "ytick.labelsize": 8.0,
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+            "figure.dpi": 150,
+            "savefig.dpi": 300,
+            "pdf.fonttype": 42,
+        }
+    )
+
+
+def _scenario(payload: dict[str, Any], identifier: str) -> dict[str, Any]:
+    matches = [
+        record for record in payload["scenarios"] if record["scenario"]["identifier"] == identifier
+    ]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one payload scenario named {identifier!r}")
+    return matches[0]
+
+
+def _signed(value: float, digits: int) -> str:
+    return "0" if abs(value) < 1.0e-15 else f"{value:+.{digits}f}"
+
+
+def _legend_label(record: dict[str, Any]) -> str:
+    scenario = record["scenario"]
+    panel = scenario["panel"]
+    if panel == "p":
+        return rf"$p={_signed(scenario['p'], 2)}$"
+    if panel == "eta":
+        return rf"$\eta={_signed(scenario['eta'], 3)}$"
+    if panel == "q":
+        return rf"$q={_signed(scenario['q'], 0)}$"
+    return (
+        rf"$p={_signed(scenario['p'], 2)},\ "
+        rf"\eta={_signed(scenario['eta'], 3)}$"
+    )
+
+
+def _save_figure(
+    figure: plt.Figure,
+    figure_directory: Path,
+    stem: str,
+    *,
+    title: str,
+) -> list[Path]:
+    figure_directory.mkdir(parents=True, exist_ok=True)
+    pdf_path = figure_directory / f"{stem}.pdf"
+    png_path = figure_directory / f"{stem}.png"
+    figure.savefig(
+        pdf_path,
+        bbox_inches="tight",
+        metadata={"Title": title, "CreationDate": None, "ModDate": None},
+    )
+    figure.savefig(
+        png_path,
+        bbox_inches="tight",
+        dpi=220,
+        metadata={"Software": "stochvolmodels"},
+    )
+    plt.close(figure)
+    return [pdf_path, png_path]
+
+
+def _render_raw_smiles(payload: dict[str, Any], figure_directory: Path) -> list[Path]:
+    _setup_style()
+    colors = ("#2878B5", "#F28E2B", "#3AA255")
+    linestyles = ("-", "--", ":")
+    panels = (
+        (("p_minus", "baseline_p", "p_plus"), r"$p$: tails and variance"),
+        (("eta_minus", "baseline_eta", "eta_plus"), r"$\eta$: variance level"),
+        (("q_minus", "baseline_q", "q_plus"), r"$q$: skew direction"),
+    )
+    figure, axes = plt.subplots(1, 3, figsize=(8.4, 2.9), sharex=True, sharey=True)
+    for axis, (identifiers, title) in zip(axes, panels):
+        for identifier, color, linestyle in zip(identifiers, colors, linestyles):
+            record = _scenario(payload, identifier)
+            axis.plot(
+                np.asarray(record["log_moneyness"], dtype=float),
+                np.asarray(record["implied_volatilities"], dtype=float),
+                color=color,
+                linestyle=linestyle,
+                linewidth=1.8,
+                label=_legend_label(record),
+            )
+        axis.axvline(0.0, color="0.75", linewidth=0.7, zorder=0)
+        axis.grid(color="0.88", linewidth=0.6)
+        axis.set_title(title)
+        axis.set_xlabel(r"log-moneyness $k=\log(K/F)$")
+        axis.legend(frameon=False, loc="upper right")
+    axes[0].set_ylabel("Black implied volatility")
+    axes[0].yaxis.set_major_formatter(PercentFormatter(1.0))
+    axes[0].set_ylim(0.155, 0.285)
+    figure.tight_layout(w_pad=1.0)
+    return _save_figure(
+        figure,
+        figure_directory,
+        "risk_premium_smiles",
+        title="Risk-premium parameters and the Black implied-volatility smile",
+    )
+
+
+def _render_fixed_variance_smiles(
+    payload: dict[str, Any],
+    figure_directory: Path,
+) -> list[Path]:
+    _setup_style()
+    colors = ("#2878B5", "#F28E2B", "#3AA255")
+    linestyles = ("-", "--", ":")
+    identifiers = ("p_fixed_minus", "baseline_fixed", "p_fixed_plus")
+    figure, axis = plt.subplots(figsize=(5.8, 3.45))
+    for identifier, color, linestyle in zip(identifiers, colors, linestyles):
+        record = _scenario(payload, identifier)
+        axis.plot(
+            np.asarray(record["log_moneyness"], dtype=float),
+            np.asarray(record["implied_volatilities"], dtype=float),
+            color=color,
+            linestyle=linestyle,
+            linewidth=1.9,
+            label=_legend_label(record),
+        )
+    axis.axvline(0.0, color="0.75", linewidth=0.7, zorder=0)
+    axis.grid(color="0.88", linewidth=0.6)
+    axis.set_title(r"Tail premium $p$ with $E_Q[V]=4\%$ held fixed")
+    axis.set_xlabel(r"log-moneyness $k=\log(K/F)$")
+    axis.set_ylabel("Black implied volatility")
+    axis.yaxis.set_major_formatter(PercentFormatter(1.0))
+    axis.legend(frameon=False, loc="upper right")
+    figure.tight_layout()
+    return _save_figure(
+        figure,
+        figure_directory,
+        "p_tail_premium_fixed_variance",
+        title="Tail-risk premium at fixed mean variance",
+    )
+
+
+def _table_row(label: str, record: dict[str, Any]) -> str:
+    return (
+        f"{label} & {record['atm_iv']:.4f} & {record['atm_skew']:.4f} "
+        f"& {record['rr_025']:.4f} & {record['bf_025']:.4f} \\\\"
+    )
+
+
+def _write_comparative_statics_table(payload: dict[str, Any], table_directory: Path) -> Path:
+    table_directory.mkdir(parents=True, exist_ok=True)
+    specifications = (
+        ("Baseline", "baseline_p"),
+        (r"$p=-0.75$, $\eta=0$", "p_minus"),
+        (r"$p=+0.75$, $\eta=0$", "p_plus"),
+        (
+            r"$p=-0.75$, $\eta=+0.030$, fixed $\mathrm{E}_{\mathbb Q}[V]$",
+            "p_fixed_minus",
+        ),
+        (
+            r"$p=+0.75$, $\eta=-0.030$, fixed $\mathrm{E}_{\mathbb Q}[V]$",
+            "p_fixed_plus",
+        ),
+        (r"$\eta=-0.024$", "eta_minus"),
+        (r"$\eta=+0.024$", "eta_plus"),
+        (r"$q=-2$", "q_minus"),
+        (r"$q=+2$", "q_plus"),
+    )
+    rows = [
+        _table_row(label, _scenario(payload, identifier)) for label, identifier in specifications
+    ]
+    text = "\n".join(
+        [
+            r"\begin{tabular}{@{}lrrrr@{}}",
+            r"\toprule",
+            "Scenario & ATM IV & ATM slope & "
+            r"$\operatorname{RR}^{(k)}_{0.25}$ & $\operatorname{BF}^{(k)}_{0.25}$ \\",
+            r"\midrule",
+            *rows,
+            r"\bottomrule",
+            r"\end{tabular}",
+            "",
+        ]
+    )
+    target = table_directory / "risk_premium_comparative_statics_table.tex"
+    target.write_text(text, encoding="utf-8", newline="\n")
+    return target
+
+
+def render_artifacts(payload: dict[str, Any], output_directory: Path | str) -> list[Path]:
+    """Render both figures and the cited table using only a validated payload."""
+
+    validated = chapter.validate_numerical_payload(payload)
+    output = chapter.validate_output_directory(output_directory)
+    figure_directory = output / "figures"
+    table_directory = output / "tables"
+    artifacts = []
+    artifacts.extend(_render_raw_smiles(validated, figure_directory))
+    artifacts.extend(_render_fixed_variance_smiles(validated, figure_directory))
+    artifacts.append(_write_comparative_statics_table(validated, table_directory))
+    return artifacts
+
+
+def run_pipeline(
+    *,
+    profile: chapter.ChapterProfile | str = chapter.ChapterProfile.CANONICAL,
+    output_directory: Path | str | None = None,
+    payload_path: Path | str | None = None,
+) -> tuple[Path, Path]:
+    """Compute once or rerender an existing payload, returning payload and manifest paths."""
+
+    selected_profile = chapter.as_profile(profile)
+    output = chapter.validate_output_directory(
+        chapter.default_output_directory(selected_profile)
+        if output_directory is None
+        else output_directory
+    )
+    output.mkdir(parents=True, exist_ok=True)
+    target_payload = output / chapter.PAYLOAD_FILENAME
+    if payload_path is None:
+        payload = chapter.build_numerical_payload(selected_profile)
+        chapter.write_numerical_payload(payload, target_payload)
+        mode = "computed"
+    else:
+        source_payload = Path(payload_path).expanduser().resolve()
+        payload = chapter.load_numerical_payload(source_payload)
+        selected_profile = chapter.as_profile(payload["profile"])
+        if source_payload != target_payload.resolve():
+            shutil.copyfile(source_payload, target_payload)
+        mode = "rerendered"
+    render_payload = chapter.load_numerical_payload(target_payload)
+    rendered = render_artifacts(render_payload, output)
+    manifest = chapter.write_artifact_manifest(
+        output,
+        profile=selected_profile,
+        mode=mode,
+        payload_path=target_payload,
+        artifacts=[target_payload, *rendered],
+    )
+    return target_payload, manifest
+
+
+def _parse_arguments(arguments: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile",
+        choices=[profile.value for profile in chapter.ChapterProfile],
+        default=chapter.ChapterProfile.CANONICAL.value,
+    )
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument(
+        "--payload",
+        type=Path,
+        help="rerender this validated payload without invoking numerical analytics",
+    )
+    return parser.parse_args(arguments)
+
+
+def main(arguments: Sequence[str] | None = None) -> None:
+    """Execute the deterministic chapter artifact pipeline."""
+
+    args = _parse_arguments(arguments)
+    payload, manifest = run_pipeline(
+        profile=args.profile,
+        output_directory=args.output_dir,
+        payload_path=args.payload,
+    )
+    print(f"payload: {payload}")
+    print(f"artifact manifest: {manifest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/volatility_book/ch_tdist_risk_premia/notes/tdist_risk_premia_note.tex
+++ b/volatility_book/ch_tdist_risk_premia/notes/tdist_risk_premia_note.tex
@@ -1,0 +1,1608 @@
+\documentclass[11pt,a4paper]{article}
+
+\usepackage{amsmath,amssymb,amsthm,mathtools}
+\usepackage{booktabs}
+\usepackage{graphicx}
+\usepackage[margin=2.7cm]{geometry}
+\usepackage[colorlinks=true,linkcolor=blue,urlcolor=blue]{hyperref}
+\graphicspath{{../figures/}}
+\hypersetup{
+  pdftitle={Static Inverse-Gamma Variance Mixtures, Student-t Option Valuation,
+    Risk Premia, and Stationary Laws of Stochastic-Volatility Diffusions},
+  pdfsubject={Student-t option valuation and physical-to-pricing risk premia}
+}
+
+\newtheorem{proposition}{Proposition}[section]
+\newtheorem{remark}{Remark}[section]
+\newtheorem{assumption}{Assumption}[section]
+
+\DeclareMathOperator{\IG}{IG}
+\DeclareMathOperator{\GammaDist}{Gamma}
+\DeclareMathOperator{\Var}{Var}
+\DeclareMathOperator{\Cov}{Cov}
+\DeclareMathOperator{\E}{E}
+
+\newcommand{\dd}{\,\mathrm{d}}
+\newcommand{\ind}{\mathbf{1}}
+\newcommand{\cdf}{G}
+\newcommand{\cM}{\mathcal{M}}
+\newcommand{\doi}[1]{\href{https://doi.org/#1}{doi:#1}}
+
+\title{Static Inverse-Gamma Variance Mixtures, Student-$t$ Option Valuation,\\
+Risk Premia, and Stationary Laws of Stochastic-Volatility Diffusions}
+\author{}
+\date{Draft: August 2026}
+
+\begin{document}
+
+\maketitle
+
+\begin{abstract}
+This note gives a self-contained formulation of a static inverse-gamma normal
+variance mixture and the resulting Student-$t$ model for European option
+valuation.  The terminal asset price is non-negative, its drift is fixed by the
+market forward, and calls, puts, put--call parity, deltas, gammas, and strike
+derivatives are obtained in closed form.  We then construct an explicit
+physical-to-pricing measure change.  A power--precision kernel preserves the
+inverse-gamma family, while a conditionally compensated Gaussian kernel
+introduces asymmetric return risk without relying on the nonexistent Student
+moment-generating function.  The three parameters have interpretable smile
+effects: variance level, tail curvature, and skew.  The notation is chosen to
+match the symmetric implementation in
+\texttt{stochvolmodels.fitters.tdist}; the accompanying
+\texttt{risk\_premium\_smile\_examples.py} implements the $p,\eta,q$
+extension.  A separate section derives the stationary laws of the
+multiplicative-variance, $3/2$, and Heston/CIR variance diffusions.  The
+stationary laws motivate static return mixtures, but they are not identified
+with the finite-horizon return laws of the continuous-time diffusions.
+\end{abstract}
+
+\tableofcontents
+
+\section{Scope and conventions}
+
+The note separates three related but different constructions.
+\begin{enumerate}
+    \item A \emph{static terminal model}: a conditional variance is drawn from
+    an inverse-gamma law and a return shock is conditionally normal.  The
+    resulting marginal shock is Student-$t$.  This construction is used for
+    option valuation one maturity at a time.
+    \item A \emph{physical-to-pricing measure change}: an admissible likelihood
+    ratio changes the inverse-gamma shape and scale and can couple large
+    variance to signed terminal returns.  This construction defines risk
+    premia at one maturity and produces skewed option smiles.
+    \item \emph{Continuous-time motivation}: positive variance diffusions have
+    inverse-gamma or gamma stationary laws.  Their stationary
+    marginal variance may motivate a one-step mixture, but the exact
+    finite-horizon return mixes over integrated variance.
+\end{enumerate}
+
+Throughout, the inverse-gamma convention is
+\begin{equation}
+  V\sim\IG(\alpha,\beta),\qquad
+  g_{\IG}(v)=\frac{\beta^\alpha}{\Gamma(\alpha)}
+  v^{-\alpha-1}\exp\left(-\frac{\beta}{v}\right),\qquad v>0,
+  \label{eq:ig_density}
+\end{equation}
+where $\alpha>0$ is the shape and $\beta>0$ is the scale.  When they exist,
+\begin{equation}
+  \E[V]=\frac{\beta}{\alpha-1},\qquad
+  \Var[V]=\frac{\beta^2}{(\alpha-1)^2(\alpha-2)}.
+  \label{eq:ig_moments}
+\end{equation}
+The gamma convention uses a rate $\lambda>0$:
+\begin{equation}
+  V\sim\GammaDist(\alpha,\lambda),\qquad
+  g_\Gamma(v)=\frac{\lambda^\alpha}{\Gamma(\alpha)}
+  v^{\alpha-1}e^{-\lambda v},\qquad v>0.
+  \label{eq:gamma_density}
+\end{equation}
+
+For option valuation at maturity $T$, let $D_T$ be the market discount factor,
+$F_T$ the market forward, and
+\begin{equation}
+  \bar S_0(T):=D_TF_T
+  \label{eq:prepaid_forward}
+\end{equation}
+the prepaid forward.  This convention incorporates deterministic carry and
+dividends in $F_T$.  The chain-pricing implementation passes
+\texttt{forward * discfactor} as its argument named \texttt{spot}; consequently
+that argument is precisely $\bar S_0(T)$ in the formulation below.
+
+\section{Related literature and positioning}
+\label{sec:related_literature}
+
+The main ingredients of the model have substantial precedents, although they
+are usually assembled in different ways.
+
+\begin{description}
+  \item[Normal--inverse-gamma foundation.]
+  Praetz \cite{Praetz1972} derived Student-$t$ laws for share-price changes by
+  mixing conditional normal returns over an inverse-gamma variance.  This is
+  the distributional foundation of the static construction below, but that
+  work does not address risk-neutral option valuation or the lower price
+  boundary.
+
+  \item[Arithmetic Student returns.]
+  Pinn \cite{Pinn2000} gives the closest early option model based on additive
+  Student-$t$ price changes and derives European-call costs and
+  minimum-variance hedge functions.  Its pricing principle is
+  variance-optimal hedging in an incomplete market; negative underlying values
+  remain possible and there is no censoring-induced atom at zero.  Vince
+  \cite{Vince1992} separately observed that imposing a zero price bound changes
+  the terminal mean and can disturb put--call parity, and proposed a numerical
+  compensating shift.  That construction is based on log-Student moves and
+  does not solve the censored martingale equation used here.
+
+  \item[Log-Student valuation and Greeks.]
+  Cassidy, Hamp, and Ouyed \cite{CassidyHampOuyed2010} construct martingale-
+  normalized log-Student option formulas with a cap or truncated support.
+  Such upper-tail control is necessary because a Student variable has no
+  finite positive exponential moment.  Their follow-up paper
+  \cite{CassidyHampOuyed2013} adds option Greeks and lower-floor extensions,
+  including the sensitivity of the martingale normalizer.  In contrast,
+  \eqref{eq:terminal_asset} is arithmetic: for $\nu>1$ it needs no upper cap,
+  and its entire censored lower tail becomes an atom at $S_T=0$.
+
+  \item[Inverse-gamma activity and geometric prices.]
+  Castelli, Leonenko, and Shchestyuk
+  \cite{CastelliLeonenkoShchestyuk2017} use a stationary reciprocal-gamma
+  activity process to generate Student-like returns and an option-pricing
+  formula.  Leonenko, Liu, and Shchestyuk
+  \cite{LeonenkoLiuShchestyuk2025} develop European prices, analytic Delta,
+  Gamma, Vega, and Theta, and delta-hedging experiments for Student
+  fractal-activity-time geometric Brownian motion.  Conditional
+  Black--Scholes quantities are averaged over activity time.  Ivanov
+  \cite{Ivanov2023} obtains related option formulas when generalized
+  Black--Scholes--Merton coefficients depend on gamma or inverse-gamma random
+  variables.  These exponential constructions keep the asset strictly
+  positive and have neither a zero atom nor the endogenous censored location
+  $A_T$.
+
+  \item[Generalized-hyperbolic skew Student law.]
+  The normal mean--variance mixture in \eqref{eq:q_joint_law}, and hence the
+  marginal density \eqref{eq:skew_t_density}, is a parameterization of the
+  established generalized-hyperbolic skew Student-$t$ distribution studied by
+  Aas and Hob\ae k Haff \cite{AasHaff2006}.  They emphasize its polynomial
+  tail on one side and exponential tail on the other.  The known marginal
+  family is not the proposed contribution here; the added structure is the
+  explicit physical-to-pricing kernel, the floored martingale location,
+  option valuation, and risk-premium Greeks.
+
+  \item[Pricing kernels and measure selection.]
+  The power--precision likelihood ratio developed below belongs to the broad
+  class of positive pricing kernels that preserve a chosen parametric family.
+  In an incomplete market it selects one equivalent martingale measure among
+  many; it is not forced by no-arbitrage alone.  Minimal Hellinger and more
+  general minimal $f^q$ martingale measures provide principled selection
+  criteria in related semimartingale settings
+  \cite{ChoulliStrickerLi2007,JeanblancKloppelMiyahara2007}.  For dynamic
+  diffusions, a formally specified drift change must additionally produce a
+  true density process and preserve the relevant boundary behavior; the
+  one-dimensional criteria in Desmettre, Leobacher, and Rogers
+  \cite{DesmettreLeobacherRogers2021} make explicit why a local Girsanov
+  calculation alone is insufficient.
+  Here the superscript in $f^q$ is standard notation from that literature and
+  is unrelated to the return-skew parameter $q$ in
+  \eqref{eq:conditional_return_kernel}.
+
+  \item[Stationary SV laws.]
+  Inverse-gamma stationarity for the multiplicative/GARCH diffusion goes back
+  to Nelson \cite{Nelson1990}.  The $3/2$ diffusion is represented in the
+  nonlinear model of Ahn and Gao \cite{AhnGao1999}; its reciprocal is a
+  square-root diffusion.  The CIR and Heston square-root specifications instead
+  have gamma stationary laws \cite{CIR1985,Heston1993}.  Dynamic GARCH-diffusion
+  option valuation has been developed through moments of \emph{integrated}
+  variance \cite{BaroneAdesiRasmussenRavanelli2005}, not by substituting the
+  stationary instantaneous variance into a one-period Student mixture.
+\end{description}
+
+Thus Student-$t$ option valuation, inverse-gamma mixing, martingale
+normalization, lower boundaries, and Greeks are not individually new.  In the
+targeted literature search, however, no exact published match was located for
+their joint use in
+\begin{equation}
+  S_T=\bar S_0(T)(A_T+X_T)^+,
+  \qquad X_T\ \hbox{centered Student-}t,
+  \label{eq:literature_position_model}
+\end{equation}
+with $A_T$ determined \emph{after} censoring from the martingale condition,
+uncapped arithmetic upside, a genuine zero-price atom, exact calls and puts,
+and Greeks that include the implicit response of $A_T$.  The partial-moment
+option identity itself is standard; the potentially distinctive contribution
+is this complete, internally consistent package.  This conclusion records the
+outcome of a targeted literature review and is not a formal claim of priority.
+
+\section{Static inverse-gamma variance mixtures}
+
+\subsection{The normal variance mixture}
+
+\begin{assumption}[Static conditional return]
+For a fixed horizon with scale factor $c>0$,
+\begin{equation}
+  X=\sqrt{cV}\,Z,\qquad Z\sim N(0,1),\qquad
+  Z\perp V,\qquad V\sim\IG(\alpha,\beta),
+  \label{eq:normal_ig_mixture}
+\end{equation}
+Equivalently, $X\mid V\sim N(0,cV)$, where the second normal parameter is
+the variance.
+\end{assumption}
+
+\begin{proposition}[Student-$t$ marginal]
+Under \eqref{eq:normal_ig_mixture},
+\begin{equation}
+  f_X(x)=
+  \frac{\Gamma(\alpha+\tfrac12)}
+       {\Gamma(\alpha)\sqrt{2\pi c\beta}}
+  \left(1+\frac{x^2}{2c\beta}\right)^{-(\alpha+1/2)},
+  \label{eq:mixture_density}
+\end{equation}
+or, equivalently,
+\begin{equation}
+  X\overset{d}{=}sZ_\nu,\qquad
+  Z_\nu\sim t_\nu,\qquad
+  \nu=2\alpha,\qquad
+  s^2=\frac{c\beta}{\alpha}.
+  \label{eq:student_mapping}
+\end{equation}
+\end{proposition}
+
+\begin{proof}
+Integrating the conditional normal density against \eqref{eq:ig_density} gives
+\begin{align*}
+f_X(x)
+&=\frac{\beta^\alpha}{\Gamma(\alpha)\sqrt{2\pi c}}
+  \int_0^\infty
+  v^{-\alpha-3/2}
+  \exp\left[-\frac{\beta+x^2/(2c)}{v}\right]\dd v\\
+&=\frac{\beta^\alpha\Gamma(\alpha+\tfrac12)}
+        {\Gamma(\alpha)\sqrt{2\pi c}}
+  \left(\beta+\frac{x^2}{2c}\right)^{-(\alpha+1/2)},
+\end{align*}
+which is \eqref{eq:mixture_density}.  Substitution of $\nu=2\alpha$ and
+$s^2=c\beta/\alpha$ yields the standard location-scale Student density.
+\end{proof}
+
+If $\alpha>1$, then
+\begin{equation}
+  \Var[X]=c\E[V]=\frac{c\beta}{\alpha-1}
+  =s^2\frac{\nu}{\nu-2}.
+  \label{eq:variance_match_ig}
+\end{equation}
+Thus, for an annualized volatility parameter $\sigma$ and $c=T$, the
+implementation convention
+\begin{equation}
+  \Var[X_T]=\sigma^2T
+  \label{eq:code_variance_target}
+\end{equation}
+is obtained with
+\begin{equation}
+  s_T=\sigma\sqrt{T\frac{\nu-2}{\nu}},\qquad \nu>2.
+  \label{eq:code_student_scale}
+\end{equation}
+This is the quantity returned by \texttt{compute\_upsilon}; despite its name,
+it is a Student scale, not a precision.
+
+\subsection{Density, distribution, and partial first moment}
+
+Set
+\begin{equation}
+  c_\nu:=\frac{\Gamma((\nu+1)/2)}
+  {\sqrt{\pi\nu}\,\Gamma(\nu/2)}.
+\end{equation}
+For the centered shock $X_T=s_TZ_\nu$,
+\begin{equation}
+  f_T(x)=\frac{c_\nu}{s_T}
+  \left(1+\frac{x^2}{\nu s_T^2}\right)^{-(\nu+1)/2}.
+  \label{eq:student_density}
+\end{equation}
+Let
+\begin{equation}
+  \cdf_T(x):=\Pr(X_T\le x),\qquad
+  H_T(x):=\int_{-\infty}^x u f_T(u)\dd u,
+  \label{eq:cdf_lower_moment}
+\end{equation}
+and define the upper partial first moment by
+\begin{equation}
+  \cM_T(x):=\int_x^\infty u f_T(u)\dd u=-H_T(x).
+  \label{eq:upper_moment}
+\end{equation}
+For $\nu>1$,
+\begin{equation}
+  H_T(x)=
+  -s_Tc_\nu\frac{\nu}{\nu-1}
+  \left(1+\frac{x^2}{\nu s_T^2}\right)^{-(\nu-1)/2}.
+  \label{eq:student_lower_moment}
+\end{equation}
+The implementation functions \texttt{cdf\_tdist} and
+\texttt{cum\_mean\_tdist} compute $\cdf_T$ and $H_T$, respectively, with
+their location argument set to zero in the terminal pricer.
+
+For a generic moment order $r$, the condition is
+\begin{equation}
+  \E[|X_T|^r]<\infty\quad\Longleftrightarrow\quad r<\nu.
+  \label{eq:student_moment_condition}
+\end{equation}
+Linear option payoffs require $\nu>1$, variance matching requires $\nu>2$,
+and finite kurtosis requires $\nu>4$.  The implementation deliberately imposes
+$\nu>2$ because \eqref{eq:code_student_scale} uses a finite variance.
+
+\subsection{Transforms}
+
+The moment-generating function of a Student variable satisfies
+$\E[e^{tX}]=\infty$ for every real $t\ne0$.  The relevant transform is the characteristic
+function, obtained from the Laplace transform of the mixing variance:
+\begin{equation}
+  \phi_X(u)=\E[e^{iuX}]=\E[e^{-cu^2V/2}]
+  =L_V(cu^2/2).
+\end{equation}
+For \eqref{eq:ig_density},
+\begin{equation}
+  L_V(\ell)=\E[e^{-\ell V}]
+  =\frac{2(\beta \ell)^{\alpha/2}}{\Gamma(\alpha)}
+  K_\alpha(2\sqrt{\beta \ell}),\qquad \ell>0,
+  \label{eq:ig_laplace}
+\end{equation}
+where $K_\alpha$ is the modified Bessel function of the second kind.
+
+\section{Physical-to-pricing measure changes and risk premia}
+\label{sec:risk_premia}
+
+\subsection{One-period pricing densities}
+
+Let the physical law at a fixed maturity be
+\begin{equation}
+  V\sim\IG(\alpha_{\mathbb P},\beta_{\mathbb P}),\qquad
+  X\mid V,\mathbb P\sim N(0,cV).
+  \label{eq:physical_joint_law}
+\end{equation}
+A one-period change of measure is a strictly positive random variable
+\begin{equation}
+  \Lambda_T=\frac{\dd\mathbb Q}{\dd\mathbb P}\bigg|_{\mathcal F_T},
+  \qquad
+  \E_{\mathbb P}[\Lambda_T]=1.
+  \label{eq:terminal_rn_density}
+\end{equation}
+For a terminal price $S_T=B_T(A_T+X_T)^+$ with an arbitrary positive price
+scale $B_T$, the pricing law must also satisfy
+\begin{equation}
+  \E_{\mathbb P}[\Lambda_TS_T]
+  =\E_{\mathbb Q}[S_T]=F_T.
+  \label{eq:pricing_measure_martingale}
+\end{equation}
+The second restriction fixes $A_T$ after the distributional parameters have
+been selected.  It does not uniquely fix $\Lambda_T$: the one-period market is
+incomplete.
+
+\subsection{Why the marginal Student Esscher transform fails}
+
+The conventional Esscher candidate
+\begin{equation}
+  \Lambda_T^{\rm Esscher}
+  =\frac{e^{tX_T}}{\E_{\mathbb P}[e^{tX_T}]}
+  \label{eq:invalid_student_esscher}
+\end{equation}
+does not exist for $t\ne0$, because the Student moment-generating function is
+infinite on both non-zero half-axes.  This rules out an exponential tilt of
+the \emph{marginal} Student shock.  It does not rule out every exponential
+factor on the enlarged state space $(X,V)$: conditional Gaussian
+normalization makes the construction below finite.
+
+\subsection{Inverse-gamma-preserving power--precision kernel}
+
+For parameters $p$ and $\eta$, define
+\begin{equation}
+  \Lambda_{p,\eta}^{V}
+  :=
+  \frac{V^p e^{-\eta/V}}
+       {\E_{\mathbb P}[V^p e^{-\eta/V}]}.
+  \label{eq:variance_pricing_kernel}
+\end{equation}
+The normalizing moment is
+\begin{equation}
+  \E_{\mathbb P}[V^p e^{-\eta/V}]
+  =
+  \frac{\beta_{\mathbb P}^{\alpha_{\mathbb P}}
+        \Gamma(\alpha_{\mathbb P}-p)}
+       {\Gamma(\alpha_{\mathbb P})
+        (\beta_{\mathbb P}+\eta)^{\alpha_{\mathbb P}-p}},
+  \label{eq:variance_kernel_normalizer}
+\end{equation}
+which is finite precisely when
+\begin{equation}
+  p<\alpha_{\mathbb P},\qquad
+  \eta>-\beta_{\mathbb P}.
+  \label{eq:static_kernel_admissibility}
+\end{equation}
+Multiplying \eqref{eq:ig_density} by \eqref{eq:variance_pricing_kernel}
+preserves the inverse-gamma family:
+\begin{equation}
+  V\mid\mathbb Q\sim\IG(a,b),\qquad
+  a:=\alpha_{\mathbb P}-p,\qquad
+  b:=\beta_{\mathbb P}+\eta.
+  \label{eq:q_ig_parameters}
+\end{equation}
+Thus, in the symmetric $q=0$ subfamily, $p$ changes the Student degrees of
+freedom $\nu_{\mathbb Q}=2a$, while $\eta$ changes the variance scale.  When
+$q\ne0$, the polynomial-side moment index is instead $a$, as made explicit
+in \eqref{eq:skew_moment_condition}.  In particular,
+\begin{equation}
+  \bar v_{\mathbb Q}:=\E_{\mathbb Q}[V]
+  =\frac{b}{a-1},\qquad a>1.
+  \label{eq:q_mean_variance}
+\end{equation}
+
+\subsection{Conditionally compensated return kernel}
+
+Define a second likelihood ratio conditionally on $V$:
+\begin{equation}
+  \Lambda_q^{X\mid V}
+  :=
+  \exp\left(\frac{qX}{c}-\frac{q^2V}{2c}\right).
+  \label{eq:conditional_return_kernel}
+\end{equation}
+Since $X\mid V,\mathbb P\sim N(0,cV)$,
+\begin{equation}
+  \E_{\mathbb P}[\Lambda_q^{X\mid V}\mid V]=1.
+\end{equation}
+Consequently, the product
+\begin{equation}
+  \Lambda_{p,\eta,q}
+  =\Lambda_{p,\eta}^{V}\Lambda_q^{X\mid V}
+  \label{eq:combined_pricing_kernel}
+\end{equation}
+is a valid, strictly positive one-period density under
+\eqref{eq:static_kernel_admissibility}.  Under the resulting pricing law,
+\begin{equation}
+  V\sim\IG(a,b),\qquad
+  X\mid V,\mathbb Q\sim N(qV,cV),
+  \qquad
+  Z_{\mathbb Q}:=\frac{X-qV}{\sqrt{cV}}\sim N(0,1),
+  \quad Z_{\mathbb Q}\perp_{\mathbb Q}V.
+  \label{eq:q_joint_law}
+\end{equation}
+The sign convention is deliberate: $q<0$ associates large-variance states
+with negative returns and generates an equity-like left skew.
+
+For $q\ne0$, direct integration gives the skewed density
+\begin{align}
+  f_{\mathbb Q}(x)
+  &=
+  \frac{2b^a}{\Gamma(a)\sqrt{2\pi c}}\,
+  e^{qx/c}
+  \left(\frac{q^2}{x^2+2bc}\right)^{(a+1/2)/2}
+  \nonumber\\
+  &\hspace{2cm}\times
+  K_{a+1/2}\left(
+    \frac{|q|}{c}\sqrt{x^2+2bc}
+  \right).
+  \label{eq:skew_t_density}
+\end{align}
+Its continuous $q\to0$ limit is the symmetric Student density
+\eqref{eq:mixture_density} with $\alpha=a$ and $\beta=b$.  The construction is therefore an
+inverse-gamma normal mean--variance mixture, not a marginal Student Esscher
+transform.
+
+The moment implications are important.  For $q=0$,
+$\E_{\mathbb Q}[|X|^r]<\infty$ if and only if $r<2a$.  For $q\ne0$, the
+$qV$ term dominates one heavy tail, so
+\begin{equation}
+  \E_{\mathbb Q}[|X|^r]<\infty
+  \quad\Longleftrightarrow\quad r<a.
+  \label{eq:skew_moment_condition}
+\end{equation}
+The domain $a>1$ is a uniform sufficient condition for a finite first
+absolute moment and linear valuation for every sign of $q$; $a>2$ is a
+uniform sufficient condition for finite variance.  The exact symmetric
+$q=0$ thresholds are weaker: a finite positive-part value requires
+$a>1/2$, and finite variance requires $a>1$.  For $q>0$, linear valuation
+requires $a>1$; for $q<0$, the payoff-relevant right tail is exponentially
+tempered even when the first absolute moment is infinite.  When $a>2$,
+\begin{equation}
+  \Var_{\mathbb Q}[X]
+  =c\bar v_{\mathbb Q}
+   +q^2\Var_{\mathbb Q}[V]
+  =c\bar v_{\mathbb Q}
+   +\frac{q^2\bar v_{\mathbb Q}^2}{a-2}.
+  \label{eq:q_total_variance}
+\end{equation}
+
+\subsection{Valuation by conditional Bachelier integration}
+
+Introduce the normal positive-part function
+\begin{equation}
+  \mathcal L(m,s):=m\Phi(m/s)+s\phi(m/s),\qquad s>0.
+  \label{eq:normal_positive_part}
+\end{equation}
+Conditional on $V$, it equals
+$\E[(m+sZ)^+]$.  The martingale location is therefore the unique solution
+of
+\begin{equation}
+  \E_{\mathbb Q}\!\left[
+    \mathcal L(A_T+qV,\sqrt{cV})
+  \right]
+  =\frac{F_T}{B_T}.
+  \label{eq:skew_martingale_location}
+\end{equation}
+For strike $K$, define
+\begin{equation}
+  m_K(V):=A_T-\frac{K}{B_T}+qV,\qquad
+  s(V):=\sqrt{cV}.
+\end{equation}
+The call and put prices are
+\begin{align}
+  C_0(K)
+  &=D_TB_T\,\E_{\mathbb Q}
+    [\mathcal L(m_K(V),s(V))],
+  \label{eq:skew_call_price}
+  \\
+  P_0(K)
+  &=C_0(K)-D_T(F_T-K).
+  \label{eq:skew_put_price}
+\end{align}
+The put expression includes the zero-state payoff through parity.  Direct
+conditional integration gives the same result when the lower tail is handled
+with the sign-reversed normal mean.
+
+The one-dimensional expectation is stable under the precision change
+\begin{equation}
+  U:=\frac{b}{V}\sim\GammaDist(a,1),
+  \label{eq:gamma_precision_quadrature}
+\end{equation}
+so generalized Gauss--Laguerre quadrature applies.  At $q=0$,
+\eqref{eq:skew_call_price} agrees with the closed-form Student partial-moment
+formula below.  This equality is a useful independent implementation check.
+
+\subsection{Strike derivatives and risk-premium Greeks}
+
+Write
+\begin{equation}
+  z_K(V):=\frac{m_K(V)}{s(V)},\qquad
+  z_0(V):=\frac{A_T+qV}{s(V)}.
+\end{equation}
+Differentiating under the integral gives
+\begin{align}
+  \frac{\partial C_0}{\partial K}
+  &=-D_T\,\E_{\mathbb Q}[\Phi(z_K(V))],
+  \label{eq:skew_call_strike_delta}
+  \\
+  \frac{\partial^2 C_0}{\partial K^2}
+  &=\frac{D_T}{B_T}\,
+    \E_{\mathbb Q}\left[
+      \frac{\phi(z_K(V))}{s(V)}
+    \right].
+  \label{eq:skew_call_strike_gamma}
+\end{align}
+Hence the call is decreasing and convex in strike, and the second derivative
+recovers the continuous terminal density away from zero.
+
+Risk-premium Greeks must include the response of $A_T$.  The following
+formulas use the uniform domain $a>1$, which ensures the required first
+moments for $q=0$ and $q>0$.  For
+$V\sim\IG(a,b)$, the centered likelihood scores are
+\begin{equation}
+  s_p(V)=\log(V/b)+\psi(a),\qquad
+  s_\eta(V)=\frac{a}{b}-\frac{1}{V},
+  \label{eq:ig_risk_premium_scores}
+\end{equation}
+where $\psi$ is the digamma function.  For
+$\vartheta\in\{p,\eta\}$,
+\begin{equation}
+  A_\vartheta
+  =
+  -\frac{
+    \E_{\mathbb Q}[
+      \mathcal L(A_T+qV,s(V))s_\vartheta(V)
+    ]}
+    {\E_{\mathbb Q}[\Phi(z_0(V))]}.
+  \label{eq:location_p_eta_greek}
+\end{equation}
+The corresponding price Greek is
+\begin{equation}
+  \frac{\partial C_0}{\partial\vartheta}
+  =
+  D_TB_T\left\{
+    \E_{\mathbb Q}[
+      \mathcal L(m_K(V),s(V))s_\vartheta(V)
+    ]
+    +A_\vartheta\E_{\mathbb Q}[\Phi(z_K(V))]
+  \right\}.
+  \label{eq:call_p_eta_greek}
+\end{equation}
+For the skew parameter,
+\begin{align}
+  A_q
+  &=
+  -\frac{\E_{\mathbb Q}[V\Phi(z_0(V))]}
+         {\E_{\mathbb Q}[\Phi(z_0(V))]},
+  \label{eq:location_q_greek}
+  \\
+  \frac{\partial C_0}{\partial q}
+  &=
+  D_TB_T\,\E_{\mathbb Q}[
+    (A_q+V)\Phi(z_K(V))
+  ].
+  \label{eq:call_q_greek}
+\end{align}
+Equations \eqref{eq:location_p_eta_greek}--\eqref{eq:call_q_greek} hold with
+$B_T,F_T,D_T,c$ fixed.  They show why bumping a risk-premium parameter while
+holding $A_T$ fixed is inconsistent with the forward.
+
+\subsection{Power and polynomial alternatives}
+
+Power kernels are therefore possible and particularly convenient on the
+latent variance.  The factor
+\[
+  V^p e^{-\eta/V}
+\]
+is positive and preserves the inverse-gamma family.  A direct asset-power
+kernel is less satisfactory in
+the floored model.  If it is proportional to $S_T^\gamma$, then
+$\gamma>0$ assigns zero density to the positive-probability state $S_T=0$
+and destroys equivalence, while $\gamma<0$ is singular at that atom.  A
+strictly positive shift such as $(\epsilon+S_T)^\gamma$ avoids this defect
+but loses the family-preserving formulas.
+
+Polynomial kernels are possible only after positivity and integrability are
+enforced.  An odd polynomial such as
+$1+a_1X+a_3X^3$ changes sign in a tail and cannot be a
+Radon--Nikodym density.  A strictly positive even polynomial can be
+normalized when all required Student moments exist; for a degree-$2m$
+polynomial in the symmetric model this requires $2m<2\alpha_{\mathbb P}$.
+It generally produces a mixture of components rather than one
+inverse-gamma law, is sensitive to high moments, and gives less transparent
+smile controls.  A kernel such as
+$\epsilon+h(X)^2$ with $\epsilon>0$ is strictly positive, and exponentials
+of bounded functions or bounded transforms also preserve positivity.
+These alternatives similarly sacrifice the closed family.  For these reasons,
+\eqref{eq:combined_pricing_kernel} is the recommended parsimonious
+formulation.
+
+\subsection{Comparative statics of \texorpdfstring{$p,\eta,q$}{p, eta, q}}
+\label{sec:risk_premium_comparative_statics}
+
+The numerical illustration uses
+\begin{equation}
+  F_T=D_T=T=c=B_T=1,\qquad
+  \alpha_{\mathbb P}=4,\qquad
+  \beta_{\mathbb P}=0.12,\qquad
+  \E_{\mathbb P}[V]=0.04.
+  \label{eq:risk_premium_baseline}
+\end{equation}
+For every curve, $A_T$ is re-solved from
+\eqref{eq:skew_martingale_location}.  The baseline
+$(p,\eta,q)=(0,0,0)$ has an unconditional shock standard deviation of
+$20\%$.  Its Black implied-volatility curve is nevertheless not flat:
+arithmetic returns, log-moneyness quotation, heavy tails, and the lower
+floor already produce a modest negative Black-volatility skew.
+
+\begin{figure}[htbp]
+  \centering
+  \includegraphics[width=\textwidth]{risk_premium_smiles.pdf}
+  \caption{One-year Black implied-volatility smiles for the three
+  risk-premium parameters.  The left panel varies $p$ with $\eta=0$, so tail
+  thickness and mean variance move together.  The middle panel varies
+  $\eta$ at fixed $p=0$ and predominantly shifts the variance level.  The
+  right panel varies $q$: negative $q$ couples high variance to negative
+  returns and steepens the left skew.  The martingale location is re-solved
+  for every curve.}
+  \label{fig:risk_premium_smiles}
+\end{figure}
+
+A raw change in $p$ changes both tail thickness and mean variance:
+\begin{equation}
+  \nu_{\mathbb Q}=2(\alpha_{\mathbb P}-p),\qquad
+  \E_{\mathbb Q}[V]
+  =\frac{\beta_{\mathbb P}+\eta}
+         {\alpha_{\mathbb P}-p-1}.
+  \label{eq:raw_p_effect}
+\end{equation}
+To isolate tail shape, hold
+$\bar v_{\mathbb Q}=\E_{\mathbb Q}[V]$ fixed and set
+\begin{equation}
+  \eta(p)
+  =\bar v_{\mathbb Q}(\alpha_{\mathbb P}-p-1)
+   -\beta_{\mathbb P}.
+  \label{eq:variance_neutral_eta}
+\end{equation}
+At the physical baseline this simplifies to
+$\eta(p)=-\bar v_{\mathbb P}p=-0.04p$.
+
+\begin{figure}[htbp]
+  \centering
+  \includegraphics[width=0.82\textwidth]
+    {p_tail_premium_fixed_variance.pdf}
+  \caption{The $p$ premium with $\eta=-0.04p$, which holds
+  $\E_{\mathbb Q}[V]=4\%$ fixed.  The ATM level moves little, while $p>0$
+  fattens the tails and raises wing curvature.  This variance-neutral
+  parameterization separates the tail premium from the scale premium.}
+  \label{fig:p_fixed_variance}
+\end{figure}
+
+For quantitative comparison let $k=\log(K/F_T)$ and define
+\begin{equation}
+  \operatorname{Slope}_{\rm ATM}
+  :=
+  \frac{\sigma_{\rm IV}(0.025)-\sigma_{\rm IV}(-0.025)}{0.05}.
+  \label{eq:atm_slope_definition}
+\end{equation}
+The wing diagnostics are
+\begin{align}
+  \operatorname{RR}^{(k)}_{0.25}
+  &:=
+  \sigma_{\rm IV}(0.25)-\sigma_{\rm IV}(-0.25),
+  \\
+  \operatorname{BF}^{(k)}_{0.25}
+  &:=
+  \tfrac12\{
+    \sigma_{\rm IV}(-0.25)+\sigma_{\rm IV}(0.25)
+  \}-\sigma_{\rm IV}(0).
+  \label{eq:log_moneyness_rr_bf}
+\end{align}
+These are fixed-log-moneyness diagnostics, not $25$-delta market quotes.
+
+\begin{table}[htbp]
+\centering
+\small
+\begin{tabular}{@{}lrrrr@{}}
+\toprule
+Scenario
+& ATM IV
+& ATM slope
+& $\operatorname{RR}^{(k)}_{0.25}$
+& $\operatorname{BF}^{(k)}_{0.25}$ \\
+\midrule
+Baseline
+& 0.1921 & -0.0961 & -0.0456 & 0.0123 \\
+$p=-0.75$, $\eta=0$
+& 0.1732 & -0.0867 & -0.0412 & 0.0112 \\
+$p=+0.75$, $\eta=0$
+& 0.2188 & -0.1089 & -0.0517 & 0.0138 \\
+$p=-0.75$, $\eta=+0.030$, fixed $\E_{\mathbb Q}[V]$
+& 0.1937 & -0.0970 & -0.0465 & 0.0103 \\
+$p=+0.75$, $\eta=-0.030$, fixed $\E_{\mathbb Q}[V]$
+& 0.1895 & -0.0945 & -0.0442 & 0.0153 \\
+$\eta=-0.024$
+& 0.1718 & -0.0859 & -0.0404 & 0.0133 \\
+$\eta=+0.024$
+& 0.2105 & -0.1052 & -0.0503 & 0.0115 \\
+$q=-2$
+& 0.1974 & -0.1612 & -0.0764 & 0.0122 \\
+$q=+2$
+& 0.1977 & -0.0354 & -0.0169 & 0.0120 \\
+\bottomrule
+\end{tabular}
+\caption{Deterministic-quadrature comparative statics.  All volatilities are
+in decimal units and $A_T$ is re-solved in every scenario.}
+\label{tab:risk_premium_comparative_statics}
+\end{table}
+
+The intended division of labor is visible in
+Figures~\ref{fig:risk_premium_smiles}--\ref{fig:p_fixed_variance} and
+Table~\ref{tab:risk_premium_comparative_statics}.  The raw $p$ change moves
+both ATM volatility and curvature.  The variance-neutral $p$ change
+predominantly moves wing curvature.  The parameter $\eta$ predominantly
+moves the ATM level.  The parameter $q$ predominantly moves slope:
+changing $q$ from $-2$ to $+2$ changes the ATM slope from about $-0.161$ to
+$-0.035$ while leaving ATM volatility near $19.8\%$.
+
+The martingale compensation offsets the conditional mean without removing
+asymmetry.  In the $q=-2$ and $q=+2$ scenarios,
+\begin{equation}
+  A_T=1.07974\quad\hbox{and}\quad A_T=0.92000,
+\end{equation}
+respectively.  The corresponding zero-state probabilities are approximately
+$9.9\times10^{-4}$ and $3.1\times10^{-5}$, compared with
+$2.1\times10^{-4}$ at the baseline.
+
+A stable calibration parameterization replaces $\eta$ by
+$\bar v_{\mathbb Q}$ and uses
+\begin{equation}
+  (\bar v_{\mathbb Q},p,q)
+  =
+  (\hbox{variance level},\hbox{tail shape},\hbox{asymmetry}).
+\end{equation}
+One can initialize $\bar v_{\mathbb Q}$ from ATM volatility, $q$ from a
+risk reversal or local slope, and variance-neutral $p$ from a butterfly or
+wing curvature; a joint refinement must re-solve $A_T$ at each evaluation.
+
+\subsection{Dynamic interpretation and measure selection}
+
+The terminal density \eqref{eq:combined_pricing_kernel} is valid for one
+maturity but does not by itself define a time-consistent density process.
+For the multiplicative diffusion \eqref{eq:multiplicative_variance}, use the
+standard convention
+\begin{equation}
+  \frac{\dd\mathbb Q}{\dd\mathbb P}\bigg|_{\mathcal F_t}
+  =
+  \mathcal E\left(-\int_0^t\lambda_m(V_s)\dd W_s^{\mathbb P}\right),
+  \qquad
+  \lambda_m(v)
+  =-\frac{\varepsilon_m}{2}
+    \left(p+\frac{\eta}{v}\right).
+  \label{eq:multiplicative_girsanov_kernel}
+\end{equation}
+Whenever this stochastic exponential is a true martingale and the boundary
+conditions remain admissible, the drift under $\mathbb Q$ stays in the same
+family with
+\begin{equation}
+  \kappa_m^{\mathbb Q}
+  =\kappa_m^{\mathbb P}-\frac{\varepsilon_m^2p}{2},
+  \qquad
+  \kappa_m^{\mathbb Q}(\theta_m^{\mathbb Q})^2
+  =
+  \kappa_m^{\mathbb P}(\theta_m^{\mathbb P})^2
+  +\frac{\varepsilon_m^2\eta}{2}.
+  \label{eq:multiplicative_q_mapping}
+\end{equation}
+The stationary shape therefore changes by $-p$ and the stationary scale by
+$+\eta$.  Positivity of mean reversion requires the stronger restriction
+$p<\alpha_{\mathbb P}-1$.
+
+For the $3/2$ diffusion \eqref{eq:three_halves_variance}, the corresponding
+family-preserving market price is
+\begin{equation}
+  \lambda_3(v)
+  =-\frac{\varepsilon_3}{2}
+    \left(p\sqrt v+\frac{\eta}{\sqrt v}\right),
+  \label{eq:three_halves_girsanov_kernel}
+\end{equation}
+with the same parameter mapping as
+\eqref{eq:multiplicative_q_mapping} after replacing the subscript $m$ by
+$3$.  Positive mean reversion now requires
+$p<\alpha_{\mathbb P}-2$.  These inequalities are necessary, not sufficient:
+true-martingale and boundary tests must be checked for the chosen initial law
+and horizon \cite{DesmettreLeobacherRogers2021}.
+
+The one-period parameter $q$ is likewise not automatically a
+continuous-time equity-risk-premium coefficient.  Its dynamic realization
+depends on the stock and variance Brownian drivers, their correlation, and
+the remaining market price of risk in the incomplete stochastic-volatility
+model.  Among the admissible measures, option calibration, an equilibrium
+stochastic discount factor, minimal Hellinger distance, or another stated
+criterion must select the pricing law
+\cite{ChoulliStrickerLi2007,JeanblancKloppelMiyahara2007}.
+
+\section{Arbitrage-consistent symmetric Student-\texorpdfstring{$t$}{t}
+terminal model}
+
+This section is the pricing-measure special case $q=0$ of
+\eqref{eq:q_joint_law}.  Unless a measure is displayed explicitly, all
+expectations in this section and the following Greek formulas are under
+$\mathbb Q$.
+
+\subsection{Non-negative terminal price and the martingale condition}
+
+For one fixed maturity, specify
+\begin{equation}
+  S_T=\bar S_0(T)\,(A_T+X_T)^+,
+  \qquad A_T=1+\mu_TT,
+  \label{eq:terminal_asset}
+\end{equation}
+where $X_T$ is centered with density \eqref{eq:student_density}.  The default
+boundary is
+\begin{equation}
+  x_T^*:=-A_T,
+  \label{eq:default_boundary}
+\end{equation}
+and the model has an atom at zero of size
+\begin{equation}
+  p_T^{(0)}=\cdf_T(x_T^*).
+  \label{eq:default_probability}
+\end{equation}
+This is a terminal zero-price mass, called a default probability in the code;
+the static model does not define a first-passage time or a pathwise default
+event.
+
+The normalization in \eqref{eq:terminal_asset} is the one used by the code.
+Consequently, $\sigma$ is the annualized standard deviation of an additive
+arithmetic shock normalized by the prepaid forward $\bar S_0=D_TF_T$.  It is
+neither a log-return volatility nor numerically identical to a Black--Scholes
+volatility.  An equivalent forward-normalized representation is
+\begin{equation}
+  S_T=F_T(\widehat A_T+\widehat X_T)^+,
+  \qquad
+  \widehat A_T=D_TA_T,
+  \qquad
+  \widehat X_T=D_TX_T,
+  \qquad
+  \widehat\sigma_T=D_T\sigma_T.
+  \label{eq:forward_normalization}
+\end{equation}
+It satisfies $\E[(\widehat A_T+\widehat X_T)^+]=1$.  Switching between the
+two normalizations without rescaling $\sigma$ changes the model.
+
+Risk neutrality requires $\E[S_T]=F_T$.  Since
+\begin{equation}
+  \E[(A_T+X_T)^+]
+  =A_T[1-\cdf_T(-A_T)]-H_T(-A_T),
+\end{equation}
+and $F_T/\bar S_0(T)=D_T^{-1}$, the drift compensation is the unique solution
+of
+\begin{equation}
+  A_T[1-\cdf_T(-A_T)]-H_T(-A_T)=D_T^{-1}.
+  \label{eq:martingale_A}
+\end{equation}
+Equivalently, with $A_T=1+\mu_TT$,
+\begin{equation}
+  \mu_TT[1-\cdf_T(x_T^*)]
+  -\cdf_T(x_T^*)-H_T(x_T^*)
+  =D_T^{-1}-1.
+  \label{eq:martingale_mu}
+\end{equation}
+Equation \eqref{eq:martingale_mu} is the root equation implemented by
+\texttt{imply\_drift\_tdist}.  The left-hand side of
+\eqref{eq:martingale_A} is continuous and strictly increasing in $A_T$, with
+derivative $1-\cdf_T(-A_T)>0$, so the solution is unique.
+
+\begin{remark}[Static, maturity-specific law]
+The parameters $(\sigma_T,\nu_T,\mu_T)$ may be calibrated separately for each
+maturity.  Each slice can then be internally arbitrage-consistent, but an
+independently calibrated collection is not automatically free of calendar
+arbitrage and is not the marginal family of a common dynamic process.
+\end{remark}
+
+\subsection{European calls and puts}
+
+Let $K\ge0$ and set
+\begin{equation}
+  y_T(K):=\frac{K}{\bar S_0(T)}-A_T.
+  \label{eq:exercise_boundary}
+\end{equation}
+Because $y_T(K)-x_T^*=K/\bar S_0(T)\ge0$, the call exercise region lies above
+the default boundary.
+
+\begin{proposition}[Closed-form valuation]
+The time-zero call and put prices are
+\begin{align}
+  C_0(K,T)
+  &=D_T\left[
+      -\bar S_0(T)H_T(y_T)
+      +(\bar S_0(T)A_T-K)(1-\cdf_T(y_T))
+    \right],
+  \label{eq:call_price}\\
+  P_0(K,T)
+  &=D_T\left[
+      (K-\bar S_0(T)A_T)
+      (\cdf_T(y_T)-\cdf_T(x_T^*))
+    \right.
+  \notag\\
+  &\hspace{2.6cm}\left.
+      {}-\bar S_0(T)(H_T(y_T)-H_T(x_T^*))
+      +K\cdf_T(x_T^*)
+    \right].
+  \label{eq:put_price}
+\end{align}
+They satisfy market put--call parity,
+\begin{equation}
+  C_0(K,T)-P_0(K,T)=D_T(F_T-K).
+  \label{eq:put_call_parity}
+\end{equation}
+\end{proposition}
+
+\begin{proof}
+For calls, $S_T>K$ is equivalent to $X_T>y_T$, so direct integration gives
+\eqref{eq:call_price}.  For puts, the payoff equals $K$ on
+$X_T\le x_T^*$ and equals
+$K-\bar S_0(T)(A_T+X_T)$ on $x_T^*<X_T<y_T$; splitting the integral at
+$x_T^*$ gives \eqref{eq:put_price}.  Subtracting and applying
+\eqref{eq:martingale_A} gives \eqref{eq:put_call_parity}.
+\end{proof}
+
+The separate term $K\cdf_T(x_T^*)$ in \eqref{eq:put_price} is essential: it is
+the put payoff on the atom at zero.  Omitting it prices an unfloored model that
+allows negative terminal asset values.
+
+\section{Greeks and strike derivatives}
+
+The following derivatives hold with $(D_T,A_T,\sigma_T,\nu_T)$ fixed.  Thus
+they are model derivatives without recalibration.  Write
+$\bar S_0=\bar S_0(T)$, $y=y_T(K)$, and suppress the maturity subscript on
+$f_T$, $\cdf_T$, and $H_T$.
+
+\subsection{Prepaid-forward delta and gamma}
+
+Differentiation with respect to the prepaid forward gives
+\begin{align}
+  \Delta_C^{\mathrm{pf}}
+  :=\frac{\partial C_0}{\partial \bar S_0}
+  &=D_T\left[A_T(1-\cdf_T(y))-H_T(y)\right],
+  \label{eq:call_delta}\\
+  \Delta_P^{\mathrm{pf}}
+  :=\frac{\partial P_0}{\partial \bar S_0}
+  &=\Delta_C^{\mathrm{pf}}-1,
+  \label{eq:put_delta}\\
+  \Gamma_C^{\mathrm{pf}}
+  =\Gamma_P^{\mathrm{pf}}
+  :=\frac{\partial^2 C_0}{\partial \bar S_0^2}
+  &=D_T\frac{K^2}{\bar S_0^3}f_T(y).
+  \label{eq:gamma}
+\end{align}
+The relation in \eqref{eq:put_delta} follows by differentiating
+\eqref{eq:put_call_parity}, since $D_TF_T=\bar S_0$.
+
+If deterministic dividend carry gives
+$\bar S_0=S_0e^{-\delta T}$, then spot Greeks are
+\begin{equation}
+  \Delta_C^{S}=e^{-\delta T}\Delta_C^{\mathrm{pf}},\qquad
+  \Gamma_C^{S}=e^{-2\delta T}\Gamma_C^{\mathrm{pf}},
+  \label{eq:spot_greeks}
+\end{equation}
+and analogously for the put.
+
+For the market forward supplied to the chain wrapper, $\bar S_0=D_TF_T$ and
+$D_T$ is held fixed, so
+\begin{equation}
+  \Delta_C^{F}=D_T\Delta_C^{\mathrm{pf}},\qquad
+  \Gamma_C^{F}=D_T^2\Gamma_C^{\mathrm{pf}},
+  \label{eq:forward_greeks}
+\end{equation}
+and analogously for the put.
+
+\subsection{Strike derivatives and digitals}
+
+For $K>0$,
+\begin{align}
+  \frac{\partial C_0}{\partial K}
+  &=-D_T[1-\cdf_T(y)],
+  &
+  \frac{\partial^2 C_0}{\partial K^2}
+  &=D_T\frac{f_T(y)}{\bar S_0},
+  \label{eq:call_strike_derivatives}\\
+  \frac{\partial P_0}{\partial K}
+  &=D_T\cdf_T(y),
+  &
+  \frac{\partial^2 P_0}{\partial K^2}
+  &=D_T\frac{f_T(y)}{\bar S_0}.
+  \label{eq:put_strike_derivatives}
+\end{align}
+Consequently the cash-or-nothing call is
+\begin{equation}
+  \mathrm{DigitalCall}_0(K,T)=D_T[1-\cdf_T(y)].
+\end{equation}
+The atom at $S_T=0$ creates a boundary effect at $K=0$; the derivatives above
+are stated for strictly positive strikes.
+
+\subsection{Volatility and tail-parameter sensitivities}
+
+The martingale compensation $A_T$ changes when $\sigma_T$ or $\nu_T$ changes.
+For a volatility bump, $X_T$ is proportional to $\sigma_T$.  Write
+$x^*=-A_T$, $Q^*=1-\cdf_T(x^*)$, and $Q_y=1-\cdf_T(y)$.  Implicit
+differentiation of \eqref{eq:martingale_A} gives
+\begin{equation}
+  \frac{\partial A_T}{\partial\sigma_T}
+  =\frac{H_T(x^*)}{\sigma_TQ^*}.
+  \label{eq:drift_vega_adjustment}
+\end{equation}
+The martingale-consistent call and put vegas are therefore identical:
+\begin{equation}
+  \boxed{
+  \frac{\partial C_0}{\partial\sigma_T}
+  =\frac{\partial P_0}{\partial\sigma_T}
+  =\frac{D_T\bar S_0}{\sigma_T}
+  \left[-H_T(y)+H_T(x^*)\frac{Q_y}{Q^*}\right].
+  }
+  \label{eq:martingale_consistent_vega}
+\end{equation}
+This is vega with respect to the prepaid-forward-normalized code parameter.
+For the forward-normalized parameter in \eqref{eq:forward_normalization}, use
+\begin{equation}
+  \frac{\partial C_0}{\partial\widehat\sigma_T}
+  =D_T^{-1}\frac{\partial C_0}{\partial\sigma_T},
+  \qquad
+  \frac{\partial P_0}{\partial\widehat\sigma_T}
+  =D_T^{-1}\frac{\partial P_0}{\partial\sigma_T},
+  \label{eq:forward_normalized_vega}
+\end{equation}
+with $D_T$ fixed.
+
+More generally, let $\vartheta$ denote a distribution parameter, such as
+$\nu_T$, and define
+\begin{equation}
+  G(A,\vartheta)
+  :=\E_\vartheta[(A+X_\vartheta)^+]-D_T^{-1}=0.
+\end{equation}
+Implicit differentiation gives
+\begin{equation}
+  \frac{\partial A_T}{\partial\vartheta}
+  =-\frac{\partial_\vartheta G(A_T,\vartheta)}
+  {1-\cdf_{T,\vartheta}(-A_T)}.
+  \label{eq:implicit_drift_greek}
+\end{equation}
+Therefore any numerical volatility or $\nu$ bump must re-solve
+\eqref{eq:martingale_A}.  Holding $A_T$ fixed during the bump breaks the
+forward identity.  The current implementation does not expose analytic Greeks;
+the formulas above are adoption targets.  A consistent finite-difference Greek
+must call \texttt{imply\_drift\_tdist} at every bumped parameter value.
+
+\section{Stationary laws of stochastic-variance diffusions}
+
+\subsection{General zero-current density}
+
+For a positive one-dimensional diffusion
+\begin{equation}
+  \dd V_t=b(V_t)\dd t+a(V_t)\dd W_t,
+\end{equation}
+a zero-current invariant density, when it is normalizable, is
+\begin{equation}
+  \pi(v)\propto \frac{1}{a^2(v)}
+  \exp\left(\int^v\frac{2b(u)}{a^2(u)}\dd u\right).
+  \label{eq:stationary_general}
+\end{equation}
+
+\subsection{Multiplicative variance diffusion}
+
+Consider
+\begin{equation}
+  \dd V_t=\kappa_m(\theta_m^2-V_t)\dd t
+  +\varepsilon_mV_t\dd W_t.
+  \label{eq:multiplicative_variance}
+\end{equation}
+Application of \eqref{eq:stationary_general} gives
+\begin{equation}
+  V_\infty\sim\IG(\alpha_m,\beta_m),\qquad
+  \alpha_m=1+\frac{2\kappa_m}{\varepsilon_m^2},\qquad
+  \beta_m=\frac{2\kappa_m\theta_m^2}{\varepsilon_m^2}.
+  \label{eq:multiplicative_stationary}
+\end{equation}
+This is the inverse-gamma stationary law of the continuous-time GARCH
+diffusion associated with Nelson's diffusion approximation
+\cite{Nelson1990}.
+Its stationary mean is $\theta_m^2$.  Its stationary variance is finite only
+when $2\kappa_m>\varepsilon_m^2$, in which case
+\begin{equation}
+  \Var[V_\infty]
+  =\frac{\theta_m^4\varepsilon_m^2}
+  {2\kappa_m-\varepsilon_m^2}.
+  \label{eq:multiplicative_stationary_variance}
+\end{equation}
+
+If the static mixture \eqref{eq:normal_ig_mixture} uses this stationary law,
+then
+\begin{equation}
+  \nu=2\alpha_m=2+\frac{4\kappa_m}{\varepsilon_m^2},
+  \qquad
+  s^2=\frac{c\beta_m}{\alpha_m}.
+  \label{eq:multiplicative_student_mapping}
+\end{equation}
+For $c=T$ and the code variance convention, $\sigma^2=\theta_m^2$.
+
+\subsection{The \texorpdfstring{$3/2$}{3/2} variance diffusion}
+
+Consider
+\begin{equation}
+  \dd V_t=\kappa_3V_t(\theta_3^2-V_t)\dd t
+  +\varepsilon_3V_t^{3/2}\dd W_t.
+  \label{eq:three_halves_variance}
+\end{equation}
+Its stationary law is
+\begin{equation}
+  V_\infty\sim\IG(\alpha_3,\beta_3),\qquad
+  \alpha_3=2+\frac{2\kappa_3}{\varepsilon_3^2},\qquad
+  \beta_3=\frac{2\kappa_3\theta_3^2}{\varepsilon_3^2}.
+  \label{eq:three_halves_stationary}
+\end{equation}
+The reciprocal transformation maps this specification to a square-root
+diffusion; the $3/2$ structure is represented in the nonlinear model of Ahn
+and Gao \cite{AhnGao1999}.
+Here $\theta_3^2$ is a drift level rather than the stationary mean:
+\begin{align}
+  \E[V_\infty]
+  &=\frac{2\kappa_3\theta_3^2}{2\kappa_3+\varepsilon_3^2},
+  \label{eq:three_halves_mean}
+  \\
+  \Var[V_\infty]
+  &=\frac{2\kappa_3\varepsilon_3^2\theta_3^4}
+  {(2\kappa_3+\varepsilon_3^2)^2}.
+  \label{eq:three_halves_stationary_variance}
+\end{align}
+The corresponding static mixture is Student with $\nu=2\alpha_3$ and
+$s^2=c\beta_3/\alpha_3$.  To match the code variance convention one must use
+$\sigma^2=\E[V_\infty]$, not $\theta_3^2$.
+
+\subsection{Heston/CIR variance diffusion}
+
+Consider
+\begin{equation}
+  \dd V_t=\kappa_h(\theta_h^2-V_t)\dd t
+  +\varepsilon_h\sqrt{V_t}\dd W_t.
+  \label{eq:heston_variance}
+\end{equation}
+Its stationary law is gamma:
+\begin{equation}
+  V_\infty\sim\GammaDist(\alpha_h,\lambda_h),\qquad
+  \alpha_h=\frac{2\kappa_h\theta_h^2}{\varepsilon_h^2},\qquad
+  \lambda_h=\frac{2\kappa_h}{\varepsilon_h^2}.
+  \label{eq:heston_stationary}
+\end{equation}
+This gamma invariant law is the stationary law of the CIR square-root process
+\cite{CIR1985} used for variance in the Heston model \cite{Heston1993}.
+The gamma scale is $\eta_h=1/\lambda_h=\varepsilon_h^2/(2\kappa_h)$ and
+\begin{equation}
+  \E[V_\infty]=\theta_h^2,
+  \qquad
+  \Var[V_\infty]
+  =\frac{\theta_h^2\varepsilon_h^2}{2\kappa_h}.
+  \label{eq:heston_stationary_moments}
+\end{equation}
+The stationary Laplace transform is
+\begin{equation}
+  L_V(\ell)=\left(\frac{\lambda_h}{\lambda_h+\ell}\right)^{\alpha_h}
+  =(1+\eta_h\ell)^{-\alpha_h}.
+  \label{eq:heston_laplace}
+\end{equation}
+The Feller condition $2\kappa_h\theta_h^2\ge\varepsilon_h^2$ makes zero
+unattainable; the invariant gamma law may still exist under the standard CIR
+boundary specification when the strict condition fails.
+
+A static normal mixture with this gamma variance is not Student-$t$.  It has
+the symmetric Bessel-$K$ density
+\begin{equation}
+  f_X(x)=
+  \frac{2|x|^{\alpha_h-1/2}}
+  {\sqrt{\pi}\,\Gamma(\alpha_h)(2c\eta_h)^{(\alpha_h+1/2)/2}}
+  K_{\alpha_h-1/2}
+  \left(\frac{2|x|}{\sqrt{2c\eta_h}}\right),
+  \label{eq:gamma_normal_mixture}
+\end{equation}
+with characteristic function
+\begin{equation}
+  \phi_X(u)=\left(1+\frac{c\eta_hu^2}{2}\right)^{-\alpha_h}.
+  \label{eq:gamma_mixture_cf}
+\end{equation}
+Unlike the Student mixture, this distribution has a moment-generating function
+on a neighborhood of the origin:
+\begin{equation}
+  M_X(t)=\left(1-\frac{c\eta_ht^2}{2}\right)^{-\alpha_h},
+  \qquad |t|<\sqrt{\frac{2}{c\eta_h}}.
+  \label{eq:gamma_mixture_mgf}
+\end{equation}
+At the origin its density is finite if and only if $\alpha_h>1/2$, in which
+case
+\begin{equation}
+  f_X(0)=\frac{\Gamma(\alpha_h-\tfrac12)}
+  {\Gamma(\alpha_h)\sqrt{2\pi c\eta_h}}.
+  \label{eq:gamma_mixture_origin}
+\end{equation}
+For $\alpha_h=1/2$ the singularity is logarithmic, and for $\alpha_h<1/2$ it
+is a power singularity.
+
+\subsection{Static mixture versus dynamic return law}
+
+Suppose the asset diffusion is
+\begin{equation}
+  \frac{\dd S_t}{S_t}=\mu_t\dd t+\sqrt{V_t}\dd W_t^S.
+\end{equation}
+Conditionally on the variance path and with zero leverage correlation, the
+centered stochastic integral satisfies
+\begin{equation}
+  \int_0^T\sqrt{V_t}\dd W_t^S
+  \ \Big|\ \{V_t:0\le t\le T\}
+  \sim N\left(0,\int_0^TV_t\dd t\right).
+  \label{eq:integrated_variance_mixture}
+\end{equation}
+Thus the exact finite-horizon mixing law uses integrated variance rather than
+the stationary marginal $V_\infty$.  In addition,
+\begin{equation}
+  \dd\log S_t=\left(\mu_t-\frac12V_t\right)\dd t
+  +\sqrt{V_t}\dd W_t^S,
+\end{equation}
+so log returns have a variance-dependent conditional mean.  The stationary
+mixtures above should therefore be described as exact one-step hierarchical
+models, short-horizon frozen-variance approximations, or independent terminal
+specifications.  They are not, without further work, exact terminal laws of the
+continuous-time diffusions.
+
+The same distinction appears in dynamic option-pricing work.  For example,
+Barone-Adesi, Rasmussen, and Ravanelli
+\cite{BaroneAdesiRasmussenRavanelli2005} derive moments of integrated variance
+for the GARCH diffusion and use them in an analytical approximation to
+European option values; they do not replace integrated variance by an
+independent draw from its stationary marginal.
+
+\section{Correspondence with the implementation}
+
+The existing library pricer implements the symmetric $q=0$ formulation.
+The chapter script \texttt{risk\_premium\_smile\_examples.py} implements the
+new $p,\eta,q$ extension through conditional-normal quadrature and generates
+Figures~\ref{fig:risk_premium_smiles}--\ref{fig:p_fixed_variance}.  The
+following table records the symmetric formulation adopted by the existing
+library code.
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Mathematical object & Implementation object \\
+\midrule
+$T$ & \texttt{ttm} \\
+$D_T$ & \texttt{discfactor} or $\exp(-\texttt{rf\_rate}\,T)$ \\
+$F_T$ & \texttt{forward} in the chain wrapper \\
+$\bar S_0=D_TF_T$ & argument \texttt{spot} in the chain wrapper \\
+$\sigma$ (prepaid-forward normalization) & \texttt{vol} \\
+$\nu$ & \texttt{nu} \\
+$s_T$ in \eqref{eq:code_student_scale} & \texttt{compute\_upsilon} \\
+$\cdf_T(x)$ & \texttt{cdf\_tdist(x, mu=0, ...)} \\
+$H_T(x)$ & \texttt{cum\_mean\_tdist(x, mu=0, ...)} \\
+$\mu_T$ & \texttt{risk\_neutral\_mu} or \texttt{drift} \\
+$A_T=1+\mu_TT$ & \texttt{1.0 + risk\_neutral\_mu*ttm} \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+For a one-maturity slice whose stored drift was solved at the same maturity,
+the implementation contract is:
+\begin{enumerate}
+  \item set $\bar S_0=D_TF_T$ and
+  $r_T=-\log(D_T)/T$;
+  \item compute $s_T$ from \eqref{eq:code_student_scale};
+  \item solve \eqref{eq:martingale_mu} for $\mu_T$;
+  \item evaluate \eqref{eq:call_price} or \eqref{eq:put_price};
+  \item verify \eqref{eq:put_call_parity}.
+\end{enumerate}
+
+The chain wrapper follows this contract exactly for a one-maturity slice with
+matching \texttt{params.ttm} and \texttt{params.drift}.  Although
+\texttt{price\_chain} accepts arrays of maturities, it passes one stored drift
+to every maturity and does not enforce that match.  The standalone function
+\texttt{compute\_vanilla\_price\_tdist} may interpret its argument named
+\texttt{spot} as the actual cash spot only when carry is absent or separately
+embedded; the chain wrapper removes the ambiguity by passing $D_TF_T$.
+
+The valuation core already implements the centered call and put formulas in
+this note.  Full code adoption nevertheless requires the following corrections
+and guardrails.
+\begin{enumerate}
+  \item The model shock is an arithmetic relative-return shock, not a log
+  return or a Black--Scholes volatility.  Student exponential moments do not
+  exist, which is precisely why \eqref{eq:terminal_asset} is used instead of an
+  exponential price map.  The existing ``terminal log-returns'' descriptions
+  should be corrected, as should the ``normal implied vol'' description of the
+  Student-$t$ inversion routine.
+  \item The public density helpers accept a non-zero location parameter.  The
+  terminal pricer always calls the CDF and partial-moment helpers with location
+  zero and applies $\mu_T$ externally.  That centered route is exact.  For a
+  non-zero location $m=\mu T$, however, the correct partial moment is
+  \[
+    H_Y(x)=m\cdf_Y(x)+sH_Z((x-m)/s).
+  \]
+  The present \texttt{cum\_mean\_tdist} uses \texttt{mu*cdf} instead of
+  \texttt{mu*ttm*cdf}; this latent helper bug does not affect centered pricing.
+  \item The quantity $\mu_T=(A_T-1)/T$ is a maturity-specific additive
+  location compensation, not the drift coefficient of a continuous-time
+  return process.  A different maturity generally requires a different root.
+  \item Calling \texttt{compute\_vanilla\_price\_tdist} with
+  \texttt{is\_compute\_risk\_neutral\_mu=False} and no explicit drift sets
+  $\mu_T$ equal to the risk-free rate.  Because the floor itself has value,
+  that fallback does not satisfy \eqref{eq:martingale_A} and should be rejected
+  or clearly marked non-risk-neutral.
+  \item The raw pricer currently treats option types \texttt{IC} and
+  \texttt{IP} as ordinary calls and puts.  Elsewhere those labels denote
+  inverse payoffs.  The inverse put genuinely diverges at the
+  positive-probability atom $S_T=0$.  For $K>0$, the inverse call has a
+  removable $0/0$ value and continuous extension zero there, but it still
+  requires an explicit zero-state convention and an implementation guard.
+  The model should accept only \texttt{C}/\texttt{P} until those contracts are
+  defined separately.
+  \item Calibration is performed one maturity at a time.  A stationary SDE
+  interpretation would impose cross-maturity parameter restrictions that the
+  current calibrator does not impose.
+\end{enumerate}
+
+\section{Verification identities}
+
+Any implementation of this formulation should verify the following independently.
+\begin{enumerate}
+  \item Distribution normalization and variance:
+  \[
+    \int_{-\infty}^{\infty}f_T(x)\dd x=1,
+    \qquad
+    \int_{-\infty}^{\infty}x^2f_T(x)\dd x=\sigma^2T.
+  \]
+  \item Martingale and default atom:
+  \[
+    \bar S_0\{A_T[1-\cdf_T(-A_T)]-H_T(-A_T)\}=F_T,
+    \qquad p_T^{(0)}=\cdf_T(-A_T).
+  \]
+  \item Put--call parity \eqref{eq:put_call_parity} for several strikes.
+  \item Finite-difference agreement with \eqref{eq:call_delta}--\eqref{eq:gamma}
+  while holding calibrated parameters fixed.
+  \item Agreement of the analytic Student density with an independent
+  inverse-gamma/normal mixture simulation.
+  \item Normalization and the weighted martingale identities for the
+  physical-to-pricing kernel:
+  \[
+    \E_{\mathbb P}[\Lambda_{p,\eta,q}]=1,\qquad
+    \E_{\mathbb P}[\Lambda_{p,\eta,q}S_T]=F_T.
+  \]
+  \item At $q=0$, agreement of
+  \eqref{eq:skew_call_price} with the independent Student partial-moment
+  formula; at $q\ne0$, agreement with adaptive integration of the gamma
+  precision density and with direct integration of the marginal Bessel-$K$
+  density \eqref{eq:skew_t_density}.
+  \item Put--call parity, Black implied-volatility round trips, decreasing
+  call prices, non-negative strike convexity, and convergence under
+  quadrature refinement.
+  \item For \eqref{eq:variance_neutral_eta}, preservation of
+  $\E_{\mathbb Q}[V]$, and equality of all duplicate baseline curves.
+\end{enumerate}
+
+The accompanying deterministic study uses 256 generalized Laguerre nodes.
+Across every plotted strike and scenario, the maximum absolute errors are
+\begin{center}
+\begin{tabular}{@{}lr@{}}
+\toprule
+Check & Maximum absolute error \\
+\midrule
+Martingale solver residual & $3.06\times10^{-14}$ \\
+Independent martingale check & $2.80\times10^{-8}$ \\
+Put--call parity & $3.04\times10^{-14}$ \\
+Symmetric Student closed form & $2.26\times10^{-8}$ \\
+Adaptive gamma-precision integration & $2.80\times10^{-8}$ \\
+Marginal Bessel-$K$ integration & $2.80\times10^{-8}$ \\
+Black price--volatility round trip & $3.33\times10^{-16}$ \\
+128 versus 256 quadrature nodes & $1.75\times10^{-7}$ \\
+Call monotonicity violation & $0$ \\
+Call convexity violation & $0$ \\
+Variance-neutral mean-$V$ error & $0$ \\
+Duplicate-baseline curve error & $0$ \\
+\bottomrule
+\end{tabular}
+\end{center}
+The comparisons use different numerical representations, rather than merely
+re-evaluating the same quadrature formula.
+
+\section{Conclusion}
+
+The inverse-gamma variance mixture provides a precise static foundation for a
+Student-$t$ return shock.  European option valuation becomes arbitrage-consistent
+at a fixed maturity after three additions: use the prepaid forward as the price
+scale, floor the terminal asset at zero, and solve the drift from the martingale
+condition.  The resulting exact put formula includes the atom at zero, and the
+Greeks depend on both exercise probability and truncated first moments.
+
+The recommended physical-to-pricing change of measure is
+\eqref{eq:combined_pricing_kernel}.  It avoids the invalid marginal Student
+Esscher transform, preserves the inverse-gamma family through $(p,\eta)$,
+and generates asymmetric return risk through the conditionally normalized
+parameter $q$.  In smile coordinates, $\eta$ primarily controls variance
+level, variance-neutral $p$ controls tail curvature, and $q$ controls skew.
+Valuation reduces to one-dimensional conditional-Bachelier integration, and
+the risk-premium Greeks follow from centered inverse-gamma scores plus the
+implicit martingale-location response.
+
+Multiplicative and $3/2$ variance diffusions have inverse-gamma stationary laws
+and therefore motivate static Student mixtures.  Heston variance has a gamma
+stationary law and motivates a Bessel-$K$, not Student, mixture.  These
+stationary constructions should remain conceptually separate from exact
+finite-horizon continuous-time return laws, which depend on integrated variance.
+The terminal kernel is a valid one-period pricing law; a dynamic interpretation
+requires a true Girsanov density, boundary admissibility, and an explicit
+criterion selecting one equivalent martingale measure from the incomplete
+market.
+
+\begin{thebibliography}{99}
+\addcontentsline{toc}{section}{References}
+\small
+\raggedright
+
+\bibitem{Praetz1972}
+P.~D. Praetz,
+``The distribution of share price changes,''
+\emph{The Journal of Business}, vol.~45, no.~1, pp.~49--55, 1972.
+\doi{10.1086/295425}.
+
+\bibitem{Pinn2000}
+K. Pinn,
+``Minimal variance hedging of options with Student-$t$ underlying,''
+\emph{Physica A: Statistical Mechanics and its Applications},
+vol.~276, nos.~3--4, pp.~581--595, 2000.
+\doi{10.1016/S0378-4371(99)00498-7}.
+
+\bibitem{Vince1992}
+R. Vince,
+\emph{The Mathematics of Money Management: Risk Analysis Techniques for
+Traders}. New York: John Wiley \& Sons, 1992. ISBN 978-0-471-54738-9.
+
+\bibitem{CassidyHampOuyed2010}
+D.~T. Cassidy, M.~J. Hamp, and R. Ouyed,
+``Pricing European options with a log Student's $t$-distribution: A Gosset
+formula,''
+\emph{Physica A: Statistical Mechanics and its Applications},
+vol.~389, no.~24, pp.~5736--5748, 2010.
+\doi{10.1016/j.physa.2010.08.037}.
+
+\bibitem{CassidyHampOuyed2013}
+D.~T. Cassidy, M.~J. Hamp, and R. Ouyed,
+``Log Student's $t$-distribution-based option sensitivities: Greeks for the
+Gosset formulae,''
+\emph{Quantitative Finance}, vol.~13, no.~8, pp.~1289--1302, 2013.
+\doi{10.1080/14697688.2012.744087}.
+
+\bibitem{CastelliLeonenkoShchestyuk2017}
+F. Castelli, N.~N. Leonenko, and N. Shchestyuk,
+``Student-like models for risky asset with dependence,''
+\emph{Stochastic Analysis and Applications},
+vol.~35, no.~3, pp.~452--464, 2017.
+\doi{10.1080/07362994.2016.1266945}.
+
+\bibitem{LeonenkoLiuShchestyuk2025}
+N.~N. Leonenko, A. Liu, and N. Shchestyuk,
+``Student models for a risky asset with dependence: Option pricing and
+Greeks,''
+\emph{Austrian Journal of Statistics},
+vol.~54, no.~1, pp.~138--165, 2025.
+\doi{10.17713/ajs.v54i1.1952}.
+
+\bibitem{Ivanov2023}
+R.~V. Ivanov,
+``On the stochastic volatility in the generalized Black--Scholes--Merton
+model,''
+\emph{Risks}, vol.~11, no.~6, article~111, 2023.
+\doi{10.3390/risks11060111}.
+
+\bibitem{AasHaff2006}
+K. Aas and I. Hob\ae k Haff,
+\textquotedblleft The generalized hyperbolic skew Student's
+$t$-distribution,\textquotedblright
+\emph{Journal of Financial Econometrics},
+vol.~4, no.~2, pp.~275--309, 2006.
+\doi{10.1093/jjfinec/nbj006}.
+
+\bibitem{ChoulliStrickerLi2007}
+T. Choulli, C. Stricker, and J. Li,
+\textquotedblleft Minimal Hellinger martingale measures of order
+$q$,\textquotedblright
+\emph{Finance and Stochastics}, vol.~11, no.~3, pp.~399--427, 2007.
+\doi{10.1007/s00780-007-0039-3}.
+
+\bibitem{JeanblancKloppelMiyahara2007}
+M. Jeanblanc, S. Kl\"oppel, and Y. Miyahara,
+\textquotedblleft Minimal $f^q$-martingale measures for exponential
+L\'evy processes,\textquotedblright
+\emph{The Annals of Applied Probability},
+vol.~17, nos.~5--6, pp.~1615--1638, 2007.
+\doi{10.1214/07-AAP439}.
+
+\bibitem{DesmettreLeobacherRogers2021}
+S. Desmettre, G. Leobacher, and L.~C.~G. Rogers,
+\textquotedblleft Change of drift in one-dimensional
+diffusions,\textquotedblright
+\emph{Finance and Stochastics}, vol.~25, no.~2, pp.~359--381, 2021.
+\doi{10.1007/s00780-021-00451-w}.
+
+\bibitem{Nelson1990}
+D.~B. Nelson,
+``ARCH models as diffusion approximations,''
+\emph{Journal of Econometrics}, vol.~45, nos.~1--2, pp.~7--38, 1990.
+\doi{10.1016/0304-4076(90)90092-8}.
+
+\bibitem{AhnGao1999}
+D.-H. Ahn and B. Gao,
+``A parametric nonlinear model of term structure dynamics,''
+\emph{The Review of Financial Studies},
+vol.~12, no.~4, pp.~721--762, 1999.
+\doi{10.1093/rfs/12.4.721}.
+
+\bibitem{CIR1985}
+J.~C. Cox, J.~E. Ingersoll, Jr., and S.~A. Ross,
+``A theory of the term structure of interest rates,''
+\emph{Econometrica}, vol.~53, no.~2, pp.~385--407, 1985.
+\doi{10.2307/1911242}.
+
+\bibitem{Heston1993}
+S.~L. Heston,
+``A closed-form solution for options with stochastic volatility with
+applications to bond and currency options,''
+\emph{The Review of Financial Studies},
+vol.~6, no.~2, pp.~327--343, 1993.
+\doi{10.1093/rfs/6.2.327}.
+
+\bibitem{BaroneAdesiRasmussenRavanelli2005}
+G. Barone-Adesi, H. Rasmussen, and C. Ravanelli,
+``An option pricing formula for the GARCH diffusion model,''
+\emph{Computational Statistics \& Data Analysis},
+vol.~49, no.~2, pp.~287--310, 2005.
+\doi{10.1016/j.csda.2004.05.014}.
+
+\end{thebibliography}
+
+\end{document}

--- a/volatility_book/ch_tdist_risk_premia/notes/tdist_risk_premia_note.tex
+++ b/volatility_book/ch_tdist_risk_premia/notes/tdist_risk_premia_note.tex
@@ -5,7 +5,10 @@
 \usepackage{graphicx}
 \usepackage[margin=2.7cm]{geometry}
 \usepackage[colorlinks=true,linkcolor=blue,urlcolor=blue]{hyperref}
-\graphicspath{{../figures/}}
+% The default is relative to this tracked notes directory.  A parent book build
+% can override the command before inputting the chapter.
+\providecommand{\TdistRiskPremiaArtifactRoot}{../../../outputs/volatility_book/ch_tdist_risk_premia/canonical}
+\graphicspath{{\TdistRiskPremiaArtifactRoot/figures/}}
 \hypersetup{
   pdftitle={Static Inverse-Gamma Variance Mixtures, Student-t Option Valuation,
     Risk Premia, and Stationary Laws of Stochastic-Volatility Diffusions},
@@ -47,11 +50,12 @@ physical-to-pricing measure change.  A power--precision kernel preserves the
 inverse-gamma family, while a conditionally compensated Gaussian kernel
 introduces asymmetric return risk without relying on the nonexistent Student
 moment-generating function.  The three parameters have interpretable smile
-effects: variance level, tail curvature, and skew.  The notation is chosen to
-match the symmetric implementation in
-\texttt{stochvolmodels.fitters.tdist}; the accompanying
-\texttt{risk\_premium\_smile\_examples.py} implements the $p,\eta,q$
-extension.  A separate section derives the stationary laws of the
+effects: variance level, tail curvature, and skew.  The symmetric law is exposed
+by \texttt{TdistTerminalModel}, while the all-$q$ pricing law is exposed by
+\texttt{InverseGammaNormalTerminalModel}.  The chapter-owned
+\texttt{tdist\_risk\_premia\_chapter.py} maps $p,\eta,q$ into those risk-neutral
+law inputs and the artifact generator writes one portable numerical payload.
+A separate section derives the stationary laws of the
 multiplicative-variance, $3/2$, and Heston/CIR variance diffusions.  The
 stationary laws motivate static return mixtures, but they are not identified
 with the finite-horizon return laws of the continuous-time diffusions.
@@ -669,8 +673,9 @@ The numerical illustration uses
   \E_{\mathbb P}[V]=0.04.
   \label{eq:risk_premium_baseline}
 \end{equation}
-For every curve, $A_T$ is re-solved from
-\eqref{eq:skew_martingale_location}.  The baseline
+For each distinct pricing law, $A_T$ is solved from
+\eqref{eq:skew_martingale_location}; duplicate baseline presentations reuse
+the same law and numerical curve.  The baseline
 $(p,\eta,q)=(0,0,0)$ has an unconditional shock standard deviation of
 $20\%$.  Its Black implied-volatility curve is nevertheless not flat:
 arithmetic returns, log-moneyness quotation, heavy tails, and the lower
@@ -684,8 +689,8 @@ floor already produce a modest negative Black-volatility skew.
   thickness and mean variance move together.  The middle panel varies
   $\eta$ at fixed $p=0$ and predominantly shifts the variance level.  The
   right panel varies $q$: negative $q$ couples high variance to negative
-  returns and steepens the left skew.  The martingale location is re-solved
-  for every curve.}
+  returns and steepens the left skew.  Each plotted curve uses the martingale
+  location solved for its distinct pricing law.}
   \label{fig:risk_premium_smiles}
 \end{figure}
 
@@ -744,36 +749,9 @@ These are fixed-log-moneyness diagnostics, not $25$-delta market quotes.
 \begin{table}[htbp]
 \centering
 \small
-\begin{tabular}{@{}lrrrr@{}}
-\toprule
-Scenario
-& ATM IV
-& ATM slope
-& $\operatorname{RR}^{(k)}_{0.25}$
-& $\operatorname{BF}^{(k)}_{0.25}$ \\
-\midrule
-Baseline
-& 0.1921 & -0.0961 & -0.0456 & 0.0123 \\
-$p=-0.75$, $\eta=0$
-& 0.1732 & -0.0867 & -0.0412 & 0.0112 \\
-$p=+0.75$, $\eta=0$
-& 0.2188 & -0.1089 & -0.0517 & 0.0138 \\
-$p=-0.75$, $\eta=+0.030$, fixed $\E_{\mathbb Q}[V]$
-& 0.1937 & -0.0970 & -0.0465 & 0.0103 \\
-$p=+0.75$, $\eta=-0.030$, fixed $\E_{\mathbb Q}[V]$
-& 0.1895 & -0.0945 & -0.0442 & 0.0153 \\
-$\eta=-0.024$
-& 0.1718 & -0.0859 & -0.0404 & 0.0133 \\
-$\eta=+0.024$
-& 0.2105 & -0.1052 & -0.0503 & 0.0115 \\
-$q=-2$
-& 0.1974 & -0.1612 & -0.0764 & 0.0122 \\
-$q=+2$
-& 0.1977 & -0.0354 & -0.0169 & 0.0120 \\
-\bottomrule
-\end{tabular}
+\input{\TdistRiskPremiaArtifactRoot/tables/risk_premium_comparative_statics_table.tex}
 \caption{Deterministic-quadrature comparative statics.  All volatilities are
-in decimal units and $A_T$ is re-solved in every scenario.}
+in decimal units and $A_T$ is solved for every distinct pricing law.}
 \label{tab:risk_premium_comparative_statics}
 \end{table}
 
@@ -1302,12 +1280,21 @@ independent draw from its stationary marginal.
 
 \section{Correspondence with the implementation}
 
-The existing library pricer implements the symmetric $q=0$ formulation.
-The chapter script \texttt{risk\_premium\_smile\_examples.py} implements the
-new $p,\eta,q$ extension through conditional-normal quadrature and generates
-Figures~\ref{fig:risk_premium_smiles}--\ref{fig:p_fixed_variance}.  The
-following table records the symmetric formulation adopted by the existing
-library code.
+The package separates two terminal-law capabilities.  The accepted
+\texttt{TdistTerminalModel} implements the symmetric $q=0$ formulation, and
+\texttt{InverseGammaNormalTerminalModel} implements the inverse-gamma/normal
+law for all admissible $q$.  The chapter retains the physical parameters and
+the economic mapping
+$(\alpha_{\mathbb Q},\beta_{\mathbb Q},q)
+=(\alpha_{\mathbb P}-p,\beta_{\mathbb P}+\eta,q)$, then passes only the
+resulting risk-neutral law to the package model.  The hash-pinned
+\path{risk_premium_smile_examples.py} is retained solely as an independent
+pre-adoption oracle; production figures and the cited table are rendered from
+the package-owned payload by
+\path{generate_tdist_risk_premia_figures.py}.
+
+The following table records the symmetric correspondence used for the
+independent $q=0$ comparison.
 \begin{center}
 \begin{tabular}{@{}ll@{}}
 \toprule
@@ -1347,16 +1334,16 @@ to every maturity and does not enforce that match.  The standalone function
 \texttt{spot} as the actual cash spot only when carry is absent or separately
 embedded; the chain wrapper removes the ambiguity by passing $D_TF_T$.
 
-The valuation core already implements the centered call and put formulas in
-this note.  Full code adoption nevertheless requires the following corrections
-and guardrails.
+The adopted all-$q$ model binds one exact maturity, uses prepaid-forward
+normalization, solves the martingale shift for each discount factor, and accepts
+only standard calls and puts.  The following guardrails also clarify the legacy
+symmetric helpers and the limits of a static terminal interpretation.
 \begin{enumerate}
   \item The model shock is an arithmetic relative-return shock, not a log
   return or a Black--Scholes volatility.  Student exponential moments do not
   exist, which is precisely why \eqref{eq:terminal_asset} is used instead of an
-  exponential price map.  The existing ``terminal log-returns'' descriptions
-  should be corrected, as should the ``normal implied vol'' description of the
-  Student-$t$ inversion routine.
+  exponential price map.  Implied volatilities in the adopted payload are Black
+  volatilities inferred from present-value option prices.
   \item The public density helpers accept a non-zero location parameter.  The
   terminal pricer always calls the CDF and partial-moment helpers with location
   zero and applies $\mu_T$ externally.  That centered route is exact.  For a
@@ -1368,20 +1355,18 @@ and guardrails.
   \texttt{mu*ttm*cdf}; this latent helper bug does not affect centered pricing.
   \item The quantity $\mu_T=(A_T-1)/T$ is a maturity-specific additive
   location compensation, not the drift coefficient of a continuous-time
-  return process.  A different maturity generally requires a different root.
+  return process.  A different maturity generally requires a different root;
+  both terminal adapters enforce the maturity bound in their parameters.
   \item Calling \texttt{compute\_vanilla\_price\_tdist} with
   \texttt{is\_compute\_risk\_neutral\_mu=False} and no explicit drift sets
   $\mu_T$ equal to the risk-free rate.  Because the floor itself has value,
   that fallback does not satisfy \eqref{eq:martingale_A} and should be rejected
   or clearly marked non-risk-neutral.
-  \item The raw pricer currently treats option types \texttt{IC} and
-  \texttt{IP} as ordinary calls and puts.  Elsewhere those labels denote
-  inverse payoffs.  The inverse put genuinely diverges at the
-  positive-probability atom $S_T=0$.  For $K>0$, the inverse call has a
-  removable $0/0$ value and continuous extension zero there, but it still
-  requires an explicit zero-state convention and an implementation guard.
-  The model should accept only \texttt{C}/\texttt{P} until those contracts are
-  defined separately.
+  \item The terminal adapters accept only \texttt{C}/\texttt{P}.  Legacy raw
+  kernels are not used to infer inverse \texttt{IC}/\texttt{IP} settlement.
+  The inverse put diverges at the positive-probability atom $S_T=0$, while the
+  inverse call still requires an explicit zero-state convention; those products
+  therefore remain outside this chapter.
   \item Calibration is performed one maturity at a time.  A stationary SDE
   interpretation would impose cross-maturity parameter restrictions that the
   current calibrator does not impose.
@@ -1449,6 +1434,20 @@ Duplicate-baseline curve error & $0$ \\
 \end{center}
 The comparisons use different numerical representations, rather than merely
 re-evaluating the same quadrature formula.
+
+From the repository root, the cited numerical payload, table, and two figures
+are regenerated with
+\begin{flushleft}\footnotesize
+\texttt{python -m }
+\path{volatility_book.ch_tdist_risk_premia.generate_tdist_risk_premia_figures}\\
+\hspace*{1em}\texttt{--profile canonical}
+\end{flushleft}
+The generator writes only below the ignored
+\path{outputs/volatility_book/ch_tdist_risk_premia/canonical} directory.
+Rendering an already validated payload is a separate guarded path and does not
+invoke pricing analytics.  The adoption verifier hash-checks the frozen oracle,
+compares all 12 scenarios and 29 strikes with the package model, and proves the
+payload-only rerender contract.
 
 \section{Conclusion}
 

--- a/volatility_book/ch_tdist_risk_premia/risk_premium_smile_examples.py
+++ b/volatility_book/ch_tdist_risk_premia/risk_premium_smile_examples.py
@@ -1,0 +1,743 @@
+"""Illustrate risk-premium effects in the inverse-gamma Student-t mixture.
+
+Under the physical measure,
+
+    V ~ IG(alpha_P, beta_P),       X | V ~ N(0, c V).
+
+The normalized terminal pricing kernel is
+
+    Z(V, X) = Z_{p, eta}(V) exp(q X / c - q^2 V / (2 c)),
+
+which gives, directly under the pricing measure,
+
+    V ~ IG(alpha_P - p, beta_P + eta),
+    X | V ~ N(q V, c V).
+
+The terminal asset is S_T = (A + X)^+ with forward one.  The script solves A
+separately in every scenario, prices calls by generalized Gauss-Laguerre
+quadrature, converts them to Black implied volatilities, validates the numerical
+prices independently, and writes the two vector figures used by the LaTeX note.
+
+Run from the repository root with
+
+    python volatility_book/ch_tdist_risk_premia/risk_premium_smile_examples.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import vanilla_option_pricers as bsm
+from matplotlib.ticker import PercentFormatter
+from scipy.integrate import quad
+from scipy.optimize import brentq
+from scipy.special import gammaln, kve, ndtr, roots_genlaguerre
+from scipy.stats import t as student_t
+
+CHAPTER_DIR = Path(__file__).resolve().parent
+DEFAULT_FIGURE_DIR = CHAPTER_DIR / "figures"
+
+
+@dataclass(frozen=True)
+class ModelSetup:
+    """Physical baseline and numerical controls for the one-period example."""
+
+    alpha_p: float = 4.0
+    beta_p: float = 0.12
+    c: float = 1.0
+    ttm: float = 1.0
+    forward: float = 1.0
+    quadrature_order: int = 256
+
+    @property
+    def physical_mean_v(self) -> float:
+        return self.beta_p / (self.alpha_p - 1.0)
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """One pricing-kernel parameter combination."""
+
+    panel: str
+    label: str
+    p: float = 0.0
+    eta: float = 0.0
+    q: float = 0.0
+
+
+@dataclass(frozen=True)
+class ScenarioResult:
+    """Smile and diagnostics for one scenario."""
+
+    scenario: Scenario
+    alpha_q: float
+    beta_q: float
+    mean_v: float
+    shift: float
+    default_probability: float
+    log_moneyness: np.ndarray
+    strikes: np.ndarray
+    call_prices: np.ndarray
+    implied_volatilities: np.ndarray
+    atm_iv: float
+    atm_skew: float
+    rr_025: float
+    bf_025: float
+
+
+def _normal_positive_part(mean: np.ndarray, stdev: np.ndarray) -> np.ndarray:
+    """Return E[(mean + stdev Z)^+] elementwise, including a stable left tail."""
+    d = mean / stdev
+    h = np.empty_like(d, dtype=float)
+    middle = np.abs(d) <= 8.0
+    right = d > 8.0
+    left = d < -8.0
+
+    middle_d = d[middle]
+    density = np.exp(-0.5 * middle_d * middle_d) / math.sqrt(2.0 * math.pi)
+    h[middle] = density + middle_d * ndtr(middle_d)
+    h[right] = d[right]
+
+    z = -d[left]
+    inverse_square = 1.0 / np.square(z)
+    mills_remainder = inverse_square * (
+        1.0
+        + inverse_square
+        * (
+            -3.0
+            + inverse_square
+            * (15.0 + inverse_square * (-105.0 + 945.0 * inverse_square))
+        )
+    )
+    h[left] = (
+        np.exp(-0.5 * z * z)
+        * mills_remainder
+        / math.sqrt(2.0 * math.pi)
+    )
+    return np.maximum(stdev * h, 0.0)
+
+
+class MixturePricer:
+    """One-dimensional conditional-normal pricer under the transformed Q law."""
+
+    def __init__(self, setup: ModelSetup, scenario: Scenario) -> None:
+        self.setup = setup
+        self.scenario = scenario
+        self.alpha_q = setup.alpha_p - scenario.p
+        self.beta_q = setup.beta_p + scenario.eta
+        if self.alpha_q <= 1.0:
+            raise ValueError("alpha_Q must exceed one for finite first moments")
+        if self.beta_q <= 0.0:
+            raise ValueError("beta_Q must be positive")
+
+        nodes, weights = roots_genlaguerre(
+            setup.quadrature_order,
+            self.alpha_q - 1.0,
+        )
+        self.weights = weights / np.sum(weights)
+        self.variances = self.beta_q / nodes
+        self.stdevs = np.sqrt(setup.c * self.variances)
+        self.conditional_means = scenario.q * self.variances
+        self.shift = self._solve_shift()
+
+    def expect_positive(self, intercept: float) -> float:
+        means = intercept + self.conditional_means
+        conditional_values = _normal_positive_part(means, self.stdevs)
+        return float(np.dot(self.weights, conditional_values))
+
+    def _solve_shift(self) -> float:
+        def objective(shift: float) -> float:
+            return self.expect_positive(shift) - self.setup.forward
+
+        lower, upper = -2.0, 2.0
+        while objective(lower) > 0.0:
+            lower *= 2.0
+        while objective(upper) < 0.0:
+            upper *= 2.0
+        return float(
+            brentq(objective, lower, upper, xtol=1.0e-13, rtol=1.0e-13)
+        )
+
+    def call_price(self, strike: float) -> float:
+        return self.expect_positive(self.shift - strike)
+
+    def put_price(self, strike: float) -> float:
+        raw_put = float(
+            np.dot(
+                self.weights,
+                _normal_positive_part(
+                    strike - self.shift - self.conditional_means,
+                    self.stdevs,
+                ),
+            )
+        )
+        floor_adjustment = float(
+            np.dot(
+                self.weights,
+                _normal_positive_part(
+                    -self.shift - self.conditional_means,
+                    self.stdevs,
+                ),
+            )
+        )
+        return raw_put - floor_adjustment
+
+    def default_probability(self) -> float:
+        d = (-self.shift - self.conditional_means) / self.stdevs
+        return float(np.dot(self.weights, ndtr(d)))
+
+    def mean_v(self) -> float:
+        return self.beta_q / (self.alpha_q - 1.0)
+
+
+def _direct_symmetric_student_call(
+    strike: float,
+    shift: float,
+    alpha_q: float,
+    beta_q: float,
+    c: float,
+) -> float:
+    """Independent q=0 Student partial-moment formula for validation."""
+    nu = 2.0 * alpha_q
+    scale = math.sqrt(c * beta_q / alpha_q)
+    threshold = (strike - shift) / scale
+    survival = student_t.sf(threshold, df=nu)
+    first_tail_moment = (
+        (nu + threshold * threshold)
+        * student_t.pdf(threshold, df=nu)
+        / (nu - 1.0)
+    )
+    return (shift - strike) * survival + scale * first_tail_moment
+
+
+def _skew_marginal_density(pricer: MixturePricer, shock: float) -> float:
+    """Evaluate the q != 0 Bessel-K marginal density in stable log form."""
+    q = pricer.scenario.q
+    if abs(q) < 1.0e-15:
+        raise ValueError("the skew marginal density requires non-zero q")
+
+    alpha = pricer.alpha_q
+    beta = pricer.beta_q
+    c = pricer.setup.c
+    radius_squared = shock * shock + 2.0 * beta * c
+    radius = math.sqrt(radius_squared)
+    bessel_argument = abs(q) * radius / c
+
+    if q * shock >= 0.0:
+        exponential_term = -2.0 * beta * abs(q) / (radius + abs(shock))
+    else:
+        exponential_term = -abs(q) * (radius + abs(shock)) / c
+
+    log_density = (
+        math.log(2.0)
+        + alpha * math.log(beta)
+        - gammaln(alpha)
+        - 0.5 * math.log(2.0 * math.pi * c)
+        + exponential_term
+        + 0.5
+        * (alpha + 0.5)
+        * (math.log(q * q) - math.log(radius_squared))
+        + math.log(kve(alpha + 0.5, bessel_argument))
+    )
+    return math.exp(log_density)
+
+
+def _direct_skew_marginal_call(pricer: MixturePricer, strike: float) -> float:
+    """Integrate the skew Bessel-K density, independently of conditional pricing."""
+    threshold = strike - pricer.shift
+
+    def integrand(shock: float) -> float:
+        payoff = pricer.shift + shock - strike
+        return max(payoff, 0.0) * _skew_marginal_density(pricer, shock)
+
+    value = 0.0
+    if threshold < 0.0:
+        value += quad(
+            integrand,
+            threshold,
+            0.0,
+            epsabs=2.0e-11,
+            epsrel=2.0e-11,
+            limit=300,
+        )[0]
+        threshold = 0.0
+    value += quad(
+        integrand,
+        threshold,
+        np.inf,
+        epsabs=2.0e-11,
+        epsrel=2.0e-11,
+        limit=300,
+    )[0]
+    return float(value)
+
+
+def _adaptive_call(pricer: MixturePricer, strike: float) -> float:
+    """Independent adaptive integral in the Gamma precision variable."""
+    intercept = pricer.shift - strike
+
+    def integrand(precision: float) -> float:
+        if precision <= 0.0:
+            return 0.0
+        variance = pricer.beta_q / precision
+        stdev = math.sqrt(pricer.setup.c * variance)
+        mean = intercept + pricer.scenario.q * variance
+        positive_part = float(
+            _normal_positive_part(np.array([mean]), np.array([stdev]))[0]
+        )
+        if positive_part == 0.0:
+            return 0.0
+        log_density = (
+            (pricer.alpha_q - 1.0) * math.log(precision)
+            - precision
+            - gammaln(pricer.alpha_q)
+        )
+        return math.exp(log_density) * positive_part
+
+    lower = quad(
+        integrand,
+        0.0,
+        1.0,
+        epsabs=2.0e-11,
+        epsrel=2.0e-11,
+        limit=300,
+    )[0]
+    upper = quad(
+        integrand,
+        1.0,
+        np.inf,
+        epsabs=2.0e-11,
+        epsrel=2.0e-11,
+        limit=300,
+    )[0]
+    return float(lower + upper)
+
+
+def _implied_volatility(
+    setup: ModelSetup,
+    strike: float,
+    call_price: float,
+) -> float:
+    return float(
+        bsm.infer_bsm_implied_vol(
+            forward=setup.forward,
+            ttm=setup.ttm,
+            strike=strike,
+            given_price=call_price,
+            discfactor=1.0,
+            optiontype="C",
+            tol=1.0e-12,
+            vol_lower=1.0e-8,
+            vol_upper=5.0,
+            is_bounds_to_nan=False,
+        )
+    )
+
+
+def compute_scenario(
+    setup: ModelSetup,
+    scenario: Scenario,
+    log_moneyness: np.ndarray,
+) -> tuple[ScenarioResult, MixturePricer]:
+    """Price one scenario and calculate smile diagnostics."""
+    pricer = MixturePricer(setup, scenario)
+    strikes = setup.forward * np.exp(log_moneyness)
+    call_prices = np.array([pricer.call_price(float(strike)) for strike in strikes])
+    implied_volatilities = np.array(
+        [
+            _implied_volatility(setup, float(strike), float(price))
+            for strike, price in zip(strikes, call_prices)
+        ]
+    )
+
+    atm_index = int(np.argmin(np.abs(log_moneyness)))
+    step = float(log_moneyness[atm_index + 1] - log_moneyness[atm_index])
+    atm_skew = float(
+        (
+            implied_volatilities[atm_index + 1]
+            - implied_volatilities[atm_index - 1]
+        )
+        / (2.0 * step)
+    )
+    left_index = int(np.argmin(np.abs(log_moneyness + 0.25)))
+    right_index = int(np.argmin(np.abs(log_moneyness - 0.25)))
+    rr_025 = float(
+        implied_volatilities[right_index] - implied_volatilities[left_index]
+    )
+    bf_025 = float(
+        0.5
+        * (
+            implied_volatilities[left_index]
+            + implied_volatilities[right_index]
+        )
+        - implied_volatilities[atm_index]
+    )
+
+    result = ScenarioResult(
+        scenario=scenario,
+        alpha_q=pricer.alpha_q,
+        beta_q=pricer.beta_q,
+        mean_v=pricer.mean_v(),
+        shift=pricer.shift,
+        default_probability=pricer.default_probability(),
+        log_moneyness=log_moneyness,
+        strikes=strikes,
+        call_prices=call_prices,
+        implied_volatilities=implied_volatilities,
+        atm_iv=float(implied_volatilities[atm_index]),
+        atm_skew=atm_skew,
+        rr_025=rr_025,
+        bf_025=bf_025,
+    )
+    return result, pricer
+
+
+def _raw_scenarios() -> tuple[Scenario, ...]:
+    return (
+        Scenario("p", "p = -0.75", p=-0.75),
+        Scenario("p", "p = 0"),
+        Scenario("p", "p = +0.75", p=0.75),
+        Scenario("eta", "eta = -0.024", eta=-0.024),
+        Scenario("eta", "eta = 0"),
+        Scenario("eta", "eta = +0.024", eta=0.024),
+        Scenario("q", "q = -2", q=-2.0),
+        Scenario("q", "q = 0"),
+        Scenario("q", "q = +2", q=2.0),
+    )
+
+
+def _fixed_variance_p_scenarios(setup: ModelSetup) -> tuple[Scenario, ...]:
+    mean_v = setup.physical_mean_v
+    return tuple(
+        Scenario(
+            "p_fixed_variance",
+            (
+                "p = 0, eta = 0"
+                if abs(p) < 1.0e-15
+                else f"p = {p:+.2f}, eta = {-mean_v * p:+.3f}"
+            ),
+            p=p,
+            eta=-mean_v * p,
+        )
+        for p in (-0.75, 0.0, 0.75)
+    )
+
+
+def compute_examples(
+    setup: ModelSetup,
+) -> tuple[list[ScenarioResult], list[ScenarioResult], dict[str, float]]:
+    """Compute raw and variance-neutral examples and all validation diagnostics."""
+    log_moneyness = np.linspace(-0.35, 0.35, 29)
+    scenarios = _raw_scenarios() + _fixed_variance_p_scenarios(setup)
+    results: list[ScenarioResult] = []
+    pricers: list[MixturePricer] = []
+    for scenario in scenarios:
+        result, pricer = compute_scenario(setup, scenario, log_moneyness)
+        results.append(result)
+        pricers.append(pricer)
+
+    martingale_errors: list[float] = []
+    independent_martingale_errors: list[float] = []
+    parity_errors: list[float] = []
+    symmetric_errors: list[float] = []
+    adaptive_errors: list[float] = []
+    marginal_density_errors: list[float] = []
+    black_errors: list[float] = []
+    convergence_errors: list[float] = []
+    monotonicity_violations: list[float] = []
+    convexity_violations: list[float] = []
+
+    for result, pricer in zip(results, pricers):
+        martingale_errors.append(abs(pricer.call_price(0.0) - setup.forward))
+        if abs(result.scenario.q) < 1.0e-15:
+            independent_forward = _direct_symmetric_student_call(
+                0.0,
+                pricer.shift,
+                pricer.alpha_q,
+                pricer.beta_q,
+                setup.c,
+            )
+        else:
+            independent_forward = _direct_skew_marginal_call(pricer, 0.0)
+        independent_martingale_errors.append(
+            abs(independent_forward - setup.forward)
+        )
+        monotonicity_violations.append(
+            float(max(0.0, np.max(np.diff(result.call_prices))))
+        )
+        slopes = np.diff(result.call_prices) / np.diff(result.strikes)
+        convexity_violations.append(float(max(0.0, -np.min(np.diff(slopes)))))
+        for strike, call, volatility in zip(
+            result.strikes,
+            result.call_prices,
+            result.implied_volatilities,
+        ):
+            put = pricer.put_price(float(strike))
+            parity_errors.append(abs(call - put - (setup.forward - strike)))
+            repriced = bsm.compute_bsm_vanilla_price(
+                forward=setup.forward,
+                strike=float(strike),
+                ttm=setup.ttm,
+                vol=float(volatility),
+                optiontype="C",
+                discfactor=1.0,
+            )
+            black_errors.append(abs(float(repriced) - call))
+            if abs(result.scenario.q) < 1.0e-15:
+                reference = _direct_symmetric_student_call(
+                    float(strike),
+                    pricer.shift,
+                    pricer.alpha_q,
+                    pricer.beta_q,
+                    setup.c,
+                )
+                symmetric_errors.append(abs(float(call) - reference))
+
+        if abs(result.scenario.q) > 1.0e-15:
+            for strike in (math.exp(-0.25), 1.0, math.exp(0.25)):
+                adaptive_errors.append(
+                    abs(pricer.call_price(strike) - _adaptive_call(pricer, strike))
+                )
+                marginal_density_errors.append(
+                    abs(
+                        pricer.call_price(strike)
+                        - _direct_skew_marginal_call(pricer, strike)
+                    )
+                )
+
+        lower_order = MixturePricer(
+            replace(setup, quadrature_order=128),
+            result.scenario,
+        )
+        convergence_errors.extend(
+            abs(pricer.call_price(float(strike)) - lower_order.call_price(float(strike)))
+            for strike in (math.exp(-0.25), 1.0, math.exp(0.25))
+        )
+
+    validation = {
+        "max_martingale_error": max(martingale_errors),
+        "max_independent_martingale_error": max(independent_martingale_errors),
+        "max_put_call_parity_error": max(parity_errors),
+        "max_symmetric_closed_form_error": max(symmetric_errors),
+        "max_adaptive_integration_error": max(adaptive_errors),
+        "max_marginal_density_integration_error": max(marginal_density_errors),
+        "max_black_round_trip_error": max(black_errors),
+        "max_128_vs_256_node_error": max(convergence_errors),
+        "max_call_monotonicity_violation": max(monotonicity_violations),
+        "max_call_convexity_violation": max(convexity_violations),
+    }
+    fixed_results = results[9:]
+    validation["max_variance_neutral_mean_v_error"] = max(
+        abs(result.mean_v - setup.physical_mean_v) for result in fixed_results
+    )
+    baseline_results = [
+        result
+        for result in results
+        if abs(result.scenario.p) < 1.0e-15
+        and abs(result.scenario.eta) < 1.0e-15
+        and abs(result.scenario.q) < 1.0e-15
+    ]
+    baseline_curve = baseline_results[0].implied_volatilities
+    validation["max_duplicate_baseline_curve_error"] = max(
+        float(np.max(np.abs(result.implied_volatilities - baseline_curve)))
+        for result in baseline_results[1:]
+    )
+    return results[:9], results[9:], validation
+
+
+def _enforce_validation(validation: dict[str, float]) -> None:
+    thresholds = {
+        "max_martingale_error": 1.0e-10,
+        "max_independent_martingale_error": 1.0e-7,
+        "max_put_call_parity_error": 1.0e-10,
+        "max_symmetric_closed_form_error": 5.0e-8,
+        "max_adaptive_integration_error": 5.0e-8,
+        "max_marginal_density_integration_error": 1.0e-7,
+        "max_black_round_trip_error": 1.0e-10,
+        "max_128_vs_256_node_error": 3.0e-7,
+        "max_call_monotonicity_violation": 1.0e-12,
+        "max_call_convexity_violation": 1.0e-12,
+        "max_variance_neutral_mean_v_error": 1.0e-13,
+        "max_duplicate_baseline_curve_error": 1.0e-13,
+    }
+    failures = {
+        name: (validation[name], threshold)
+        for name, threshold in thresholds.items()
+        if validation[name] > threshold
+    }
+    if failures:
+        details = ", ".join(
+            f"{name}={value:.3e}>{threshold:.3e}"
+            for name, (value, threshold) in failures.items()
+        )
+        raise RuntimeError(f"risk-premium example validation failed: {details}")
+
+
+def _configure_figure_style() -> None:
+    plt.rcParams.update(
+        {
+            "font.size": 9.0,
+            "axes.titlesize": 10.0,
+            "axes.labelsize": 9.0,
+            "legend.fontsize": 7.0,
+            "xtick.labelsize": 8.0,
+            "ytick.labelsize": 8.0,
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+            "figure.dpi": 150,
+            "savefig.dpi": 300,
+            "pdf.fonttype": 42,
+        }
+    )
+
+
+def _legend_label(scenario: Scenario) -> str:
+    def signed(value: float, digits: int) -> str:
+        return "0" if abs(value) < 1.0e-15 else f"{value:+.{digits}f}"
+
+    if scenario.panel == "p":
+        return rf"$p={signed(scenario.p, 2)}$"
+    if scenario.panel == "eta":
+        return rf"$\eta={signed(scenario.eta, 3)}$"
+    if scenario.panel == "q":
+        return rf"$q={signed(scenario.q, 0)}$"
+    return (
+        rf"$p={signed(scenario.p, 2)},\ "
+        rf"\eta={signed(scenario.eta, 3)}$"
+    )
+
+
+def _save_raw_figure(results: list[ScenarioResult], output_path: Path) -> None:
+    _configure_figure_style()
+    colors = ("#2878B5", "#F28E2B", "#3AA255")
+    linestyles = ("-", "--", ":")
+    panel_specs = (
+        ("p", r"$p$: tails and variance"),
+        ("eta", r"$\eta$: variance level"),
+        ("q", r"$q$: skew direction"),
+    )
+    figure, axes = plt.subplots(1, 3, figsize=(8.4, 2.9), sharex=True, sharey=True)
+    for axis, (panel, title) in zip(axes, panel_specs):
+        panel_results = [result for result in results if result.scenario.panel == panel]
+        for result, color, linestyle in zip(panel_results, colors, linestyles):
+            axis.plot(
+                result.log_moneyness,
+                result.implied_volatilities,
+                color=color,
+                linestyle=linestyle,
+                linewidth=1.8,
+                label=_legend_label(result.scenario),
+            )
+        axis.axvline(0.0, color="0.75", linewidth=0.7, zorder=0)
+        axis.grid(color="0.88", linewidth=0.6)
+        axis.set_title(title)
+        axis.set_xlabel(r"log-moneyness $k=\log(K/F)$")
+        axis.legend(frameon=False, loc="upper right")
+    axes[0].set_ylabel("Black implied volatility")
+    axes[0].yaxis.set_major_formatter(PercentFormatter(1.0))
+    axes[0].set_ylim(0.155, 0.285)
+    figure.tight_layout(w_pad=1.0)
+    figure.savefig(
+        output_path,
+        bbox_inches="tight",
+        metadata={"Title": "Risk-premium parameters and the Black implied-volatility smile"},
+    )
+    plt.close(figure)
+
+
+def _save_fixed_variance_figure(
+    results: list[ScenarioResult],
+    output_path: Path,
+) -> None:
+    _configure_figure_style()
+    colors = ("#2878B5", "#F28E2B", "#3AA255")
+    linestyles = ("-", "--", ":")
+    figure, axis = plt.subplots(figsize=(5.8, 3.45))
+    for result, color, linestyle in zip(results, colors, linestyles):
+        axis.plot(
+            result.log_moneyness,
+            result.implied_volatilities,
+            color=color,
+            linestyle=linestyle,
+            linewidth=1.9,
+            label=_legend_label(result.scenario),
+        )
+    axis.axvline(0.0, color="0.75", linewidth=0.7, zorder=0)
+    axis.grid(color="0.88", linewidth=0.6)
+    axis.set_title(r"Tail premium $p$ with $E_Q[V]=4\%$ held fixed")
+    axis.set_xlabel(r"log-moneyness $k=\log(K/F)$")
+    axis.set_ylabel("Black implied volatility")
+    axis.yaxis.set_major_formatter(PercentFormatter(1.0))
+    axis.legend(frameon=False, loc="upper right")
+    figure.tight_layout()
+    figure.savefig(
+        output_path,
+        bbox_inches="tight",
+        metadata={"Title": "Tail-risk premium at fixed mean variance"},
+    )
+    plt.close(figure)
+
+
+def _print_results(
+    raw_results: list[ScenarioResult],
+    fixed_results: list[ScenarioResult],
+    validation: dict[str, float],
+) -> None:
+    print(
+        "scenario                E[V]       A        p0       ATM       skew     RRk.25    BFk.25"
+    )
+    print("-" * 98)
+    for result in raw_results + fixed_results:
+        print(
+            f"{result.scenario.label:<23} "
+            f"{result.mean_v:>7.4f} "
+            f"{result.shift:>8.5f} "
+            f"{result.default_probability:>8.2e} "
+            f"{result.atm_iv:>8.4f} "
+            f"{result.atm_skew:>9.4f} "
+            f"{result.rr_025:>9.4f} "
+            f"{result.bf_025:>9.4f}"
+        )
+    print("\nvalidation")
+    for name, value in validation.items():
+        print(f"{name}: {value:.6e}")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate Student-t risk-premium implied-volatility figures."
+    )
+    parser.add_argument(
+        "--figure-dir",
+        type=Path,
+        default=DEFAULT_FIGURE_DIR,
+        help="Output directory for the two PDF figures.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    args.figure_dir.mkdir(parents=True, exist_ok=True)
+    setup = ModelSetup()
+    raw_results, fixed_results, validation = compute_examples(setup)
+    _enforce_validation(validation)
+    _save_raw_figure(raw_results, args.figure_dir / "risk_premium_smiles.pdf")
+    _save_fixed_variance_figure(
+        fixed_results,
+        args.figure_dir / "p_tail_premium_fixed_variance.pdf",
+    )
+    _print_results(raw_results, fixed_results, validation)
+
+
+if __name__ == "__main__":
+    main()

--- a/volatility_book/ch_tdist_risk_premia/source_provenance.json
+++ b/volatility_book/ch_tdist_risk_premia/source_provenance.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "snapshot_kind": "first_tracked_snapshot_of_untracked_maintainer_working_files",
+  "snapshot_date": "2026-08-25",
+  "package_baseline_commit": "580246b4029ee22a396f9bccab88a4392716f406",
+  "authority": {
+    "selected_candidate": "maintainer checkout volatility_book/ch_tdist_risk_premia",
+    "historical_git_ref": null,
+    "statement": "These hashes identify the maintainer-approved source candidate. They do not establish historical Git provenance before this snapshot."
+  },
+  "files": [
+    {
+      "path": "risk_premium_smile_examples.py",
+      "bytes": 23960,
+      "sha256_raw": "4e6f4a6700c3d63ed4981be962ce3fa73a09475607ea7aaeb5457cbb2f3b6533",
+      "sha256_lf": "4e6f4a6700c3d63ed4981be962ce3fa73a09475607ea7aaeb5457cbb2f3b6533"
+    },
+    {
+      "path": "notes/tdist_risk_premia_note.tex",
+      "bytes": 60665,
+      "sha256_raw": "49d2cd1182727675e79facbaca5e4bba8721e3af4a2177e264a72305079e169a",
+      "sha256_lf": "49d2cd1182727675e79facbaca5e4bba8721e3af4a2177e264a72305079e169a"
+    }
+  ],
+  "reference_authorities": {
+    "static_inverse_gamma_note_sha256": "64530ea0b11063b4d82040d105ae050a974fd670f64d23797a7f345a05128be1",
+    "earlier_valuation_tdistribution_note_sha256": "cd6513e60e0f030c4f7862336b4690c72be5ec79b8cbf731e268155106f22558",
+    "earlier_script_sha256": "01c5b3bd5c53b1432af1badff47b117d34265f4f349568d620ae8566cfc9d6f7",
+    "earlier_json_sha256": "17208ce6dacdc780d4a5a400af5a1e51d09ca0dae2cddbd06d742881fe22fcfd"
+  },
+  "known_gaps": [
+    "The note predates the accepted T2 Student-t terminal adapter and contains stale package-interface commentary.",
+    "The script writes figures beside chapter source; adoption must route generated outputs beneath the ignored outputs directory.",
+    "The TeX note requires two generated figures that are intentionally excluded from this source snapshot."
+  ],
+  "excluded_as_generated_or_reference_only": [
+    "figures/*",
+    "notes/*.aux",
+    "notes/*.log",
+    "notes/*.out",
+    "notes/*.pdf",
+    "notes/*.toc",
+    "notes/*.synctex.gz",
+    "notes/*.fls",
+    "notes/*.fdb_latexmk",
+    "__pycache__/*",
+    "*.py[cod]"
+  ]
+}

--- a/volatility_book/ch_tdist_risk_premia/tdist_risk_premia_chapter.py
+++ b/volatility_book/ch_tdist_risk_premia/tdist_risk_premia_chapter.py
@@ -1,0 +1,884 @@
+"""Package-routed analytics and portable payloads for the Student risk-premia chapter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+from dataclasses import asdict, dataclass, replace
+from enum import Enum
+from numbers import Real
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+import numpy as np
+import vanilla_option_pricers as bsm
+
+from stochvolmodels.data.option_chain import OptionSlice
+from stochvolmodels.fitters.tdist import imply_drift_tdist
+from stochvolmodels.models.inverse_gamma_normal import (
+    InverseGammaNormalParams,
+    InverseGammaNormalTerminalModel,
+)
+from stochvolmodels.pricers.tdist_pricer import TdistParams, TdistTerminalModel
+
+CHAPTER_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+ACCEPTANCE_MANIFEST = CHAPTER_DIR / "acceptance_manifest.json"
+DEFAULT_OUTPUT_ROOT = REPOSITORY_ROOT / "outputs" / "volatility_book" / "ch_tdist_risk_premia"
+PAYLOAD_FILENAME = "numerical_payload.json"
+ARTIFACT_MANIFEST_FILENAME = "artifact_manifest.json"
+FORBID_RECOMPUTE_ENV = "STOCHVOLMODELS_TDIST_RISK_PREMIA_FORBID_RECOMPUTE"
+PAYLOAD_SCHEMA_VERSION = 1
+EXPECTED_CURVE_CAPTURE_SHA256 = "2f78c1e678774f692946fc37f97496c754a0f306604af136d5800a342fbefeae"
+LOG_MONEYNESS = np.linspace(-0.35, 0.35, 29)
+EXPECTED_SCENARIO_IDS = (
+    "p_minus",
+    "baseline_p",
+    "p_plus",
+    "eta_minus",
+    "baseline_eta",
+    "eta_plus",
+    "q_minus",
+    "baseline_q",
+    "q_plus",
+    "p_fixed_minus",
+    "baseline_fixed",
+    "p_fixed_plus",
+)
+VALIDATION_THRESHOLDS = {
+    "max_put_call_parity_error": 1.0e-12,
+    "max_black_round_trip_error": 1.0e-12,
+    "max_128_vs_256_node_error": 3.0e-7,
+    "max_symmetric_student_price_error": 5.0e-8,
+    "max_symmetric_student_iv_error": 1.0e-6,
+    "max_nonunit_discount_student_error": 4.0e-6,
+    "max_call_monotonicity_violation": 1.0e-12,
+    "max_call_convexity_violation": 1.0e-12,
+    "max_variance_neutral_mean_v_error": 1.0e-13,
+    "max_duplicate_baseline_curve_error": 1.0e-13,
+}
+
+
+class ChapterProfile(str, Enum):
+    """Supported output profiles for the deterministic chapter pipeline."""
+
+    CANONICAL = "canonical"
+
+
+@dataclass(frozen=True, slots=True)
+class ModelSetup:
+    """Physical baseline and pricing conventions for the one-period example."""
+
+    alpha_p: float = 4.0
+    beta_p: float = 0.12
+    c: float = 1.0
+    ttm: float = 1.0
+    forward: float = 1.0
+    discfactor: float = 1.0
+    quadrature_order: int = 256
+
+    @property
+    def physical_mean_v(self) -> float:
+        """Return the physical inverse-gamma mean."""
+
+        return self.beta_p / (self.alpha_p - 1.0)
+
+
+@dataclass(frozen=True, slots=True)
+class Scenario:
+    """One chapter-owned pricing-kernel parameter combination."""
+
+    identifier: str
+    panel: str
+    label: str
+    p: float = 0.0
+    eta: float = 0.0
+    q: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioResult:
+    """Package-computed smile and diagnostics for one scenario."""
+
+    scenario: Scenario
+    alpha_q: float
+    beta_q: float
+    mean_v: float
+    shift: float
+    default_probability: float
+    log_moneyness: np.ndarray
+    strikes: np.ndarray
+    call_prices: np.ndarray
+    implied_volatilities: np.ndarray
+    atm_iv: float
+    atm_skew: float
+    rr_025: float
+    bf_025: float
+
+
+def as_profile(value: ChapterProfile | str) -> ChapterProfile:
+    """Return a validated chapter profile."""
+
+    if isinstance(value, ChapterProfile):
+        return value
+    try:
+        return ChapterProfile(str(value))
+    except ValueError as error:
+        choices = ", ".join(profile.value for profile in ChapterProfile)
+        raise ValueError(f"profile must be one of: {choices}") from error
+
+
+def default_output_directory(profile: ChapterProfile | str) -> Path:
+    """Return the ignored output directory for ``profile``."""
+
+    return DEFAULT_OUTPUT_ROOT / as_profile(profile).value
+
+
+def _assert_recompute_allowed() -> None:
+    if os.environ.get(FORBID_RECOMPUTE_ENV) == "1":
+        raise RuntimeError(f"numerical recomputation forbidden by {FORBID_RECOMPUTE_ENV}=1")
+
+
+def validate_output_directory(path: Path | str) -> Path:
+    """Resolve output and confine repository-local artifacts to the ignored root."""
+
+    output = Path(path).expanduser().resolve()
+    repository = REPOSITORY_ROOT.resolve()
+    try:
+        repository.relative_to(output)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("output directory must not equal or contain the repository root")
+    try:
+        output.relative_to(repository)
+    except ValueError:
+        return output
+    try:
+        output.relative_to(DEFAULT_OUTPUT_ROOT.resolve())
+    except ValueError as error:
+        raise ValueError(
+            f"repository-local Student risk-premia artifacts must be below {DEFAULT_OUTPUT_ROOT}"
+        ) from error
+    return output
+
+
+def raw_scenarios() -> tuple[Scenario, ...]:
+    """Return the nine direct comparative-static scenarios in display order."""
+
+    return (
+        Scenario("p_minus", "p", "p = -0.75", p=-0.75),
+        Scenario("baseline_p", "p", "p = 0"),
+        Scenario("p_plus", "p", "p = +0.75", p=0.75),
+        Scenario("eta_minus", "eta", "eta = -0.024", eta=-0.024),
+        Scenario("baseline_eta", "eta", "eta = 0"),
+        Scenario("eta_plus", "eta", "eta = +0.024", eta=0.024),
+        Scenario("q_minus", "q", "q = -2", q=-2.0),
+        Scenario("baseline_q", "q", "q = 0"),
+        Scenario("q_plus", "q", "q = +2", q=2.0),
+    )
+
+
+def fixed_variance_scenarios(setup: ModelSetup) -> tuple[Scenario, ...]:
+    """Return the three tail-premium scenarios with pricing mean variance fixed."""
+
+    mean_v = setup.physical_mean_v
+    return tuple(
+        Scenario(
+            ("p_fixed_minus" if p < 0.0 else "p_fixed_plus" if p > 0.0 else "baseline_fixed"),
+            "p_fixed_variance",
+            ("p = 0, eta = 0" if abs(p) < 1.0e-15 else f"p = {p:+.2f}, eta = {-mean_v * p:+.3f}"),
+            p=p,
+            eta=-mean_v * p,
+        )
+        for p in (-0.75, 0.0, 0.75)
+    )
+
+
+def pricing_law(setup: ModelSetup, scenario: Scenario) -> InverseGammaNormalTerminalModel:
+    """Map chapter economics to the package-owned risk-neutral terminal law."""
+
+    _assert_recompute_allowed()
+    return InverseGammaNormalTerminalModel(
+        InverseGammaNormalParams(
+            alpha=setup.alpha_p - scenario.p,
+            beta=setup.beta_p + scenario.eta,
+            c=setup.c,
+            q=scenario.q,
+            ttm=setup.ttm,
+        ),
+        quadrature_order=setup.quadrature_order,
+    )
+
+
+def _option_slice(
+    setup: ModelSetup,
+    strikes: np.ndarray,
+    optiontypes: np.ndarray,
+    *,
+    identifier: str,
+) -> OptionSlice:
+    return OptionSlice(
+        ttm=setup.ttm,
+        forward=setup.forward,
+        strikes=np.asarray(strikes, dtype=float),
+        optiontypes=np.asarray(optiontypes),
+        discfactor=setup.discfactor,
+        id=identifier,
+    )
+
+
+def _smile_statistics(
+    log_moneyness: np.ndarray,
+    implied_volatilities: np.ndarray,
+) -> tuple[float, float, float, float]:
+    """Return ATM IV, local ATM slope, fixed-log-moneyness RR and BF."""
+
+    atm_index = int(np.argmin(np.abs(log_moneyness)))
+    step = float(log_moneyness[atm_index + 1] - log_moneyness[atm_index])
+    left_index = int(np.argmin(np.abs(log_moneyness + 0.25)))
+    right_index = int(np.argmin(np.abs(log_moneyness - 0.25)))
+    atm_skew = float(
+        (implied_volatilities[atm_index + 1] - implied_volatilities[atm_index - 1]) / (2.0 * step)
+    )
+    rr_025 = float(implied_volatilities[right_index] - implied_volatilities[left_index])
+    bf_025 = float(
+        0.5 * (implied_volatilities[left_index] + implied_volatilities[right_index])
+        - implied_volatilities[atm_index]
+    )
+    return float(implied_volatilities[atm_index]), atm_skew, rr_025, bf_025
+
+
+def compute_scenario(
+    setup: ModelSetup,
+    scenario: Scenario,
+    log_moneyness: np.ndarray = LOG_MONEYNESS,
+) -> ScenarioResult:
+    """Compute one scenario entirely through the package terminal-law interface."""
+
+    _assert_recompute_allowed()
+    model = pricing_law(setup, scenario)
+    log_strikes = np.asarray(log_moneyness, dtype=float)
+    strikes = setup.forward * np.exp(log_strikes)
+    option_slice = _option_slice(
+        setup,
+        strikes,
+        np.full(strikes.size, "C"),
+        identifier=f"tdist-risk-premia-{scenario.identifier}",
+    )
+    calls = model.price_european(option_slice)
+    implied_volatilities = model.implied_vols(option_slice)
+    atm_iv, atm_skew, rr_025, bf_025 = _smile_statistics(log_strikes, implied_volatilities)
+    return ScenarioResult(
+        scenario=scenario,
+        alpha_q=model.params.alpha,
+        beta_q=model.params.beta,
+        mean_v=model.mean_mixing_variance,
+        shift=model.martingale_shift(discfactor=setup.discfactor),
+        default_probability=model.default_probability(discfactor=setup.discfactor),
+        log_moneyness=log_strikes,
+        strikes=strikes,
+        call_prices=calls,
+        implied_volatilities=implied_volatilities,
+        atm_iv=atm_iv,
+        atm_skew=atm_skew,
+        rr_025=rr_025,
+        bf_025=bf_025,
+    )
+
+
+def _student_reference_model(
+    params: InverseGammaNormalParams,
+    *,
+    discfactor: float,
+) -> TdistTerminalModel:
+    rf_rate = -math.log(discfactor) / params.ttm
+    vol = math.sqrt(params.c * params.beta / ((params.alpha - 1.0) * params.ttm))
+    nu = 2.0 * params.alpha
+    drift = imply_drift_tdist(rf_rate=rf_rate, vol=vol, nu=nu, ttm=params.ttm)
+    return TdistTerminalModel(TdistParams(drift=drift, vol=vol, nu=nu, ttm=params.ttm))
+
+
+def _nonunit_discount_student_error() -> float:
+    setup = ModelSetup(ttm=0.75, forward=105.0, discfactor=0.96)
+    scenario = Scenario("nonunit_discount", "validation", "non-unit discount")
+    model = pricing_law(setup, scenario)
+    strikes = setup.forward * np.exp(np.array([-0.20, 0.0, 0.20]))
+    option_slice = _option_slice(
+        setup,
+        strikes,
+        np.array(["P", "C", "C"]),
+        identifier="tdist-risk-premia-nonunit-discount",
+    )
+    student = _student_reference_model(model.params, discfactor=setup.discfactor)
+    return float(
+        np.max(np.abs(model.price_european(option_slice) - student.price_european(option_slice)))
+    )
+
+
+def _validation_metrics(setup: ModelSetup, results: Sequence[ScenarioResult]) -> dict[str, float]:
+    parity_errors: list[float] = []
+    black_errors: list[float] = []
+    refinement_errors: list[float] = []
+    student_price_errors: list[float] = []
+    student_iv_errors: list[float] = []
+    monotonicity_violations: list[float] = []
+    convexity_violations: list[float] = []
+
+    unique_results: dict[tuple[float, float, float], ScenarioResult] = {}
+    for result in results:
+        unique_results.setdefault((result.alpha_q, result.beta_q, result.scenario.q), result)
+
+    for result in unique_results.values():
+        model = pricing_law(setup, result.scenario)
+        put_slice = _option_slice(
+            setup,
+            result.strikes,
+            np.full(result.strikes.size, "P"),
+            identifier=f"tdist-risk-premia-{result.scenario.identifier}-puts",
+        )
+        puts = model.price_european(put_slice)
+        parity_errors.extend(
+            np.abs(result.call_prices - puts - setup.discfactor * (setup.forward - result.strikes))
+        )
+        repriced = np.array(
+            [
+                bsm.compute_bsm_vanilla_price(
+                    forward=setup.forward,
+                    strike=float(strike),
+                    ttm=setup.ttm,
+                    vol=float(volatility),
+                    optiontype="C",
+                    discfactor=setup.discfactor,
+                )
+                for strike, volatility in zip(
+                    result.strikes,
+                    result.implied_volatilities,
+                )
+            ],
+            dtype=float,
+        )
+        black_errors.extend(np.abs(np.asarray(repriced, dtype=float) - result.call_prices))
+        monotonicity_violations.append(float(max(0.0, np.max(np.diff(result.call_prices)))))
+        slopes = np.diff(result.call_prices) / np.diff(result.strikes)
+        convexity_violations.append(float(max(0.0, -np.min(np.diff(slopes)))))
+
+        lower_setup = ModelSetup(**{**asdict(setup), "quadrature_order": 128})
+        lower_model = pricing_law(lower_setup, result.scenario)
+        selected = np.array([math.exp(-0.25), 1.0, math.exp(0.25)]) * setup.forward
+        selected_slice = _option_slice(
+            setup,
+            selected,
+            np.full(selected.size, "C"),
+            identifier=f"tdist-risk-premia-{result.scenario.identifier}-refinement",
+        )
+        refinement_errors.extend(
+            np.abs(
+                model.price_european(selected_slice) - lower_model.price_european(selected_slice)
+            )
+        )
+
+        if abs(result.scenario.q) < 1.0e-15:
+            call_slice = _option_slice(
+                setup,
+                result.strikes,
+                np.full(result.strikes.size, "C"),
+                identifier=f"tdist-risk-premia-{result.scenario.identifier}-student",
+            )
+            student = _student_reference_model(model.params, discfactor=setup.discfactor)
+            student_price_errors.extend(
+                np.abs(student.price_european(call_slice) - result.call_prices)
+            )
+            student_iv_errors.extend(
+                np.abs(student.implied_vols(call_slice) - result.implied_volatilities)
+            )
+
+    fixed = results[9:]
+    baseline = [
+        result
+        for result in results
+        if abs(result.scenario.p) < 1.0e-15
+        and abs(result.scenario.eta) < 1.0e-15
+        and abs(result.scenario.q) < 1.0e-15
+    ]
+    return {
+        "max_put_call_parity_error": float(max(parity_errors)),
+        "max_black_round_trip_error": float(max(black_errors)),
+        "max_128_vs_256_node_error": float(max(refinement_errors)),
+        "max_symmetric_student_price_error": float(max(student_price_errors)),
+        "max_symmetric_student_iv_error": float(max(student_iv_errors)),
+        "max_nonunit_discount_student_error": _nonunit_discount_student_error(),
+        "max_call_monotonicity_violation": max(monotonicity_violations),
+        "max_call_convexity_violation": max(convexity_violations),
+        "max_variance_neutral_mean_v_error": max(
+            abs(result.mean_v - setup.physical_mean_v) for result in fixed
+        ),
+        "max_duplicate_baseline_curve_error": max(
+            float(np.max(np.abs(result.implied_volatilities - baseline[0].implied_volatilities)))
+            for result in baseline[1:]
+        ),
+    }
+
+
+def enforce_validation(validation: dict[str, float]) -> None:
+    """Raise when a package or book-production acceptance limit is exceeded."""
+
+    failures = {
+        name: (validation[name], threshold)
+        for name, threshold in VALIDATION_THRESHOLDS.items()
+        if not np.isfinite(validation[name])
+        or validation[name] < 0.0
+        or validation[name] > threshold
+    }
+    if failures:
+        details = ", ".join(
+            f"{name}={value:.3e} outside [0,{threshold:.3e}]"
+            for name, (value, threshold) in failures.items()
+        )
+        raise RuntimeError(f"Student risk-premia validation failed: {details}")
+
+
+def compute_examples(
+    setup: ModelSetup | None = None,
+) -> tuple[list[ScenarioResult], dict[str, float]]:
+    """Compute all 12 chapter scenarios and package-owned validation metrics."""
+
+    _assert_recompute_allowed()
+    selected_setup = ModelSetup() if setup is None else setup
+    scenarios = raw_scenarios() + fixed_variance_scenarios(selected_setup)
+    cached_results: dict[tuple[float, float, float], ScenarioResult] = {}
+    results = []
+    for scenario in scenarios:
+        key = (
+            selected_setup.alpha_p - scenario.p,
+            selected_setup.beta_p + scenario.eta,
+            scenario.q,
+        )
+        if key not in cached_results:
+            cached_results[key] = compute_scenario(selected_setup, scenario)
+        results.append(replace(cached_results[key], scenario=scenario))
+    validation = _validation_metrics(selected_setup, results)
+    enforce_validation(validation)
+    return results, validation
+
+
+def curve_capture(results: Sequence[ScenarioResult]) -> dict[str, Any]:
+    """Return the portable rounded capture used by the frozen acceptance hash."""
+
+    return {
+        "log_moneyness": np.round(results[0].log_moneyness, 8).tolist(),
+        "records": [
+            {
+                "alpha": round(result.alpha_q, 12),
+                "beta": round(result.beta_q, 12),
+                "q": round(result.scenario.q, 12),
+                "shift": round(result.shift, 12),
+                "default_probability": round(result.default_probability, 12),
+                "call_prices": np.round(result.call_prices, 10).tolist(),
+                "implied_volatilities": np.round(result.implied_volatilities, 10).tolist(),
+            }
+            for result in results
+        ],
+    }
+
+
+def _compact_sha256(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _result_payload(result: ScenarioResult) -> dict[str, Any]:
+    return {
+        "scenario": asdict(result.scenario),
+        "alpha_q": result.alpha_q,
+        "beta_q": result.beta_q,
+        "mean_v": result.mean_v,
+        "shift": result.shift,
+        "default_probability": result.default_probability,
+        "log_moneyness": result.log_moneyness.tolist(),
+        "strikes": result.strikes.tolist(),
+        "call_prices": result.call_prices.tolist(),
+        "implied_volatilities": result.implied_volatilities.tolist(),
+        "atm_iv": result.atm_iv,
+        "atm_skew": result.atm_skew,
+        "rr_025": result.rr_025,
+        "bf_025": result.bf_025,
+    }
+
+
+def _validate_finite_json(value: Any, location: str = "payload") -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _validate_finite_json(item, f"{location}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_finite_json(item, f"{location}[{index}]")
+    elif isinstance(value, float) and not math.isfinite(value):
+        raise ValueError(f"{location} is non-finite")
+
+
+def _require_exact_keys(value: Any, expected: set[str], location: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TypeError(f"{location} must be a dictionary")
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise ValueError(f"{location} keys differ: missing={missing}, extra={extra}")
+    return value
+
+
+def _finite_number(value: Any, location: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise TypeError(f"{location} must be a JSON number, not {type(value).__name__}")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{location} is non-finite")
+    return number
+
+
+def _finite_vector(value: Any, size: int, location: str) -> np.ndarray:
+    if not isinstance(value, list) or len(value) != size:
+        raise ValueError(f"{location} must contain exactly {size} values")
+    return np.asarray(
+        [_finite_number(item, f"{location}[{index}]") for index, item in enumerate(value)],
+        dtype=float,
+    )
+
+
+def validate_numerical_payload(payload: Any) -> dict[str, Any]:
+    """Validate the portable payload shape, values and internal curve hash."""
+
+    required = {
+        "schema_version",
+        "chapter",
+        "profile",
+        "setup",
+        "scenarios",
+        "validation",
+        "curve_capture_sha256",
+        "provenance",
+    }
+    payload = _require_exact_keys(payload, required, "numerical payload")
+    if (
+        type(payload["schema_version"]) is not int
+        or payload["schema_version"] != PAYLOAD_SCHEMA_VERSION
+    ):
+        raise ValueError("unsupported numerical payload schema version")
+    if payload["chapter"] != "volatility_book/ch_tdist_risk_premia":
+        raise ValueError("numerical payload chapter identifier is wrong")
+    if not isinstance(payload["profile"], str):
+        raise TypeError("numerical payload profile must be a string")
+    as_profile(payload["profile"])
+
+    setup = _require_exact_keys(
+        payload["setup"], set(asdict(ModelSetup())), "numerical payload.setup"
+    )
+    expected_setup = asdict(ModelSetup())
+    for name, expected in expected_setup.items():
+        value = setup[name]
+        if name == "quadrature_order":
+            if type(value) is not int or value != expected:
+                raise ValueError(f"numerical payload.setup.{name} differs from {expected}")
+        elif _finite_number(value, f"numerical payload.setup.{name}") != float(expected):
+            raise ValueError(f"numerical payload.setup.{name} differs from {expected}")
+
+    scenarios = payload["scenarios"]
+    if not isinstance(scenarios, list) or len(scenarios) != 12:
+        raise ValueError("numerical payload must contain exactly 12 scenarios")
+    expected_scenarios = raw_scenarios() + fixed_variance_scenarios(ModelSetup())
+    result_keys = {
+        "scenario",
+        "alpha_q",
+        "beta_q",
+        "mean_v",
+        "shift",
+        "default_probability",
+        "log_moneyness",
+        "strikes",
+        "call_prices",
+        "implied_volatilities",
+        "atm_iv",
+        "atm_skew",
+        "rr_025",
+        "bf_025",
+    }
+    scenario_keys = {"identifier", "panel", "label", "p", "eta", "q"}
+    expected_strikes = ModelSetup().forward * np.exp(LOG_MONEYNESS)
+    for index, (record, expected_scenario) in enumerate(
+        zip(scenarios, expected_scenarios, strict=True)
+    ):
+        record = _require_exact_keys(record, result_keys, f"scenario {index}")
+        scenario = _require_exact_keys(
+            record["scenario"], scenario_keys, f"scenario {index}.scenario"
+        )
+        expected_metadata = asdict(expected_scenario)
+        for name in ("identifier", "panel", "label"):
+            if not isinstance(scenario[name], str) or scenario[name] != expected_metadata[name]:
+                raise ValueError(f"scenario {index}.scenario.{name} is wrong")
+        for name in ("p", "eta", "q"):
+            value = _finite_number(scenario[name], f"scenario {index}.scenario.{name}")
+            if value != float(expected_metadata[name]):
+                raise ValueError(f"scenario {index}.scenario.{name} is wrong")
+
+        log_moneyness = _finite_vector(
+            record["log_moneyness"], 29, f"scenario {index}.log_moneyness"
+        )
+        strikes = _finite_vector(record["strikes"], 29, f"scenario {index}.strikes")
+        call_prices = _finite_vector(record["call_prices"], 29, f"scenario {index}.call_prices")
+        implied_volatilities = _finite_vector(
+            record["implied_volatilities"], 29, f"scenario {index}.implied_volatilities"
+        )
+        if not np.array_equal(log_moneyness, LOG_MONEYNESS):
+            raise ValueError(f"scenario {index}.log_moneyness grid is wrong")
+        if not np.allclose(strikes, expected_strikes, rtol=0.0, atol=1.0e-15):
+            raise ValueError(f"scenario {index}.strikes are inconsistent with the setup")
+        if np.any(strikes <= 0.0):
+            raise ValueError(f"scenario {index}.strikes must be positive")
+        if np.any(call_prices < 0.0):
+            raise ValueError(f"scenario {index}.call_prices must be non-negative")
+        if np.any(implied_volatilities <= 0.0):
+            raise ValueError(f"scenario {index}.implied_volatilities must be positive")
+
+        scalars = {
+            name: _finite_number(record[name], f"scenario {index}.{name}")
+            for name in (
+                "alpha_q",
+                "beta_q",
+                "mean_v",
+                "shift",
+                "default_probability",
+                "atm_iv",
+                "atm_skew",
+                "rr_025",
+                "bf_025",
+            )
+        }
+        expected_alpha = ModelSetup().alpha_p - expected_scenario.p
+        expected_beta = ModelSetup().beta_p + expected_scenario.eta
+        expected_mean_v = expected_beta / (expected_alpha - 1.0)
+        for name, expected in (
+            ("alpha_q", expected_alpha),
+            ("beta_q", expected_beta),
+            ("mean_v", expected_mean_v),
+        ):
+            if not math.isclose(scalars[name], expected, rel_tol=0.0, abs_tol=1.0e-15):
+                raise ValueError(f"scenario {index}.{name} is inconsistent with its law")
+        if not 0.0 <= scalars["default_probability"] <= 1.0:
+            raise ValueError(f"scenario {index}.default_probability is outside [0, 1]")
+        summaries = _smile_statistics(log_moneyness, implied_volatilities)
+        for name, expected in zip(
+            ("atm_iv", "atm_skew", "rr_025", "bf_025"), summaries, strict=True
+        ):
+            if not math.isclose(scalars[name], expected, rel_tol=0.0, abs_tol=1.0e-14):
+                raise ValueError(f"scenario {index}.{name} is inconsistent with its smile")
+
+    scenario_ids = tuple(record["scenario"]["identifier"] for record in scenarios)
+    if scenario_ids != EXPECTED_SCENARIO_IDS:
+        raise ValueError("numerical payload scenario identifiers or order are wrong")
+
+    validation = _require_exact_keys(
+        payload["validation"], set(VALIDATION_THRESHOLDS), "numerical payload.validation"
+    )
+    validated_metrics = {
+        name: _finite_number(validation[name], f"numerical payload.validation.{name}")
+        for name in VALIDATION_THRESHOLDS
+    }
+    enforce_validation(validated_metrics)
+
+    provenance = _require_exact_keys(
+        payload["provenance"],
+        {"acceptance_manifest", "production_model", "frozen_oracle_used_in_production"},
+        "numerical payload.provenance",
+    )
+    manifest_provenance = _require_exact_keys(
+        provenance["acceptance_manifest"],
+        {"path", "sha256"},
+        "numerical payload.provenance.acceptance_manifest",
+    )
+    expected_manifest_path = "volatility_book/ch_tdist_risk_premia/acceptance_manifest.json"
+    if manifest_provenance["path"] != expected_manifest_path:
+        raise ValueError("numerical payload acceptance-manifest path is wrong")
+    if manifest_provenance["sha256"] != _sha256(ACCEPTANCE_MANIFEST):
+        raise ValueError("numerical payload acceptance-manifest hash is wrong")
+    expected_model = "stochvolmodels.models.inverse_gamma_normal.InverseGammaNormalTerminalModel"
+    if provenance["production_model"] != expected_model:
+        raise ValueError("numerical payload production model is wrong")
+    if provenance["frozen_oracle_used_in_production"] is not False:
+        raise ValueError("numerical payload must record that production excludes the oracle")
+
+    _validate_finite_json(payload)
+    reconstructed = {
+        "log_moneyness": np.round(scenarios[0]["log_moneyness"], 8).tolist(),
+        "records": [
+            {
+                "alpha": round(float(record["alpha_q"]), 12),
+                "beta": round(float(record["beta_q"]), 12),
+                "q": round(float(record["scenario"]["q"]), 12),
+                "shift": round(float(record["shift"]), 12),
+                "default_probability": round(float(record["default_probability"]), 12),
+                "call_prices": np.round(record["call_prices"], 10).tolist(),
+                "implied_volatilities": np.round(record["implied_volatilities"], 10).tolist(),
+            }
+            for record in scenarios
+        ],
+    }
+    actual_hash = _compact_sha256(reconstructed)
+    if not isinstance(payload["curve_capture_sha256"], str):
+        raise TypeError("numerical payload curve capture hash must be a string")
+    if payload["curve_capture_sha256"] != actual_hash:
+        raise ValueError("numerical payload curve capture hash is inconsistent")
+    if actual_hash != EXPECTED_CURVE_CAPTURE_SHA256:
+        raise ValueError("numerical payload differs from the frozen accepted curves")
+    return payload
+
+
+def build_numerical_payload(
+    profile: ChapterProfile | str = ChapterProfile.CANONICAL,
+) -> dict[str, Any]:
+    """Compute and validate the package-routed numerical payload."""
+
+    _assert_recompute_allowed()
+    if not ACCEPTANCE_MANIFEST.is_file():
+        raise FileNotFoundError(f"acceptance manifest is missing: {ACCEPTANCE_MANIFEST}")
+    selected_profile = as_profile(profile)
+    setup = ModelSetup()
+    results, validation = compute_examples(setup)
+    capture_hash = _compact_sha256(curve_capture(results))
+    if capture_hash != EXPECTED_CURVE_CAPTURE_SHA256:
+        raise RuntimeError("package-routed curves differ from the frozen acceptance hash")
+    payload = {
+        "schema_version": PAYLOAD_SCHEMA_VERSION,
+        "chapter": "volatility_book/ch_tdist_risk_premia",
+        "profile": selected_profile.value,
+        "setup": asdict(setup),
+        "scenarios": [_result_payload(result) for result in results],
+        "validation": validation,
+        "curve_capture_sha256": capture_hash,
+        "provenance": {
+            "acceptance_manifest": {
+                "path": "volatility_book/ch_tdist_risk_premia/acceptance_manifest.json",
+                "sha256": _sha256(ACCEPTANCE_MANIFEST),
+            },
+            "production_model": (
+                "stochvolmodels.models.inverse_gamma_normal.InverseGammaNormalTerminalModel"
+            ),
+            "frozen_oracle_used_in_production": False,
+        },
+    }
+    return validate_numerical_payload(payload)
+
+
+def write_numerical_payload(payload: dict[str, Any], path: Path | str) -> Path:
+    """Write a validated payload with stable JSON formatting."""
+
+    validated = validate_numerical_payload(payload)
+    target = Path(path).expanduser().resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(validated, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return target
+
+
+def load_numerical_payload(path: Path | str) -> dict[str, Any]:
+    """Load and validate one payload, rejecting JSON non-finite constants."""
+
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+    with Path(path).expanduser().resolve().open("r", encoding="utf-8") as stream:
+        payload = json.load(stream, parse_constant=reject_constant)
+    return validate_numerical_payload(payload)
+
+
+def write_artifact_manifest(
+    output_directory: Path | str,
+    *,
+    profile: ChapterProfile | str,
+    mode: str,
+    payload_path: Path,
+    artifacts: Iterable[Path],
+) -> Path:
+    """Write output-relative hashes for a computed or payload-only render."""
+
+    if mode not in {"computed", "rerendered"}:
+        raise ValueError("artifact manifest mode must be 'computed' or 'rerendered'")
+    output = validate_output_directory(output_directory)
+    payload = Path(payload_path).resolve()
+    try:
+        payload_relative = payload.relative_to(output).as_posix()
+    except ValueError as error:
+        raise ValueError("payload_path must be inside output_directory") from error
+    entries = []
+    for artifact in sorted({Path(item).resolve() for item in artifacts}, key=str):
+        if not artifact.is_file():
+            raise FileNotFoundError(f"expected artifact is missing: {artifact}")
+        try:
+            relative = artifact.relative_to(output).as_posix()
+        except ValueError as error:
+            raise ValueError(f"artifact is outside output directory: {artifact}") from error
+        entries.append({"path": relative, "sha256": _sha256(artifact)})
+    manifest = {
+        "schema_version": 1,
+        "profile": as_profile(profile).value,
+        "mode": mode,
+        "payload": {"path": payload_relative, "sha256": _sha256(payload)},
+        "artifacts": entries,
+    }
+    _validate_finite_json(manifest, "artifact_manifest")
+    target = output / ARTIFACT_MANIFEST_FILENAME
+    target.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return target
+
+
+__all__ = [
+    "ACCEPTANCE_MANIFEST",
+    "ARTIFACT_MANIFEST_FILENAME",
+    "ChapterProfile",
+    "DEFAULT_OUTPUT_ROOT",
+    "EXPECTED_CURVE_CAPTURE_SHA256",
+    "EXPECTED_SCENARIO_IDS",
+    "FORBID_RECOMPUTE_ENV",
+    "LOG_MONEYNESS",
+    "ModelSetup",
+    "PAYLOAD_FILENAME",
+    "Scenario",
+    "ScenarioResult",
+    "as_profile",
+    "build_numerical_payload",
+    "compute_examples",
+    "compute_scenario",
+    "curve_capture",
+    "default_output_directory",
+    "enforce_validation",
+    "fixed_variance_scenarios",
+    "load_numerical_payload",
+    "pricing_law",
+    "raw_scenarios",
+    "validate_numerical_payload",
+    "validate_output_directory",
+    "write_artifact_manifest",
+    "write_numerical_payload",
+]

--- a/volatility_book/ch_tdist_risk_premia/verify_tdist_risk_premia_package_adoption.py
+++ b/volatility_book/ch_tdist_risk_premia/verify_tdist_risk_premia_package_adoption.py
@@ -1,0 +1,627 @@
+"""Verify the portable package adoption of the Student risk-premia chapter."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import copy
+import hashlib
+import importlib.util
+import json
+import math
+import os
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path, PurePosixPath
+from types import ModuleType
+from typing import Any, Iterator, Mapping, Sequence
+
+import numpy as np
+
+from volatility_book.ch_tdist_risk_premia import generate_tdist_risk_premia_figures as generator
+from volatility_book.ch_tdist_risk_premia import tdist_risk_premia_chapter as chapter
+
+FROZEN_ORACLE = chapter.CHAPTER_DIR / "risk_premium_smile_examples.py"
+SOURCE_PROVENANCE = chapter.CHAPTER_DIR / "source_provenance.json"
+NOTE = chapter.CHAPTER_DIR / "notes" / "tdist_risk_premia_note.tex"
+FROZEN_ORACLE_SHA256 = "4e6f4a6700c3d63ed4981be962ce3fa73a09475607ea7aaeb5457cbb2f3b6533"
+SOURCE_PROVENANCE_SHA256 = "22bd1a21b3b3852f11577b5a8596ab3393cca4b2f3e11e22404a55ac606521a5"
+PRE_ADOPTION_NOTE_SHA256 = "49d2cd1182727675e79facbaca5e4bba8721e3af4a2177e264a72305079e169a"
+FROZEN_VALIDATION_SHA256 = "5a6fa80531840bd19ac6f1c4276bc6dea47682ffa3c159a622f69ddc0b1b447e"
+EXPECTED_TABLE_SHA256 = "d7948327698ed025cf0f37899b23d8270b5f1054fb285f01b9bd6cbf083aa029"
+EXPECTED_OUTPUT_FILES = {
+    "artifact_manifest.json",
+    "figures/p_tail_premium_fixed_variance.pdf",
+    "figures/p_tail_premium_fixed_variance.png",
+    "figures/risk_premium_smiles.pdf",
+    "figures/risk_premium_smiles.png",
+    "numerical_payload.json",
+    "tables/risk_premium_comparative_statics_table.tex",
+}
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _compact_sha256(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+    with path.open("r", encoding="utf-8") as stream:
+        value = json.load(stream, parse_constant=reject_constant)
+    _require(isinstance(value, dict), f"expected a JSON object: {path}")
+    return value
+
+
+def _portable_relative_path(value: object, location: str) -> str:
+    _require(isinstance(value, str) and value, f"{location} must be a non-empty string")
+    _require("\\" not in value, f"{location} must use forward slashes")
+    path = PurePosixPath(value)
+    _require(not path.is_absolute(), f"{location} must be relative")
+    _require(".." not in path.parts and "." not in path.parts, f"{location} traverses")
+    _require(":" not in path.parts[0], f"{location} must not contain a drive")
+    return path.as_posix()
+
+
+def _valid_sha256(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and value == value.lower()
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _manifest_file(role: str, manifest: Mapping[str, Any]) -> Mapping[str, Any]:
+    matches = [record for record in manifest["provenance"]["files"] if record["role"] == role]
+    _require(len(matches) == 1, f"manifest must contain one provenance role {role!r}")
+    return matches[0]
+
+
+def verify_acceptance_manifest() -> dict[str, Any]:
+    """Validate the static manifest, frozen hashes and source ledger."""
+
+    manifest = _load_json(chapter.ACCEPTANCE_MANIFEST)
+    _require(manifest.get("schema_version") == 1, "bad acceptance-manifest schema")
+    _require(
+        manifest.get("manifest_id") == "stochvolmodels.tdist_risk_premia_chapter.acceptance",
+        "bad acceptance-manifest identifier",
+    )
+    _require(manifest.get("acceptance_status") == "T3T_ADOPTION_CONTRACT", "bad status")
+    _require(
+        manifest.get("chapter") == "volatility_book/ch_tdist_risk_premia",
+        "bad chapter path",
+    )
+    _require(_sha256(FROZEN_ORACLE) == FROZEN_ORACLE_SHA256, "frozen oracle hash changed")
+    _require(
+        _sha256(SOURCE_PROVENANCE) == SOURCE_PROVENANCE_SHA256,
+        "source-provenance hash changed",
+    )
+    expected_hashes = {
+        "verification_only_frozen_oracle": FROZEN_ORACLE_SHA256,
+        "source_provenance_ledger": SOURCE_PROVENANCE_SHA256,
+        "pre_adoption_note": PRE_ADOPTION_NOTE_SHA256,
+    }
+    for role, expected in expected_hashes.items():
+        record = _manifest_file(role, manifest)
+        _portable_relative_path(record.get("path"), f"provenance.files[{role}].path")
+        _require(record.get("sha256") == expected, f"bad manifest hash for {role}")
+
+    ledger = _load_json(SOURCE_PROVENANCE)
+    records = {record["path"]: record for record in ledger["files"]}
+    _require(
+        records["risk_premium_smile_examples.py"]["sha256_raw"] == FROZEN_ORACLE_SHA256,
+        "source ledger frozen-script hash changed",
+    )
+    _require(
+        records["notes/tdist_risk_premia_note.tex"]["sha256_raw"] == PRE_ADOPTION_NOTE_SHA256,
+        "source ledger pre-adoption note hash changed",
+    )
+    output_contract = manifest["output_contract"]
+    _require(output_contract["gitignore_rule"] == "/outputs/", "bad ignore contract")
+    _require(not output_contract["generated_artifacts_are_tracked"], "outputs cannot be tracked")
+    _require(
+        set(output_contract["artifacts_relative_to_profile_directory"]) == EXPECTED_OUTPUT_FILES,
+        "manifest output file set is wrong",
+    )
+    numerical = manifest["numerical_contract"]
+    _require(
+        tuple(numerical["scenario_ids"]) == chapter.EXPECTED_SCENARIO_IDS,
+        "manifest scenario order is wrong",
+    )
+    _require(
+        numerical["portable_curve_capture"]["sha256"] == chapter.EXPECTED_CURVE_CAPTURE_SHA256,
+        "manifest curve hash is wrong",
+    )
+    _require(
+        numerical["frozen_validation_dictionary"]["sha256"] == FROZEN_VALIDATION_SHA256,
+        "manifest frozen-validation hash is wrong",
+    )
+    return manifest
+
+
+def verify_production_boundary() -> None:
+    """Prove that production imports package analytics, never the frozen oracle."""
+
+    for path in (
+        chapter.CHAPTER_DIR / "tdist_risk_premia_chapter.py",
+        chapter.CHAPTER_DIR / "generate_tdist_risk_premia_figures.py",
+    ):
+        text = path.read_text(encoding="utf-8")
+        _require("risk_premium_smile_examples" not in text, f"production references oracle: {path}")
+        tree = ast.parse(text, filename=str(path))
+        imports = {
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        }
+        imports.update(
+            node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)
+        )
+        _require(
+            not any(name.endswith("risk_premium_smile_examples") for name in imports),
+            f"production imports oracle: {path}",
+        )
+    computation_text = (chapter.CHAPTER_DIR / "tdist_risk_premia_chapter.py").read_text(
+        encoding="utf-8"
+    )
+    _require("InverseGammaNormalTerminalModel" in computation_text, "package model not adopted")
+    for forbidden in ("roots_genlaguerre", "brentq", "class MixturePricer"):
+        _require(
+            forbidden not in computation_text, f"production reimplements package math: {forbidden}"
+        )
+
+
+def _load_frozen_oracle() -> ModuleType:
+    _require(_sha256(FROZEN_ORACLE) == FROZEN_ORACLE_SHA256, "refusing modified frozen oracle")
+    module_name = "_stochvolmodels_frozen_tdist_risk_premia_oracle"
+    specification = importlib.util.spec_from_file_location(module_name, FROZEN_ORACLE)
+    _require(
+        specification is not None and specification.loader is not None,
+        "cannot load frozen oracle",
+    )
+    module = importlib.util.module_from_spec(specification)
+    sys.modules[module_name] = module
+    try:
+        specification.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+    return module
+
+
+def _frozen_results() -> tuple[list[Any], dict[str, float]]:
+    oracle = _load_frozen_oracle()
+    raw, fixed, validation = oracle.compute_examples(oracle.ModelSetup())
+    oracle._enforce_validation(validation)
+    _require(_compact_sha256(validation) == FROZEN_VALIDATION_SHA256, "frozen validation changed")
+    return [*raw, *fixed], validation
+
+
+def _assert_close(label: str, actual: object, expected: object, tolerance: float) -> None:
+    actual_array = np.asarray(actual, dtype=float)
+    expected_array = np.asarray(expected, dtype=float)
+    _require(actual_array.shape == expected_array.shape, f"{label} shape differs")
+    error = float(np.max(np.abs(actual_array - expected_array))) if actual_array.size else 0.0
+    _require(error <= tolerance, f"{label} differs by {error:.6e} > {tolerance:.6e}")
+
+
+def verify_package_frozen_oracle(
+    manifest: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, float]]:
+    """Compare every package-produced curve and diagnostic with the frozen script."""
+
+    payload = chapter.build_numerical_payload(chapter.ChapterProfile.CANONICAL)
+    frozen_results, frozen_validation = _frozen_results()
+    package_records = payload["scenarios"]
+    _require(len(package_records) == len(frozen_results) == 12, "scenario count differs")
+    tolerances = manifest["numerical_contract"]["package_vs_frozen_absolute_tolerances"]
+    maximum_errors = {
+        "law": 0.0,
+        "shift": 0.0,
+        "default": 0.0,
+        "calls": 0.0,
+        "ivols": 0.0,
+        "summary": 0.0,
+    }
+    for index, (record, frozen) in enumerate(zip(package_records, frozen_results)):
+        scenario = record["scenario"]
+        _require(scenario["panel"] == frozen.scenario.panel, f"scenario {index} panel differs")
+        _require(scenario["label"] == frozen.scenario.label, f"scenario {index} label differs")
+        for name in ("p", "eta", "q"):
+            _require(scenario[name] == getattr(frozen.scenario, name), f"scenario {index}.{name}")
+        law_actual = np.array([record["alpha_q"], record["beta_q"], record["mean_v"]])
+        law_frozen = np.array([frozen.alpha_q, frozen.beta_q, frozen.mean_v])
+        maximum_errors["law"] = max(
+            maximum_errors["law"],
+            float(np.max(np.abs(law_actual - law_frozen))),
+        )
+        maximum_errors["shift"] = max(maximum_errors["shift"], abs(record["shift"] - frozen.shift))
+        maximum_errors["default"] = max(
+            maximum_errors["default"],
+            abs(record["default_probability"] - frozen.default_probability),
+        )
+        maximum_errors["calls"] = max(
+            maximum_errors["calls"],
+            float(np.max(np.abs(np.asarray(record["call_prices"]) - frozen.call_prices))),
+        )
+        maximum_errors["ivols"] = max(
+            maximum_errors["ivols"],
+            float(
+                np.max(
+                    np.abs(np.asarray(record["implied_volatilities"]) - frozen.implied_volatilities)
+                )
+            ),
+        )
+        _assert_close(
+            f"scenario {index} log-moneyness",
+            record["log_moneyness"],
+            frozen.log_moneyness,
+            0.0,
+        )
+        _assert_close(f"scenario {index} strikes", record["strikes"], frozen.strikes, 1.0e-15)
+        summary_actual = np.array(
+            [record["atm_iv"], record["atm_skew"], record["rr_025"], record["bf_025"]]
+        )
+        summary_frozen = np.array([frozen.atm_iv, frozen.atm_skew, frozen.rr_025, frozen.bf_025])
+        maximum_errors["summary"] = max(
+            maximum_errors["summary"],
+            float(np.max(np.abs(summary_actual - summary_frozen))),
+        )
+
+    limits = {
+        "law": tolerances["law_parameters_and_mean_v"],
+        "shift": tolerances["shift_and_default_probability"],
+        "default": tolerances["shift_and_default_probability"],
+        "calls": tolerances["call_prices"],
+        "ivols": tolerances["black_implied_volatilities"],
+        "summary": tolerances["summary_statistics"],
+    }
+    for name, error in maximum_errors.items():
+        _require(error <= limits[name], f"package/frozen {name} error {error:.6e}")
+    _require(
+        payload["curve_capture_sha256"] == chapter.EXPECTED_CURVE_CAPTURE_SHA256,
+        "package curve hash changed",
+    )
+    baselines = [package_records[index] for index in (1, 4, 7, 10)]
+    for baseline in baselines[1:]:
+        _require(
+            baseline["call_prices"] == baselines[0]["call_prices"]
+            and baseline["implied_volatilities"] == baselines[0]["implied_volatilities"],
+            "duplicate baseline curves differ",
+        )
+    for index in (9, 10, 11):
+        _require(abs(package_records[index]["mean_v"] - 0.04) <= 1.0e-13, "mean V moved")
+    return payload, {**maximum_errors, **{f"frozen_{k}": v for k, v in frozen_validation.items()}}
+
+
+def _tree_fingerprint(root: Path) -> tuple[tuple[str, int, str], ...]:
+    return tuple(
+        sorted(
+            (
+                path.relative_to(root).as_posix(),
+                path.stat().st_size,
+                _sha256(path),
+            )
+            for path in root.rglob("*")
+            if path.is_file()
+        )
+    )
+
+
+def _validate_artifact_manifest(output: Path, mode: str) -> dict[str, Any]:
+    manifest_path = output / chapter.ARTIFACT_MANIFEST_FILENAME
+    _require(not manifest_path.is_symlink(), "artifact manifest cannot be a symlink")
+    manifest = _load_json(manifest_path)
+    _require(
+        set(manifest) == {"schema_version", "profile", "mode", "payload", "artifacts"},
+        "artifact-manifest keys differ",
+    )
+    _require(type(manifest["schema_version"]) is int, "artifact schema must be an integer")
+    _require(manifest["schema_version"] == 1, "bad artifact-manifest schema")
+    _require(manifest["profile"] == chapter.ChapterProfile.CANONICAL.value, "bad profile")
+    _require(manifest["mode"] == mode, "bad artifact-manifest mode")
+    payload_record = manifest["payload"]
+    _require(isinstance(payload_record, dict), "artifact manifest lacks payload")
+    _require(set(payload_record) == {"path", "sha256"}, "payload record keys differ")
+    _require(payload_record["path"] == chapter.PAYLOAD_FILENAME, "bad payload path")
+    _require(_valid_sha256(payload_record["sha256"]), "bad payload SHA-256 syntax")
+    _require(
+        payload_record["sha256"] == _sha256(output / chapter.PAYLOAD_FILENAME),
+        "artifact-manifest payload hash differs",
+    )
+    records = manifest["artifacts"]
+    _require(isinstance(records, list), "artifact records must be a list")
+    _require(
+        len(records) == len(EXPECTED_OUTPUT_FILES) - 1,
+        "artifact record count differs",
+    )
+    declared = set()
+    for index, record in enumerate(records):
+        _require(isinstance(record, dict), f"artifacts[{index}] must be an object")
+        _require(set(record) == {"path", "sha256"}, f"artifacts[{index}] keys differ")
+        relative = _portable_relative_path(record["path"], f"artifacts[{index}].path")
+        _require(relative not in declared, f"duplicate artifact record: {relative}")
+        artifact = output / Path(*PurePosixPath(relative).parts)
+        _require(artifact.is_file(), f"missing declared artifact: {relative}")
+        _require(not artifact.is_symlink(), f"artifact cannot be a symlink: {relative}")
+        try:
+            artifact.resolve(strict=True).relative_to(output.resolve(strict=True))
+        except ValueError as error:
+            raise AssertionError(f"artifact resolves outside output: {relative}") from error
+        _require(_valid_sha256(record["sha256"]), f"bad artifact SHA-256 syntax: {relative}")
+        _require(record["sha256"] == _sha256(artifact), f"artifact hash differs: {relative}")
+        declared.add(relative)
+    _require(
+        declared == EXPECTED_OUTPUT_FILES - {"artifact_manifest.json"}, "declared files differ"
+    )
+    return manifest
+
+
+def _expected_table_text(payload: dict[str, Any]) -> str:
+    records = {record["scenario"]["identifier"]: record for record in payload["scenarios"]}
+    specifications = (
+        ("Baseline", "baseline_p"),
+        (r"$p=-0.75$, $\eta=0$", "p_minus"),
+        (r"$p=+0.75$, $\eta=0$", "p_plus"),
+        (
+            r"$p=-0.75$, $\eta=+0.030$, fixed $\mathrm{E}_{\mathbb Q}[V]$",
+            "p_fixed_minus",
+        ),
+        (
+            r"$p=+0.75$, $\eta=-0.030$, fixed $\mathrm{E}_{\mathbb Q}[V]$",
+            "p_fixed_plus",
+        ),
+        (r"$\eta=-0.024$", "eta_minus"),
+        (r"$\eta=+0.024$", "eta_plus"),
+        (r"$q=-2$", "q_minus"),
+        (r"$q=+2$", "q_plus"),
+    )
+    rows = []
+    for label, identifier in specifications:
+        record = records[identifier]
+        rows.append(
+            f"{label} & {record['atm_iv']:.4f} & {record['atm_skew']:.4f} "
+            f"& {record['rr_025']:.4f} & {record['bf_025']:.4f} \\\\"
+        )
+    return "\n".join(
+        [
+            r"\begin{tabular}{@{}lrrrr@{}}",
+            r"\toprule",
+            "Scenario & ATM IV & ATM slope & "
+            r"$\operatorname{RR}^{(k)}_{0.25}$ & $\operatorname{BF}^{(k)}_{0.25}$ \\",
+            r"\midrule",
+            *rows,
+            r"\bottomrule",
+            r"\end{tabular}",
+            "",
+        ]
+    )
+
+
+def _validate_output_tree(output: Path, *, mode: str) -> dict[str, Any]:
+    paths = list(output.rglob("*"))
+    symlinks = [path.relative_to(output).as_posix() for path in paths if path.is_symlink()]
+    _require(not symlinks, f"output tree contains symlinks: {symlinks}")
+    actual = {path.relative_to(output).as_posix() for path in paths if path.is_file()}
+    _require(actual == EXPECTED_OUTPUT_FILES, f"output file set differs: {sorted(actual)}")
+    payload = chapter.load_numerical_payload(output / chapter.PAYLOAD_FILENAME)
+    for stem in ("risk_premium_smiles", "p_tail_premium_fixed_variance"):
+        pdf = output / "figures" / f"{stem}.pdf"
+        png = output / "figures" / f"{stem}.png"
+        _require(pdf.stat().st_size > 100 and pdf.read_bytes()[:4] == b"%PDF", f"bad PDF {pdf}")
+        _require(
+            png.stat().st_size > 100 and png.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n",
+            f"bad PNG {png}",
+        )
+    table = output / "tables" / "risk_premium_comparative_statics_table.tex"
+    table_text = table.read_text(encoding="utf-8")
+    expected_table_text = _expected_table_text(payload)
+    _require(table_text == expected_table_text, "table content differs from payload oracle")
+    _require(
+        hashlib.sha256(table_text.encode("utf-8")).hexdigest() == EXPECTED_TABLE_SHA256,
+        "table differs from the accepted portable hash",
+    )
+    _require(":\\" not in table_text and "../" not in table_text, "table contains a path")
+    _validate_artifact_manifest(output, mode)
+    return payload
+
+
+@contextmanager
+def _environment(name: str, value: str) -> Iterator[None]:
+    previous = os.environ.get(name)
+    os.environ[name] = value
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = previous
+
+
+def _expect_failure(callable_: Any, label: str) -> None:
+    try:
+        callable_()
+    except (AssertionError, RuntimeError, TypeError, ValueError):
+        return
+    raise AssertionError(f"invalid mutation was accepted: {label}")
+
+
+def verify_payload_mutations(payload: dict[str, Any]) -> None:
+    """Prove strict payload validation rejects value, type, schema and order defects."""
+
+    corrupted = copy.deepcopy(payload)
+    corrupted["scenarios"][0]["call_prices"][0] += 1.0e-4
+    _expect_failure(lambda: chapter.validate_numerical_payload(corrupted), "corrupted call")
+    reordered = copy.deepcopy(payload)
+    reordered["scenarios"][0], reordered["scenarios"][1] = (
+        reordered["scenarios"][1],
+        reordered["scenarios"][0],
+    )
+    _expect_failure(lambda: chapter.validate_numerical_payload(reordered), "scenario order")
+    nonfinite = copy.deepcopy(payload)
+    nonfinite["scenarios"][0]["call_prices"][0] = math.nan
+    _expect_failure(lambda: chapter.validate_numerical_payload(nonfinite), "non-finite call")
+    boolean = copy.deepcopy(payload)
+    boolean["scenarios"][0]["call_prices"][0] = True
+    _expect_failure(lambda: chapter.validate_numerical_payload(boolean), "boolean call")
+    numeric_string = copy.deepcopy(payload)
+    numeric_string["scenarios"][0]["alpha_q"] = str(numeric_string["scenarios"][0]["alpha_q"])
+    _expect_failure(lambda: chapter.validate_numerical_payload(numeric_string), "string scalar")
+    inconsistent_summary = copy.deepcopy(payload)
+    inconsistent_summary["scenarios"][0]["bf_025"] += 1.0e-4
+    _expect_failure(
+        lambda: chapter.validate_numerical_payload(inconsistent_summary),
+        "inconsistent smile summary",
+    )
+    extra_key = copy.deepcopy(payload)
+    extra_key["scenarios"][0]["unexpected"] = 0.0
+    _expect_failure(lambda: chapter.validate_numerical_payload(extra_key), "extra scenario key")
+    extra_validation = copy.deepcopy(payload)
+    extra_validation["validation"]["unexpected"] = 0.0
+    _expect_failure(
+        lambda: chapter.validate_numerical_payload(extra_validation),
+        "extra validation key",
+    )
+    negative_validation = copy.deepcopy(payload)
+    negative_validation["validation"]["max_put_call_parity_error"] = -1.0
+    _expect_failure(
+        lambda: chapter.validate_numerical_payload(negative_validation),
+        "negative validation metric",
+    )
+
+
+def verify_generator_roundtrip() -> None:
+    """Compute once, then prove payload-only rendering cannot invoke analytics."""
+
+    chapter.DEFAULT_OUTPUT_ROOT.mkdir(parents=True, exist_ok=True)
+    notes_before = _tree_fingerprint(NOTE.parent)
+    with tempfile.TemporaryDirectory(
+        prefix="verify_", dir=chapter.DEFAULT_OUTPUT_ROOT
+    ) as temporary:
+        root = Path(temporary)
+        computed = root / "computed"
+        rerendered = root / "rerendered"
+        source_payload, _ = generator.run_pipeline(
+            profile=chapter.ChapterProfile.CANONICAL,
+            output_directory=computed,
+        )
+        computed_payload = _validate_output_tree(computed, mode="computed")
+        with _environment(chapter.FORBID_RECOMPUTE_ENV, "1"):
+            _expect_failure(
+                lambda: chapter.build_numerical_payload(chapter.ChapterProfile.CANONICAL),
+                "recompute guard",
+            )
+            _expect_failure(lambda: chapter.compute_examples(), "direct analytics guard")
+            generator.run_pipeline(
+                profile=chapter.ChapterProfile.CANONICAL,
+                output_directory=rerendered,
+                payload_path=source_payload,
+            )
+        rerendered_payload = _validate_output_tree(rerendered, mode="rerendered")
+        _require(
+            _sha256(computed / chapter.PAYLOAD_FILENAME)
+            == _sha256(rerendered / chapter.PAYLOAD_FILENAME),
+            "payload-only rerender changed payload bytes",
+        )
+        _require(
+            _sha256(computed / "tables" / "risk_premium_comparative_statics_table.tex")
+            == _sha256(rerendered / "tables" / "risk_premium_comparative_statics_table.tex"),
+            "payload-only rerender changed table bytes",
+        )
+        _require(computed_payload == rerendered_payload, "payload-only rerender changed values")
+    _require(_tree_fingerprint(NOTE.parent) == notes_before, "generator wrote under tracked notes")
+
+
+def verify_note_contract() -> None:
+    """Require the adopted note to use ignored artifacts and state the ownership split."""
+
+    text = NOTE.read_text(encoding="utf-8")
+    required = (
+        r"\providecommand{\TdistRiskPremiaArtifactRoot}",
+        r"\graphicspath{{\TdistRiskPremiaArtifactRoot/figures/}}",
+        r"\input{\TdistRiskPremiaArtifactRoot/tables/",
+        "InverseGammaNormalTerminalModel",
+        "TdistTerminalModel",
+        "generate_tdist_risk_premia_figures",
+    )
+    for fragment in required:
+        _require(fragment in text, f"note adoption fragment missing: {fragment}")
+    _require("../figures/" not in text, "note still references source-local figures")
+
+
+def verify_output_policy(manifest: Mapping[str, Any]) -> None:
+    """Require the default root and reject tracked or destructive output locations."""
+
+    expected = (
+        chapter.REPOSITORY_ROOT / "outputs" / "volatility_book" / "ch_tdist_risk_premia"
+    ).resolve()
+    _require(chapter.DEFAULT_OUTPUT_ROOT.resolve() == expected, "default output root moved")
+    _require(
+        manifest["output_contract"]["default_root"]
+        == "outputs/volatility_book/ch_tdist_risk_premia",
+        "manifest default output root moved",
+    )
+    _expect_failure(
+        lambda: chapter.validate_output_directory(chapter.REPOSITORY_ROOT),
+        "repository-root output",
+    )
+    _expect_failure(
+        lambda: chapter.validate_output_directory(chapter.CHAPTER_DIR / "figures"),
+        "tracked chapter output",
+    )
+
+
+def _parse_arguments(arguments: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--skip-roundtrip",
+        action="store_true",
+        help="skip temporary figure/table generation; numerical oracle checks still run",
+    )
+    return parser.parse_args(arguments)
+
+
+def main(arguments: Sequence[str] | None = None) -> None:
+    """Run the complete T3T package-adoption acceptance contract."""
+
+    args = _parse_arguments(arguments)
+    manifest = verify_acceptance_manifest()
+    verify_production_boundary()
+    payload, maxima = verify_package_frozen_oracle(manifest)
+    verify_payload_mutations(payload)
+    verify_note_contract()
+    verify_output_policy(manifest)
+    if not args.skip_roundtrip:
+        verify_generator_roundtrip()
+        scope = "manifest, oracle, outputs, and rerender"
+    else:
+        scope = "manifest and oracle (roundtrip skipped)"
+    print(f"PASS Student risk-premia package adoption: {scope}")
+    print(json.dumps(maxima, indent=2, sort_keys=True, allow_nan=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

- freeze the approved regime and Student risk-premia chapter sources with hash-pinned provenance
- add provisional two-state regime-switching LogSV equilibrium, induced-Q simulation, transform, Fourier, implied-volatility, and Monte Carlo analytics
- add analytic diffusive, timing, and tail-risk attribution controls
- add a maturity-bound inverse-gamma/normal terminal distribution and Black-smile model
- route both chapters through package-owned analytics while retaining frozen sources solely as independent verification oracles
- generate deterministic, schema-validated payloads with guarded payload-only rerendering; all outputs remain ignored

The seven commits remain independently revertible: `062d239` and `3d5d848` freeze source authority; `a11fbf6`, `50cbe3a`, and `2391cc7` implement/adopt regime analytics; `e616e38` and `e08a874` implement/adopt the inverse-gamma/normal terminal law.

## Numerical evidence

- regime package versus frozen monolith: coefficients `1.53e-16`, MGFs `1.14e-16`, terminal log return `2.22e-16`, volatility `1.11e-16`, and exact terminal regimes
- canonical regime profile: 120,000 paths, 1,440 steps/year, Fourier refinement `7.97e-7`, analytic-versus-Q-MC price error `2.85e-4`, and physical Feynman-Kac errors `2.34e-3` and `1.07e-3`
- inverse-gamma/normal package versus frozen 12-by-29 capture: shifts `2.11e-14`, calls `1.98e-14`, Black IVs `1.64e-13`, and smile summaries `1.31e-13`
- independent Student, adaptive gamma-precision, and Bessel-K checks remain within `2.80e-8`; 128-versus-256-node refinement is `1.75e-7`

## Verification

- regime characterization: 22 focused fast and 7 focused slow tests
- inverse-gamma/normal characterization: 29 focused cases
- complete non-slow source suite and all 15 slow tests under public OCA 5.2.0
- both package-adoption verifiers, canonical pipelines, and guarded rerenders
- critical Ruff, changed-file Ruff/format, whitespace, build, and isolated-wheel gates
- `ruff check --select F,TID251,TID253,ICN src/stochvolmodels`
- 104-file wheel and 129-member sdist content checks; neither includes `volatility_book/` or `outputs/`
- three-pass TeX builds and complete visual inspection of the 20-page regime and 21-page Student chapters

Five core numerical defects and ten chapter-adoption defects were introduced independently, observed failing, and restored. They cover horizon indexing, RNG coupling, timing attribution, prepaid-forward normalization, conditional-mean sign, tracked-output targets, frozen-oracle tampering, guarded recomputation, corrupted payloads, and butterfly/table diagnostics. Strict validators also reject malformed schemas, non-finite or incorrectly typed values, unsafe paths, duplicate manifest records, and symlinks.

## Scope and deferred work

- no dependency, package-root export, version bump, tag, release, or generated tracked artifact
- no generic `PathModel`, calibration framework, provider surface, or public-API stabilization
- T2 Student/GMM analytics and existing Hawkes/GMM workflows remain unchanged
- illustrative parameters, scenario economics, and physical-to-pricing mappings remain chapter-owned
- non-unit regime attribution scales are analytic counterfactuals, not alternate Monte Carlo measures
- legacy nonzero-location `cum_mean_tdist` remains deferred because production pricing uses `mu=0`
- book-analytics release and full-book assembly remain downstream

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Volatility, rate, dividend, spot/forward, option-type, and maturity conventions remain explicit.
- [x] Numerical regression baselines were not regenerated merely to make a failure pass.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] `ruff check --select F,TID251,TID253,ICN src/stochvolmodels` passes.
- [x] User-visible changes are documented in `CHANGELOG.md` and the adopted chapter notes.
- [x] No runtime dependency or stable public-signature change is introduced.

## Merge method

The acceptance manifests pin intermediate provenance commits. Preserve the seven-commit history and use a merge commit; do not squash or rebase this PR.