### PR TITLE
Release StochVolModels 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Entries start at 1.2.0. For earlier releases see the git log.
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-08-28
+
 ### Added
 - `stochvolmodels.models.inverse_gamma_normal` adds a provisional, maturity-specific
   inverse-gamma/normal terminal distribution and Black-smile model for the volatility-book

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/ArturSepp/StochVolModels"
 url: "https://pypi.org/project/stochvolmodels/"
 license: MIT
-version: 2.3.0
-date-released: "2026-08-24"
+version: 2.4.0
+date-released: "2026-08-28"
 keywords:
   - stochastic-volatility
   - option-pricing

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ uv run --no-project python scripts/check_sdist_contents.py dist/*.tar.gz
 uv run --no-project python scripts/check_wheel_contents.py dist/*.whl
 ```
 
-The v2.3.0 quickstart prints two five-strike slices and deterministic reference values including
+The v2.4.0 quickstart prints two five-strike slices and deterministic reference values including
 `vanilla_price=0.197331` and `six_month_atm_price=0.275202`. The first call normally takes seconds
 because Numba compiles the numerical kernels. See the
 [full verification guide](https://stochvolmodels.readthedocs.io/en/latest/getting_started.html) and
@@ -680,7 +680,7 @@ metadata is available in [`CITATION.cff`](CITATION.cff).
   title={StochVolModels: Python Implementation of Stochastic Volatility Models},
   author={Sepp, Artur},
   year={2026},
-  version={2.3.0},
+  version={2.4.0},
   howpublished={\url{https://github.com/ArturSepp/StochVolModels}},
   note={Python package for pricing analytics and Monte Carlo simulations}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stochvolmodels"
-version = "2.3.0"
+version = "2.4.0"
 description = "Fourier-transform pricing, Monte Carlo validation, and calibration of European options under stochastic-volatility models in Python."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -4415,7 +4415,7 @@ wheels = [
 
 [[package]]
 name = "stochvolmodels"
-version = "2.3.0"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

- prepare the accumulated public analytics for the 2.4.0 package release
- update version, changelog, citation metadata, README citation, and lock metadata
- leave package source and numerical behavior unchanged

## Verification

- fast source suite: passed
- Ruff static/import boundary gate: passed
- stable docstring coverage: 100%
- sdist content: 129 members; wheel content: 104 files
- Twine distribution check: passed
- clean installed-wheel suite: 613 passed, 15 skipped, 15 deselected
- OCA 5.2.0 metadata/dependency check and offline quickstart: passed

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Bumped project version from 2.3.0 to 2.4.0.</li>
<li>Added a provisional maturity-specific inverse-gamma/normal terminal distribution and Black-smile model to stochvolmodels.models.inverse_gamma_normal.</li>
<li>Updated documentation and metadata in CHANGELOG.md, CITATION.cff, README.md, pyproject.toml, and uv.lock to reflect the new version.</li>
</ul></div>