### PR TITLE
Harden book-analytics release readiness

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,75 @@
+name: Release readiness
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  MPLBACKEND: Agg
+  TZ: UTC
+
+jobs:
+  book-analytics-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install uv and Python 3.12
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: "3.12"
+
+      - name: Sync locked book environment
+        run: uv sync --locked --group test --extra research
+
+      - name: Assert the exact book data dependency
+        run: >-
+          uv run --no-sync python -c
+          "import importlib.metadata as m;
+          assert m.version('option-chain-analytics') == '5.2.0'"
+
+      - name: Build source and wheel distributions
+        run: |
+          uv build --sdist --clear --out-dir dist
+          uv build --wheel dist/*.tar.gz --out-dir dist
+
+      - name: Assert distribution contents
+        run: |
+          uv run --no-project python scripts/check_sdist_contents.py dist/*.tar.gz
+          uv run --no-project python scripts/check_wheel_contents.py dist/*.whl
+
+      - name: Install the wheel with its research extra
+        shell: bash
+        run: |
+          wheel_path=$(find "$GITHUB_WORKSPACE/dist" -maxdepth 1 -name '*.whl' -print -quit)
+          uv venv --python 3.12 "$RUNNER_TEMP/research-wheel-venv"
+          uv pip install --python "$RUNNER_TEMP/research-wheel-venv/bin/python" \
+            "${wheel_path}[research]" pytest pytest-regressions
+
+      - name: Run installed-wheel research contracts outside the checkout
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/research-wheel-check"
+          cd "$RUNNER_TEMP/research-wheel-check"
+          "$RUNNER_TEMP/research-wheel-venv/bin/python" -c \
+            "import importlib.metadata as m, pathlib, stochvolmodels as s; \
+            assert 'site-packages' in pathlib.Path(s.__file__).as_posix(); \
+            assert s.__version__ == m.version('stochvolmodels'); \
+            assert m.version('option-chain-analytics') == '5.2.0'"
+          "$RUNNER_TEMP/research-wheel-venv/bin/python" -m pytest \
+            --basetemp "$RUNNER_TEMP/research-wheel-pytest" --pyargs \
+            stochvolmodels.tests.test_oca_option_chain_adapter \
+            stochvolmodels.tests.test_cboe_option_data_optional -q
+
+      - name: Verify the cache-aware book-production contract
+        run: >-
+          uv run --no-sync python -m volatility_book.verify_book_production --profile smoke

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,9 @@ Please open an issue before implementing any of the following:
 - a feature that belongs in a sibling package such as `vanilla-option-pricers`, `qis`, or
   `optimalportfolios`.
 
-American, exotic, and path-dependent payoffs are outside this package's intended scope. Examples
-that require a paid data subscription cannot be reviewer or CI gates.
+New American or general exotic/path-dependent product families are outside this package's intended
+scope. The narrowly characterized book-analytics layer includes European and integrated-variance
+payoffs. Examples that require a paid data subscription cannot be reviewer or CI gates.
 
 ## Reporting a bug
 
@@ -50,12 +51,12 @@ offer private support or a guaranteed response time.
 ```console
 git clone https://github.com/ArturSepp/StochVolModels.git
 cd StochVolModels
-python -m pip install -e ".[dev,docs]"
-python -m pytest -m "not slow"
-python -m pytest -m slow
-ruff check --select E9,F63,F7,F82,F811 src
-python -m sphinx -W --keep-going -b html docs docs/_build/html
-python examples/getting_started/quickstart.py
+uv sync --locked --group test --group lint --extra docs
+uv run --no-sync pytest -m "not slow"
+uv run --no-sync pytest -m slow
+uv run --no-sync ruff check --select E9,F63,F7,F82,F811 src
+uv run --no-sync python -m sphinx -W --keep-going -b html docs docs/_build/html
+uv run --no-sync python examples/getting_started/quickstart.py
 ```
 
 Tests live in `src/stochvolmodels/tests/`. Unmarked fast tests cover core contracts and

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,9 +20,11 @@ recursive-include src/stochvolmodels *.npz *.yml *.yaml *.json *.txt *.md
 include src/stochvolmodels/settings.yaml.example
 exclude src/stochvolmodels/settings.yaml
 
-# Explicitly exclude repository-only examples, papers, figures, notebooks, and image files
+# Explicitly exclude repository-only examples, papers, book analytics, figures, notebooks, and
+# image files.
 recursive-exclude examples *
 recursive-exclude papers *
+recursive-exclude volatility_book *
 recursive-exclude docs *
 recursive-exclude resources *
 recursive-exclude src/stochvolmodels/pde_solvers *

--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ The same analytics power the research: the repository's `papers/` directory repr
 
 Use `stochvolmodels` for European vanilla pricing and implied-volatility analytics under stochastic volatility, for model calibration to option chains (a calibration example to Bitcoin options data is included), and for replicating the papers above.
 
-It is not a general derivatives platform: no American or path-dependent payoffs, no local-volatility or term-structure models. Black-Scholes-Merton and absolute-normal Bachelier analytics are provided by the required [`vanilla-option-pricers`](https://github.com/ArturSepp/VanillaOptionPricers) package and re-exported from `stochvolmodels`; for strategy backtesting and reporting, use [`qis`](https://github.com/ArturSepp/QuantInvestStrats).
+It is not a general derivatives platform: there is no American-option, local-volatility, or
+term-structure framework. Black-Scholes-Merton and absolute-normal Bachelier analytics are
+provided by the required
+[`vanilla-option-pricers`](https://github.com/ArturSepp/VanillaOptionPricers) package and
+re-exported from `stochvolmodels`; for strategy backtesting and reporting, use
+[`qis`](https://github.com/ArturSepp/QuantInvestStrats).
 
 ## Installation
 Install using
@@ -71,14 +76,15 @@ python examples/getting_started/quickstart.py
 From a source checkout, verify the complete public artifact and documentation path with:
 
 ```console
-python -m pip install -e ".[dev,docs]"
-python -m pytest -m "not slow"
-python -m pytest -m slow
-python -m pytest --cov=stochvolmodels --cov-report=json
-python scripts/check_coverage_scopes.py coverage.json
-python -m sphinx -W --keep-going -b html docs docs/_build/html
-python -m build
-python scripts/check_wheel_contents.py dist/*.whl
+uv sync --locked --group test --extra docs
+uv run --no-sync pytest -m "not slow"
+uv run --no-sync pytest -m slow
+uv run --no-sync pytest --cov=stochvolmodels --cov-report=json
+uv run --no-sync python scripts/check_coverage_scopes.py coverage.json
+uv run --no-sync python -m sphinx -W --keep-going -b html docs docs/_build/html
+uv build
+uv run --no-project python scripts/check_sdist_contents.py dist/*.tar.gz
+uv run --no-project python scripts/check_wheel_contents.py dist/*.whl
 ```
 
 The v2.3.0 quickstart prints two five-strike slices and deterministic reference values including
@@ -106,7 +112,6 @@ because Numba compiles the numerical kernels. See the
 | `visualization` | `plotly >= 5.0.0` | interactive figures |
 | `numerical` | `scikit-learn >= 1.3.0`, `statsmodels >= 0.14.0` | statistical fits |
 | `jupyter` | `jupyter`, `notebook`, `jupyterlab`, `ipykernel`, `ipywidgets` | notebooks |
-| `dev` | `pytest`, `pytest-cov`, `pytest-regressions` | automated tests and coverage |
 
 Install an extra using
 ```python
@@ -121,6 +126,34 @@ the [testing and coverage guide](https://stochvolmodels.readthedocs.io/en/latest
 The names listed by `stochvolmodels.__all__` are the stable high-level API. Historical package-root
 names remain available lazily for compatibility, but names not in `__all__` should be treated as
 advanced interfaces.
+
+The book-analytics work adds a deliberately provisional direct-import surface without expanding
+the stable package root:
+
+- `ModelPaths`, `PathModel`, and `TransformModel` separate path simulation from transform
+  capabilities. `LogSvModel` and `TgarchModel` are the first path implementations.
+
+- `TerminalDistributionModel` and `TerminalSmileModel` are separate one-maturity capabilities.
+  `TdistTerminalModel`, `GmmTerminalModel`, and `InverseGammaNormalTerminalModel` implement this
+  boundary without pretending to be dynamic path models.
+
+- `EuropeanOptionPayoff`, `IntegratedVarianceOptionPayoff`, `value_paths`, and
+  `value_paths_self_normalized` provide explicit payoff, measure, weighting, recentering, standard
+  error, and effective-sample-size conventions.
+
+- The regime-switching LogSV modules provide equilibrium, transform, Fourier, Monte Carlo, and
+  risk-premium attribution analytics used by the book chapters.
+
+These names ship in the wheel and are documented in the
+[API guide](https://stochvolmodels.readthedocs.io/en/latest/api.html), but remain outside
+`stochvolmodels.__all__` until their contracts are stabilized across another dynamic model. The
+repository-only chapter pipelines and their ignored artifacts live under `volatility_book/`. A
+locked, deterministic smoke rollup uses OCA 5.2.0 exactly:
+
+```console
+uv sync --locked --extra research
+python -m volatility_book.run_book_production --profile smoke
+```
 
 The rough-LogSV Monte Carlo and Factor HJM implementations are experimental research surfaces.
 Their characterized pricing paths are tested, but deep imports under

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,6 +7,37 @@ LogSV deep-module paths are experimental research APIs.
 The installed release string is `stochvolmodels.__version__`. The API contract test resolves every
 name below and fails if `__all__`, the documented maturity boundary, or a stable docstring drifts.
 
+## Provisional book-analytics capabilities
+
+The following direct-module APIs ship in the wheel but are intentionally absent from the stable
+package-root `__all__`. They support the repository's volatility-book analytics and may be refined
+after validation across additional model implementations:
+
+- `stochvolmodels.data.model_paths.ModelPaths` is the validated path payload.
+
+- `stochvolmodels.models.PathModel` and `TransformModel` describe independent dynamic
+  capabilities. `stochvolmodels.models.logsv.LogSvModel` and
+  `stochvolmodels.models.tgarch.TgarchModel` are the first path implementations.
+
+- `stochvolmodels.models.TerminalDistributionModel` and `TerminalSmileModel` describe
+  one-maturity laws and smiles separately from path models. Implementations are
+  `stochvolmodels.pricers.tdist_pricer.TdistTerminalModel`,
+  `stochvolmodels.pricers.gmm_pricer.GmmTerminalModel`, and
+  `stochvolmodels.models.inverse_gamma_normal.InverseGammaNormalTerminalModel`.
+
+- `stochvolmodels.products.payoffs` provides `EuropeanOptionPayoff` and
+  `IntegratedVarianceOptionPayoff`. `stochvolmodels.valuation` provides raw and self-normalized
+  path valuation with explicit measure, likelihood-weight, recentering, standard-error, and ESS
+  policies.
+
+- `stochvolmodels.models.regime_logsv`, `stochvolmodels.models.regime_logsv_simulation`, and
+  `stochvolmodels.pricers.regime_switch_logsv_pricer` provide the provisional regime-switching
+  LogSV equilibrium, transform, Fourier, and independent Monte Carlo stack.
+
+Student-t and GMM validate the terminal boundary without being made into artificial path models.
+Root aliases and protocol stabilization are deferred until the same contracts have been exercised
+by another dynamic model.
+
 ## Data and model classes
 
 ```{eval-rst}

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -15,11 +15,11 @@ python -m pip install stochvolmodels
 For a source checkout, create an environment and install the project in editable mode:
 
 ```console
-python -m pip install -e ".[dev]"
+uv sync --locked --group test
 ```
 
 Optional research, plotting, numerical-fit, notebook, and documentation tools are separated from
-the core runtime. For example, `python -m pip install ".[docs]"` installs the documentation stack.
+the core runtime. For example, `uv sync --locked --extra docs` installs the documentation stack.
 
 ## Run the authoritative quickstart
 
@@ -35,10 +35,10 @@ The source is included here mechanically, so the documentation and CI execute th
 :language: python
 ```
 
-On the reference Windows/Python 3.12 run, version 2.2.0 produced vanilla price `0.197331`, vanilla
-implied volatility `0.999577`, and six-month at-the-money price/volatility `0.275202`/`0.995757` in
-19.95 seconds. Values are deterministic; elapsed time is machine-dependent. The first process pays
-Numba compilation cost, so later calls are usually faster.
+The deterministic reference run produces vanilla price `0.197331`, vanilla implied volatility
+`0.999577`, and six-month at-the-money price/volatility `0.275202`/`0.995757`. Elapsed time is
+machine-dependent. The first process pays Numba compilation cost, so later calls are usually
+faster.
 
 Change `sigma0` and `theta` first to move the current and long-run volatility levels. Then change
 `beta` for return/volatility dependence and `volvol` for volatility-of-volatility. See the
@@ -50,8 +50,8 @@ guide](calibration.md) before fitting market data.
 - A `ValueError` normally indicates inconsistent maturities, forwards, strikes, quote arrays, or
   unsupported option codes.
 - A slow first call is expected JIT compilation, not network activity.
-- This quickstart does not validate a trading convention, calibrate to live quotes, or support
-  American/path-dependent payoffs.
+- This quickstart does not validate a trading convention, calibrate to live quotes, or provide an
+  American/general path-dependent pricing workflow.
 
 ## Optional Colab trial
 

--- a/scripts/check_sdist_contents.py
+++ b/scripts/check_sdist_contents.py
@@ -1,0 +1,88 @@
+"""Validate that a StochVolModels sdist excludes repository-only material."""
+
+from __future__ import annotations
+
+import argparse
+import tarfile
+from pathlib import Path
+
+from check_wheel_contents import REQUIRED_RUNTIME_FILES
+
+
+def check_sdist(sdist_path: Path) -> None:
+    """Raise ``AssertionError`` when *sdist_path* violates the artifact contract."""
+    with tarfile.open(sdist_path, mode="r:*") as archive:
+        members = tuple(member.name.rstrip("/") for member in archive.getmembers())
+
+    roots = {member.split("/", 1)[0] for member in members if member}
+    assert len(roots) == 1, f"expected one sdist root, found: {sorted(roots)}"
+    root = roots.pop()
+    assert root.startswith("stochvolmodels-"), f"unexpected sdist root: {root}"
+
+    prefix = f"{root}/"
+    payload = tuple(member.removeprefix(prefix) for member in members if member != root)
+    assert all(member and not member.startswith(("/", "../")) for member in payload), (
+        "sdist contains an absolute, empty, or parent-traversing member"
+    )
+
+    forbidden_prefixes = (
+        "agents/",
+        "docs/",
+        "examples/",
+        "outputs/",
+        "papers/",
+        "resources/",
+        "volatility_book/",
+        "src/stochvolmodels/pde_solvers/",
+    )
+    forbidden = [member for member in payload if member.startswith(forbidden_prefixes)]
+    assert not forbidden, f"repository-only files entered sdist: {forbidden[:10]}"
+
+    development = [
+        member for member in payload if "/run_local/" in member or member.endswith("_run.py")
+    ]
+    assert not development, f"development runners entered sdist: {development[:10]}"
+    assert "src/stochvolmodels/settings.yaml" not in payload, (
+        "machine-local settings.yaml entered the sdist"
+    )
+
+    required = {
+        "CHANGELOG.md",
+        "LICENSE.txt",
+        "MANIFEST.in",
+        "README.md",
+        "pyproject.toml",
+        "src/stochvolmodels/settings.yaml.example",
+        *(f"src/{member}" for member in REQUIRED_RUNTIME_FILES),
+    }
+    missing = required.difference(payload)
+    assert not missing, f"required sdist files missing: {sorted(missing)}"
+
+    test_modules = {
+        member
+        for member in payload
+        if member.startswith("src/stochvolmodels/tests/test_") and member.endswith(".py")
+    }
+    assert len(test_modules) == 32, (
+        f"expected exactly 32 automated test modules, found {len(test_modules)}"
+    )
+    baselines = {member for member in payload if member.endswith(".npz")}
+    assert baselines == {
+        "src/stochvolmodels/tests/test_rough_logsv_pricer_regression/"
+        "test_rough_logsv_pricer_pricing_regression.npz"
+    }, f"unexpected regression baselines: {sorted(baselines)}"
+    assert not any(member.endswith((".pyc", ".pyo")) for member in payload)
+
+    print(f"sdist-content-check: PASS ({len(members)} members): {sdist_path.name}")
+
+
+def main() -> None:
+    """Parse an sdist path and validate it."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("sdist", type=Path)
+    args = parser.parse_args()
+    check_sdist(args.sdist)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_wheel_contents.py
+++ b/scripts/check_wheel_contents.py
@@ -7,6 +7,22 @@ from pathlib import Path
 from zipfile import ZipFile
 
 
+REQUIRED_RUNTIME_FILES = {
+    "stochvolmodels/__init__.py",
+    "stochvolmodels/data/model_paths.py",
+    "stochvolmodels/models/__init__.py",
+    "stochvolmodels/models/inverse_gamma_normal.py",
+    "stochvolmodels/models/logsv.py",
+    "stochvolmodels/models/regime_logsv.py",
+    "stochvolmodels/models/regime_logsv_simulation.py",
+    "stochvolmodels/models/tgarch.py",
+    "stochvolmodels/pricers/regime_switch_logsv_pricer.py",
+    "stochvolmodels/products/__init__.py",
+    "stochvolmodels/products/payoffs.py",
+    "stochvolmodels/valuation.py",
+}
+
+
 def check_wheel(wheel_path: Path) -> None:
     """Raise ``AssertionError`` when *wheel_path* violates the artifact contract."""
     with ZipFile(wheel_path) as wheel:
@@ -29,6 +45,7 @@ def check_wheel(wheel_path: Path) -> None:
         "stochvolmodels/examples/",
         "examples/",
         "papers/",
+        "volatility_book/",
         "docs/",
         "resources/",
         "stochvolmodels/pde_solvers/",
@@ -42,21 +59,7 @@ def check_wheel(wheel_path: Path) -> None:
     assert "stochvolmodels/settings.yaml" not in members, (
         "machine-local settings.yaml entered the wheel"
     )
-    required_runtime_files = {
-        "stochvolmodels/__init__.py",
-        "stochvolmodels/data/model_paths.py",
-        "stochvolmodels/models/__init__.py",
-        "stochvolmodels/models/inverse_gamma_normal.py",
-        "stochvolmodels/models/logsv.py",
-        "stochvolmodels/models/regime_logsv.py",
-        "stochvolmodels/models/regime_logsv_simulation.py",
-        "stochvolmodels/models/tgarch.py",
-        "stochvolmodels/pricers/regime_switch_logsv_pricer.py",
-        "stochvolmodels/products/__init__.py",
-        "stochvolmodels/products/payoffs.py",
-        "stochvolmodels/valuation.py",
-    }
-    missing_runtime_files = required_runtime_files.difference(members)
+    missing_runtime_files = REQUIRED_RUNTIME_FILES.difference(members)
     assert not missing_runtime_files, (
         f"required runtime files missing from wheel: {sorted(missing_runtime_files)}"
     )


### PR DESCRIPTION
## Summary

- add a manual-only B1 release-readiness workflow that builds from the sdist, installs the wheel
  with its research extra outside the checkout, asserts OCA 5.2.0, runs installed OCA contracts,
  and executes the B1A book-production verifier
- explicitly exclude repository-only `volatility_book/` sources from the sdist and independently
  check both source and wheel artifact boundaries
- document the provisional path, terminal-model, payoff, valuation, and regime analytics without
  expanding the stable 34-name package root
- replace stale references to the removed `dev` extra with the tracked uv dependency groups

## Verification

- exact locked environment: OCA 5.2.0, QIS 5.11.1
- 628 non-slow source tests
- 12 focused repository/public-API tests
- 12 clean installed-wheel OCA tests outside the checkout
- warning-free Sphinx HTML and doctest builds
- critical whole-source/script Ruff plus full checker lint/format
- 129-member sdist and 104-file wheel content checks
- deliberate forbidden-book-file sdist mutation rejected
- full B1A verifier: fresh compute, reuse, locking, rollback, and selective recovery

## Boundaries

- no package numerical or signature change
- no dependency, lock, version, changelog, citation, tag, release, or publication change
- full-book TeX/PDF assembly remains deferred until a master source and acceptance contract exist

After merge and normal CI, the new workflow should be dispatched manually on exact `main`. The
2.4.0 metadata/lock/book-contract synchronization remains a separate explicitly authorized unit.


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a new GitHub Actions workflow 'Release readiness' to validate build artifacts and distribution contents.</li>
<li>Updated CONTRIBUTING.md to clarify the scope of the package, specifically regarding product families.</li>
<li>Added scripts to verify the contents of source distributions and wheels.</li>
<li>Updated documentation and manifest files to reflect project changes.</li>
</ul></div>